### PR TITLE
fix: normalize pydantic refs into components

### DIFF
--- a/src/azure_functions_openapi/openapi.py
+++ b/src/azure_functions_openapi/openapi.py
@@ -21,6 +21,7 @@ def generate_openapi_spec(title: str = "API", version: str = "1.0.0") -> Dict[st
     try:
         registry = get_openapi_registry()
         paths: Dict[str, Dict[str, Any]] = {}
+        components: Dict[str, Any] = {"schemas": {}}
 
         for func_name, meta in registry.items():
             try:
@@ -41,7 +42,9 @@ def generate_openapi_spec(title: str = "API", version: str = "1.0.0") -> Dict[st
                         responses["200"] = {
                             "description": "Successful Response",
                             "content": {
-                                "application/json": {"schema": model_to_schema(meta["response_model"])}
+                                "application/json": {
+                                    "schema": model_to_schema(meta["response_model"], components)
+                                }
                             },
                         }
                     except Exception as e:
@@ -77,7 +80,9 @@ def generate_openapi_spec(title: str = "API", version: str = "1.0.0") -> Dict[st
                             op["requestBody"] = {
                                 "required": True,
                                 "content": {
-                                    "application/json": {"schema": model_to_schema(meta["request_model"])}
+                                    "application/json": {
+                                        "schema": model_to_schema(meta["request_model"], components)
+                                    }
                                 },
                             }
                         except Exception as e:
@@ -95,7 +100,7 @@ def generate_openapi_spec(title: str = "API", version: str = "1.0.0") -> Dict[st
                 # Continue processing other functions
                 continue
 
-        spec = {
+        spec: Dict[str, Any] = {
             "openapi": "3.0.0",
             "info": {
                 "title": title,
@@ -107,6 +112,8 @@ def generate_openapi_spec(title: str = "API", version: str = "1.0.0") -> Dict[st
             },
             "paths": paths,
         }
+        if components.get("schemas"):
+            spec["components"] = components
         
         logger.info(f"Generated OpenAPI spec with {len(paths)} paths for {len(registry)} functions")
         return spec

--- a/src/azure_functions_openapi/utils.py
+++ b/src/azure_functions_openapi/utils.py
@@ -1,6 +1,6 @@
 # src/azure_functions_openapi/utils.py
 import re
-from typing import Any, Dict, cast
+from typing import Any, Dict, List, Optional, Tuple, cast
 
 from packaging import version
 import pydantic
@@ -8,20 +8,147 @@ import pydantic
 PYDANTIC_V2 = version.parse(pydantic.__version__) >= version.parse("2.0.0")
 
 
-def model_to_schema(model_cls: Any) -> Dict[str, Any]:
-    """Return JSON schema from a Pydantic model class.
+def _rewrite_ref(ref: str) -> str:
+    if ref.startswith("#/$defs/"):
+        return ref.replace("#/$defs/", "#/components/schemas/")
+    if ref.startswith("#/definitions/"):
+        return ref.replace("#/definitions/", "#/components/schemas/")
+    return ref
+
+
+def _rewrite_refs(obj: Any) -> Any:
+    if isinstance(obj, dict):
+        rewritten: Dict[str, Any] = {}
+        for key, value in obj.items():
+            if key == "$ref" and isinstance(value, str):
+                rewritten[key] = _rewrite_ref(value)
+            else:
+                rewritten[key] = _rewrite_refs(value)
+        return rewritten
+    if isinstance(obj, list):
+        return [_rewrite_refs(item) for item in obj]
+    return obj
+
+
+def _pop_definitions(schema: Dict[str, Any]) -> Dict[str, Any]:
+    definitions: Dict[str, Any] = {}
+    for key in ("$defs", "definitions"):
+        value = schema.pop(key, None)
+        if isinstance(value, dict):
+            definitions.update(value)
+    return definitions
+
+
+def _collect_schemas(schema: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Dict[str, Any]]]:
+    normalized = cast(Dict[str, Any], _rewrite_refs(schema))
+    definitions = _pop_definitions(normalized)
+    collected: Dict[str, Dict[str, Any]] = {}
+
+    queue: List[Tuple[str, Any]] = list(definitions.items())
+    while queue:
+        name, definition = queue.pop(0)
+        if not isinstance(definition, dict):
+            continue
+        definition = cast(Dict[str, Any], _rewrite_refs(definition))
+        nested = _pop_definitions(definition)
+        if nested:
+            queue.extend(list(nested.items()))
+        collected[name] = definition
+
+    return normalized, collected
+
+
+def _resolve_name_collision(
+    name: str,
+    schema: Dict[str, Any],
+    existing: Dict[str, Dict[str, Any]],
+) -> str:
+    if name not in existing:
+        return name
+    if existing[name] == schema:
+        return name
+    index = 2
+    while True:
+        candidate = f"{name}_{index}"
+        if candidate not in existing:
+            return candidate
+        if existing[candidate] == schema:
+            return candidate
+        index += 1
+
+
+def _rewrite_refs_with_map(obj: Any, name_map: Dict[str, str]) -> Any:
+    if not name_map:
+        return obj
+    if isinstance(obj, dict):
+        rewritten: Dict[str, Any] = {}
+        for key, value in obj.items():
+            if key == "$ref" and isinstance(value, str):
+                if value.startswith("#/components/schemas/"):
+                    ref_name = value.split("#/components/schemas/", 1)[1]
+                    if ref_name in name_map:
+                        rewritten[key] = f"#/components/schemas/{name_map[ref_name]}"
+                        continue
+                rewritten[key] = value
+            else:
+                rewritten[key] = _rewrite_refs_with_map(value, name_map)
+        return rewritten
+    if isinstance(obj, list):
+        return [_rewrite_refs_with_map(item, name_map) for item in obj]
+    return obj
+
+
+def model_to_schema(model_cls: Any, components: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Return OpenAPI schema from a Pydantic model class.
     Parameters:
         model_cls: Pydantic model class.
+        components: OpenAPI components dict to register schemas.
     Returns:
-        Dict[str, Any]: JSON schema representation of the model.
+        Dict[str, Any]: Schema with $ref to components.schemas.
     """
 
     if PYDANTIC_V2:
-        return cast(Dict[str, Any], model_cls.model_json_schema())
-    return cast(Dict[str, Any], model_cls.schema())
+        schema = cast(
+            Dict[str, Any],
+            model_cls.model_json_schema(ref_template="#/components/schemas/{model}"),
+        )
+    else:
+        schema = cast(
+            Dict[str, Any],
+            model_cls.schema(ref_template="#/components/schemas/{model}"),
+        )
+
+    if components is None:
+        components = {}
+    schemas = components.setdefault("schemas", {})
+
+    normalized, definitions = _collect_schemas(schema)
+    local_schemas: Dict[str, Dict[str, Any]] = {model_cls.__name__: normalized}
+    local_schemas.update(definitions)
+
+    name_map: Dict[str, str] = {}
+    for name, local_schema in local_schemas.items():
+        resolved_name = _resolve_name_collision(name, local_schema, schemas)
+        if resolved_name != name:
+            name_map[name] = resolved_name
+
+    if name_map:
+        updated_local_schemas: Dict[str, Dict[str, Any]] = {}
+        for name, local_schema in local_schemas.items():
+            final_name = name_map.get(name, name)
+            rewritten_schema = cast(Dict[str, Any], _rewrite_refs_with_map(local_schema, name_map))
+            updated_local_schemas[final_name] = rewritten_schema
+        local_schemas = updated_local_schemas
+
+    for name, local_schema in local_schemas.items():
+        if name not in schemas or schemas[name] != local_schema:
+            schemas[name] = local_schema
+
+    root_name = name_map.get(model_cls.__name__, model_cls.__name__)
+    return {"$ref": f"#/components/schemas/{root_name}"}
 
 
-def validate_route_path(route: str) -> bool:
+def validate_route_path(route: Any) -> bool:
     """Validate route path format for security.
     
     Parameters:
@@ -55,7 +182,7 @@ def validate_route_path(route: str) -> bool:
     return True
 
 
-def sanitize_operation_id(operation_id: str) -> str:
+def sanitize_operation_id(operation_id: Any) -> str:
     """Sanitize operation ID to prevent injection attacks.
     
     Parameters:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -151,8 +151,16 @@ def test_generate_spec_with_pydantic_models() -> None:
     op = generate_openapi_spec()["paths"]["/login"]["post"]
     schema_req = op["requestBody"]["content"]["application/json"]["schema"]
     schema_resp = op["responses"]["200"]["content"]["application/json"]["schema"]
-    assert {"username", "password"} <= schema_req["properties"].keys()
-    assert "message" in schema_resp["properties"]
+    assert schema_req == {"$ref": "#/components/schemas/RequestModel"}
+    assert schema_resp == {"$ref": "#/components/schemas/ResponseModel"}
+
+    spec = generate_openapi_spec()
+    components = spec.get("components", {})
+    schemas = components.get("schemas", {})
+    assert "RequestModel" in schemas
+    assert "ResponseModel" in schemas
+    assert "$defs" not in schemas["RequestModel"]
+    assert "$defs" not in schemas["ResponseModel"]
 
 
 def test_openapi_spec_contains_operation_id_and_tags() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,10 +35,15 @@ else:
 @pytest.mark.parametrize("model_cls", ModelVariants)
 def test_model_to_schema(model_cls: Type[BaseModel]) -> None:
     """Verify that the model_to_schema function returns a valid schema for the given model class."""
-    schema: Dict[str, Any] = model_to_schema(model_cls)
+    components: Dict[str, Any] = {"schemas": {}}
+    schema: Dict[str, Any] = model_to_schema(model_cls, components)
 
     # Common schema assertions
-    assert isinstance(schema, dict)
-    assert "title" in schema or "properties" in schema
-    assert "done" in schema.get("properties", {})
-    assert "title" in schema.get("properties", {})
+    assert schema == {"$ref": f"#/components/schemas/{model_cls.__name__}"}
+    assert model_cls.__name__ in components["schemas"]
+
+    registered = components["schemas"][model_cls.__name__]
+    assert "title" in registered or "properties" in registered
+    assert "done" in registered.get("properties", {})
+    assert "title" in registered.get("properties", {})
+    assert "$defs" not in registered


### PR DESCRIPTION
## Summary
- rewrite Pydantic $defs/definitions references into OpenAPI components schemas
- register model schemas in components and return $ref-only payloads
- add tests covering $defs rewrites and component registration

## Testing
- make test

## Issue
- Closes #1