### PR TITLE
Relax route validation to match decorator examples

### DIFF
--- a/src/azure_functions_openapi/utils.py
+++ b/src/azure_functions_openapi/utils.py
@@ -173,12 +173,8 @@ def validate_route_path(route: Any) -> bool:
         if re.search(pattern, route, re.IGNORECASE):
             return False
 
-    # Route should start with / and contain only safe characters
-    if not route.startswith("/"):
-        return False
-
     # Allow alphanumeric, hyphens, underscores, slashes, and curly braces for path parameters
-    if not re.match(r"^/[a-zA-Z0-9_\-/{}\s]*$", route):
+    if not re.match(r"^/?[a-zA-Z0-9_\-/{}\s]*$", route):
         return False
 
     return True

--- a/tests/test_utils_enhanced.py
+++ b/tests/test_utils_enhanced.py
@@ -117,6 +117,8 @@ class TestValidateRoutePath:
     def test_validate_route_path_valid_routes(self) -> None:
         """Test validation of valid route paths."""
         valid_routes = [
+            "hello",
+            "todos/{id}",
             "/api/test",
             "/users/{id}",
             "/api/v1/users/{user_id}/posts/{post_id}",
@@ -134,7 +136,7 @@ class TestValidateRoutePath:
         invalid_routes: list[Any] = [
             None,
             "",
-            "not_starting_with_slash",
+            "api/test?param=1",
             "/api/../test",  # Path traversal
             "/api/<script>alert('xss')</script>",  # XSS attempt
             "/api/javascript:alert('xss')",  # JavaScript injection


### PR DESCRIPTION
## Summary
- allow routes without a leading slash in validation
- update route validation tests to cover slashless examples

## Testing
- pytest tests/test_utils_enhanced.py

Fixes #43