### PR TITLE
Fix tests that assume unregistered endpoints

### DIFF
--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -3,8 +3,29 @@ import json
 
 from pydantic import BaseModel
 
+from azure_functions_openapi.cache import clear_all_cache
 from azure_functions_openapi.decorator import get_openapi_registry, openapi
 from azure_functions_openapi.openapi import generate_openapi_spec, get_openapi_json
+
+
+def _register_http_trigger() -> None:
+    @openapi(
+        route="/api/http_trigger",
+        summary="HTTP Trigger with name parameter",
+        description=(
+            "Returns a greeting using the **name** from query or body.\n\n"
+            "### Usage\n\n"
+            "`?name=Azure`\n\n"
+            "```json\n"
+            '{"name": "Azure"}\n'
+            "```"
+        ),
+        tags=["Example"],
+        operation_id="greetUser",
+        response={200: {"description": "OK"}},
+    )
+    def http_trigger() -> None:
+        pass
 
 
 def test_generate_openapi_spec_structure() -> None:
@@ -164,6 +185,8 @@ def test_generate_spec_with_pydantic_models() -> None:
 
 
 def test_openapi_spec_contains_operation_id_and_tags() -> None:
+    clear_all_cache()
+    _register_http_trigger()
     spec = json.loads(get_openapi_json())
     item = spec["paths"]["/api/http_trigger"]["get"]
 
@@ -176,6 +199,8 @@ def test_openapi_spec_contains_operation_id_and_tags() -> None:
 
 
 def test_markdown_description_rendering() -> None:
+    clear_all_cache()
+    _register_http_trigger()
     item = json.loads(get_openapi_json())["paths"]["/api/http_trigger"]["get"]
     desc = item["description"]
     assert "### Usage" in desc and "`?name=Azure`" in desc and "```json" in desc

--- a/tests/test_openapi_spec.py
+++ b/tests/test_openapi_spec.py
@@ -1,11 +1,35 @@
 # tests/test_openapi_spec.py
 import json
 
+from azure_functions_openapi.cache import clear_all_cache
+from azure_functions_openapi.decorator import openapi
 from azure_functions_openapi.openapi import get_openapi_json
+
+
+def _register_http_trigger() -> None:
+    @openapi(
+        route="/api/http_trigger",
+        summary="HTTP Trigger with name parameter",
+        description=(
+            "Returns a greeting using the **name** from query or body.\n\n"
+            "### Usage\n\n"
+            "`?name=Azure`\n\n"
+            "```json\n"
+            '{"name": "Azure"}\n'
+            "```"
+        ),
+        tags=["Example"],
+        operation_id="greetUser",
+        response={200: {"description": "OK"}},
+    )
+    def http_trigger() -> None:
+        pass
 
 
 def test_openapi_spec_http_trigger_metadata() -> None:
     """Verify that the generated spec for /api/http_trigger contains the expected metadata."""
+    clear_all_cache()
+    _register_http_trigger()
     spec = json.loads(get_openapi_json())
 
     # Ensure the path exists


### PR DESCRIPTION
## Summary
- register the http_trigger example inside the OpenAPI tests
- clear cached specs before asserting on generated paths
- align the example description with expected markdown checks

## Testing
- pytest tests/test_openapi_spec.py tests/test_openapi.py

Fixes #40