### PR TITLE
chore: drop python 3.9 support

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout code
@@ -33,7 +33,7 @@ jobs:
         run: ls -lh coverage.xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install Hatch and docs dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
-  # Format code using Black (PEP8-compliant, compatible with Python 3.9)
+  # Format code using Black (PEP8-compliant, compatible with Python 3.10)
   - repo: https://github.com/psf/black
-    rev: 23.11.0  # Stable release supporting Python 3.9
+    rev: 23.11.0  # Stable release supporting Python 3.10
     hooks:
       - id: black
 
-  # Lint and auto-fix style using Ruff (Python 3.9 compatible)
+  # Lint and auto-fix style using Ruff (Python 3.10 compatible)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4  # Stable version tested with Python 3.9
+    rev: v0.4.4  # Stable version tested with Python 3.10
     hooks:
       - id: ruff
         args: ["--fix"]
 
-  # Static type checking using mypy (ensure Python 3.9 environment is activated)
+  # Static type checking using mypy (ensure Python 3.10 environment is activated)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0  # Compatible with Python 3.9
+    rev: v1.15.0  # Compatible with Python 3.10
     hooks:
       - id: mypy
         language: python
@@ -31,7 +31,7 @@ repos:
 
   # Run static security checks using Bandit (scan src/, exclude tests/)
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.7  # Compatible with Python 3.9+
+    rev: 1.7.7  # Compatible with Python 3.10+
     hooks:
       - id: bandit
         language: python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable changes to this project will be documented in this file.
 
 - *(makefile)* Add Hatch-based automation for test, build, release
 - *(pyproject)* Configure hatch build and publish targets
+- Drop Python 3.9 support; require Python 3.10+
 - Bump version to 0.4.1
 
 ### 📚 Documentation

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -204,7 +204,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           pip install azure-functions-openapi
@@ -311,7 +311,7 @@ azure-functions-openapi generate --format json | \
 Use the CLI tool in Docker containers:
 
 ```dockerfile
-FROM python:3.9-slim
+FROM python:3.10-slim
 
 # Install the package
 RUN pip install azure-functions-openapi

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ This document provides guidance for setting up the development environment for t
 
 ## Python Version
 
-- This project supports Python 3.9+.
+- This project supports Python 3.10+.
 - All development and formatting tools are configured accordingly via [Hatch](https://hatch.pypa.io/).
 
 ## Local Setup
@@ -91,6 +91,6 @@ azure-functions-openapi/
 
 ## Tips
 
-- Ensure you're using Python 3.9+.
+- Ensure you're using Python 3.10+.
 - Use `make check-all` before committing to validate your changes.
 - Prefer `make` commands to ensure consistent dev experience across platforms.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ Welcome to **azure-functions-openapi** — a comprehensive library that provides
 - **Pydantic v1 and v2 support** with automatic schema generation
 - **Type-safe schema generation** with full type hints
 - **Zero-configuration integration** - works out of the box
-- **Compatible with Python 3.9+**
+- **Compatible with Python 3.10+**
 
 ### 🔒 Security & Performance
 - **Enhanced Security**: CSP headers, input validation, XSS protection

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,7 @@ This project supports Python-based Azure Functions using the **Programming Model
 
 ## Requirements
 
-- Python **3.9+** (3.9–3.12 tested)
+- Python **3.10+** (3.10–3.12 tested)
 - [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local)
 - Azure Functions Python Programming Model **v2**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "OpenAPI (Swagger) integration for Python-based Azure Functions"
 authors = [{ name = "Yeongseon Choe", email = "yeongseon.choe@gmail.com" }]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.10,<3.13"
 dynamic = ["version"]
 
 dependencies = [
@@ -73,7 +73,7 @@ url = "https://test.pypi.org/legacy/"
 # ----------------------------------------
 
 [tool.hatch.envs.default]
-python = "3.9"
+python = "3.10"
 features = ["dev", "docs"]
 
 [tool.hatch.envs.default.scripts]
@@ -98,14 +98,14 @@ azure-functions-openapi = "azure_functions_openapi.cli:main"
 # ---------------------------------------------
 [tool.black]
 line-length = 100
-target-version = ["py39", "py310", "py311", "py312"]
+target-version = ["py310", "py311", "py312"]
 
 # ---------------------------------------------
 # 🔍 Linting - Ruff
 # ---------------------------------------------
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 exclude = ["tests"]
 
 [tool.ruff.lint]
@@ -121,7 +121,7 @@ section-order = ["future", "standard-library", "third-party", "first-party", "lo
 # 🧪 Type Checking - Mypy
 # ---------------------------------------------
 [tool.mypy]
-python_version = "3.9"
+python_version = "3.10"
 strict = true
 ignore_missing_imports = true
 exclude = "examples/"


### PR DESCRIPTION
## Summary
- require Python 3.10+ in packaging metadata
- update CI/docs/pre-commit references to drop 3.9

## Testing
- make check-all

## Issue
- Closes #3