### PR TITLE
Expose public APIs in package __init__

### DIFF
--- a/src/azure_functions_openapi/__init__.py
+++ b/src/azure_functions_openapi/__init__.py
@@ -1,6 +1,14 @@
 # src/azure_functions_openapi/__init__.py
 
-from azure_functions_openapi.openapi import OPENAPI_VERSION_3_0, OPENAPI_VERSION_3_1
+from azure_functions_openapi.decorator import openapi
+from azure_functions_openapi.openapi import (
+    OPENAPI_VERSION_3_0,
+    OPENAPI_VERSION_3_1,
+    generate_openapi_spec,
+    get_openapi_json,
+    get_openapi_yaml,
+)
+from azure_functions_openapi.swagger_ui import render_swagger_ui
 
 __version__ = "0.8.0"
 
@@ -8,4 +16,9 @@ __all__ = [
     "__version__",
     "OPENAPI_VERSION_3_0",
     "OPENAPI_VERSION_3_1",
+    "generate_openapi_spec",
+    "get_openapi_json",
+    "get_openapi_yaml",
+    "openapi",
+    "render_swagger_ui",
 ]


### PR DESCRIPTION
## Summary
- export openapi decorator and OpenAPI generation helpers from package root
- expose swagger UI renderer alongside version constants

## Testing
- not run (import/export change only)

Fixes #42