### PR TITLE
feat: add Python 3.13 and 3.14 support

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ description = "OpenAPI (Swagger) integration for Python-based Azure Functions"
 authors = [{ name = "Yeongseon Choe", email = "yeongseon.choe@gmail.com" }]
 license = "MIT"
 readme = "README.md"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.15"
 dynamic = ["version"]
 
 dependencies = [
@@ -98,7 +98,7 @@ azure-functions-openapi = "azure_functions_openapi.cli:main"
 # ---------------------------------------------
 [tool.black]
 line-length = 100
-target-version = ["py310", "py311", "py312"]
+target-version = ["py310", "py311", "py312", "py313", "py314"]
 
 # ---------------------------------------------
 # 🔍 Linting - Ruff


### PR DESCRIPTION
## Summary
Extends Python version support to include 3.13 and 3.14.

## Changes
- Update `requires-python` in pyproject.toml: `>=3.10,<3.13` → `>=3.10,<3.15`
- Add Python 3.13 and 3.14 to CI test matrix
- Update Black `target-version` to include `py313` and `py314`

## Verification
CI will verify compatibility by running tests on Python 3.13 and 3.14.

**Note**: Python 3.14 is currently in development. If CI fails for 3.14, we can adjust to `<3.14` until stable release.

## Related Issue
Closes #7