### PR TITLE
chore: align pre-commit hooks with pyproject.toml settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
+        exclude: "^tests/"
 
   # Static type checking using mypy (ensure Python 3.10 environment is activated)
   - repo: https://github.com/pre-commit/mirrors-mypy
@@ -29,12 +30,11 @@ repos:
           - typer
           - requests
 
-  # Run static security checks using Bandit (scan src/, exclude tests/)
+  # Run static security checks using Bandit (scan src/ only)
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.7  # Compatible with Python 3.10+
     hooks:
       - id: bandit
-        language: python
-        name: bandit-src-only
-        entry: bandit -r src/ -x tests/
-        pass_filenames: false  # Analyze entire directory, not individual files
+        args: ["-c", "pyproject.toml"]
+        additional_dependencies: ["bandit[toml]"]
+        files: "^src/"


### PR DESCRIPTION
## Summary

- Align pre-commit hook configuration with pyproject.toml settings
- Improve commit speed by scanning only relevant files

## Changes

### ruff hook
- Add `exclude: "^tests/"` to match `[tool.ruff].exclude = ["tests"]` in pyproject.toml

### bandit hook
- Use pyproject.toml config via `-c pyproject.toml` argument
- Change from scanning entire `src/` directory to only staged files matching `^src/`
- Remove `pass_filenames: false` for faster incremental checks

## Before vs After

| Hook | Before | After |
|------|--------|-------|
| ruff | Checks all files including tests | Excludes tests (matches pyproject.toml) |
| bandit | Scans entire src/ on every commit | Scans only staged src/ files |

Closes #11