### PR TITLE
chore(deps): update dev dependencies to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,20 +1,20 @@
 repos:
   # Format code using Black (PEP8-compliant, compatible with Python 3.10)
   - repo: https://github.com/psf/black
-    rev: 23.11.0  # Stable release supporting Python 3.10
+    rev: 25.1.0  # Latest stable release
     hooks:
       - id: black
 
   # Lint and auto-fix style using Ruff (Python 3.10 compatible)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.4  # Stable version tested with Python 3.10
+    rev: v0.11.13  # Latest stable version
     hooks:
       - id: ruff
         args: ["--fix"]
 
   # Static type checking using mypy (ensure Python 3.10 environment is activated)
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.15.0  # Compatible with Python 3.10
+    rev: v1.15.0  # Latest stable compatible with Python 3.10
     hooks:
       - id: mypy
         language: python
@@ -31,7 +31,7 @@ repos:
 
   # Run static security checks using Bandit (scan src/, exclude tests/)
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.7  # Compatible with Python 3.10+
+    rev: 1.8.3  # Latest stable version
     hooks:
       - id: bandit
         language: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,18 +18,18 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "black==23.11.0",        # Matches pre-commit rev
+    "black==25.1.0",         # Matches pre-commit rev
     "build",
     "coverage",
     "hatch",
-    "mypy==1.15.0",          # Matches pre-commit rev
+    "mypy==1.15.0",          # Matches pre-commit rev (latest stable)
     "pre-commit",
     "pytest",
-    "ruff==0.4.4",           # Matches pre-commit rev
+    "ruff==0.11.13",         # Matches pre-commit rev
     "types-PyYAML",
     "pytest-cov",
     "git-changelog",
-    "bandit==1.7.7"          # Explicit version matching pre-commit rev
+    "bandit==1.8.3"          # Matches pre-commit rev
 ]
 docs = [
     "mkdocs",


### PR DESCRIPTION
## Summary
Updates dev dependencies to latest stable versions while keeping pyproject.toml and .pre-commit-config.yaml in sync.

## Changes

| Tool | Previous | Updated |
|------|----------|---------|
| black | 23.11.0 | 25.1.0 |
| ruff | 0.4.4 | 0.11.13 |
| bandit | 1.7.7 | 1.8.3 |
| mypy | 1.15.0 | 1.15.0 (unchanged, already latest) |

## Verification
- `pre-commit run --all-files` passes for black, ruff, and bandit
- mypy errors are pre-existing (29 errors in tests/examples - same as main branch)

## Related Issue
Closes #12