### PR TITLE
fix: correct coverage measurement configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ style = "ruff check src tests"
 typecheck = "mypy src tests"
 lint = "hatch run style && hatch run typecheck"
 test = "PYTHONPATH=. pytest -v tests"
-cov = "coverage run -m pytest && coverage report && coverage html"
+cov = "PYTHONPATH=. pytest --cov=src/azure_functions_openapi --cov-report=term-missing --cov-report=html --cov-report=xml tests/"
 docs = "mkdocs serve"
 precommit = "pre-commit run --all-files"
 precommit-install = "pre-commit install"
@@ -132,7 +132,7 @@ pretty = true
 # 🧪 Testing - Pytest
 # ---------------------------------------------
 [tool.pytest.ini_options]
-addopts = "--cov=src/azure_functions_openapi --cov-report=xml -ra -q"
+addopts = "--cov=src/azure_functions_openapi --cov-report=xml --cov-report=term-missing -ra -q"
 testpaths = ["tests"]
 pythonpath = ["src", "examples"]
 
@@ -141,7 +141,7 @@ pythonpath = ["src", "examples"]
 # ---------------------------------------------
 [tool.coverage.run]
 branch = true
-source = ["src/azure_functions_openapi", "examples"]
+source = ["src/azure_functions_openapi"]
 
 [tool.coverage.report]
 show_missing = true


### PR DESCRIPTION
## Summary

- Fix `hatch run cov` script to correctly measure test coverage
- Coverage now reports **48%** instead of **0%**

## Changes

- Change hatch `cov` script to use pytest-cov directly instead of `coverage run`
- Add `PYTHONPATH=.` to cov script for examples module resolution
- Add `--cov-report=term-missing` to pytest addopts for better visibility
- Remove `examples` from coverage source (not a test target)

## Coverage Results

| Module | Coverage |
|--------|----------|
| cache.py | 98% |
| decorator.py | 97% |
| errors.py | 97% |
| openapi.py | 93% |
| utils.py | 66% |
| cli.py | 0% (no tests) |
| monitoring.py | 0% (no tests) |
| server_info.py | 0% (no tests) |
| **TOTAL** | **48%** |

## Testing

```bash
hatch run cov
# 147 passed, coverage reports correctly
```

Closes #10