### PR TITLE
Fix cache argument forwarding and packaging dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dynamic = ["version"]
 
 dependencies = [
     "azure-functions",
+    "packaging",
     "PyYAML",
     "pydantic>=1.10,<3.0"
 ]

--- a/src/azure_functions_openapi/cache.py
+++ b/src/azure_functions_openapi/cache.py
@@ -191,7 +191,7 @@ def cached_openapi_json(title: str, version: str) -> str:
     """Cache OpenAPI JSON generation."""
     from azure_functions_openapi.openapi import get_openapi_json
 
-    return get_openapi_json()
+    return get_openapi_json(title=title, version=version)
 
 
 @cached(ttl=300, key_prefix="openapi_yaml")  # 5 minutes
@@ -199,4 +199,4 @@ def cached_openapi_yaml(title: str, version: str) -> str:
     """Cache OpenAPI YAML generation."""
     from azure_functions_openapi.openapi import get_openapi_yaml
 
-    return get_openapi_yaml()
+    return get_openapi_yaml(title=title, version=version)


### PR DESCRIPTION
## Summary
- forward title/version into cached JSON/YAML generators to keep cache values consistent
- add missing packaging dependency required by utils
- reference the cache/dependency items from #39

## Testing
- pytest tests/test_cache.py

Refs #39