### PR TITLE
docs: add community files to repository root

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,56 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery and unwelcome sexual attention
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+yeongseon.choe@gmail.com.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing Guide
+
+We welcome contributions to the `azure-functions-openapi` project!
+
+## How to Contribute
+
+1. **Fork the Repository**
+2. **Create a New Branch**
+   ```bash
+   git checkout -b feature/your-feature-name
+   ```
+
+3. **Write Code & Tests**
+   - Run `make test` to ensure everything passes.
+   - Follow code style using `black`, `ruff`, and `mypy`.
+
+4. **Commit Your Changes**
+   ```bash
+   git commit -m "feat: describe your feature"
+   ```
+
+5. **Push and Create a Pull Request**
+
+## Project Commands
+
+```bash
+make format      # Format code with black
+make lint        # Lint with ruff
+make typecheck   # Type check with mypy
+make test        # Run tests
+make cov         # Run tests with coverage
+```
+
+## Commit Message Guidelines
+
+We follow the [Conventional Commits](https://www.conventionalcommits.org/) specification.
+
+### Prefix Types
+
+| Type        | Description                               |
+|-------------|-------------------------------------------|
+| `feat:`     | New feature                               |
+| `fix:`      | Bug fix                                   |
+| `docs:`     | Documentation changes only                |
+| `style:`    | Code formatting, no logic changes         |
+| `refactor:` | Code refactoring without behavior changes |
+| `test:`     | Adding or modifying tests                 |
+| `chore:`    | Tooling, dependencies, CI/CD, versioning  |
+
+### Examples
+
+```bash
+git commit -m "feat: add OpenAPI 3.1 support"
+git commit -m "fix: handle empty request body gracefully"
+git commit -m "docs: improve quickstart documentation"
+git commit -m "refactor: extract schema builder logic"
+git commit -m "chore: update dev dependencies"
+```
+
+> ✅ Use imperative present tense ("add", not "added").
+> ✅ Keep the message concise and relevant to the change.
+
+## Code of Conduct
+
+Be respectful and inclusive. See our [Code of Conduct](CODE_OF_CONDUCT.md) for details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please:
+
+1. **Do not** create a public issue
+2. Email security concerns to: yeongseon.choe@gmail.com
+3. Include detailed information about the vulnerability
+4. Allow time for the issue to be addressed before disclosure
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.6.x   | :white_check_mark: |
+| < 0.6   | :x:                |
+
+## Security Updates
+
+Security updates are released as:
+- **Patch versions** for critical security fixes
+- **Minor versions** for security improvements
+
+Always update to the latest version to ensure you have the latest security fixes.
+
+## Security Features
+
+See [Security Guide](docs/SECURITY.md) for detailed information about:
+- Content Security Policy (CSP)
+- Security Headers
+- Input Validation and Sanitization
+- Error Handling
+- Caching Security


### PR DESCRIPTION
Add CONTRIBUTING.md, CODE_OF_CONDUCT.md, and SECURITY.md to repository root for GitHub Community Standards compliance. Closes #15