### PR TITLE
docs: fix CI badge workflow and tool versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
 [![Python Version](https://img.shields.io/pypi/pyversions/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
-[![CI](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/test.yml)
+[![CI](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/ci-test.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi/)

--- a/docs/development.md
+++ b/docs/development.md
@@ -34,10 +34,10 @@ This project uses pre-commit to ensure consistent code quality across formatting
 
 | Tool   | Version   | Purpose                          |
 |--------|-----------|----------------------------------|
-| black  | 23.11.0   | Auto-code formatter              |
-| ruff   | v0.4.4    | Linter + import sorter + fixer  |
+| black  | 25.1.0    | Auto-code formatter              |
+| ruff   | v0.11.13  | Linter + import sorter + fixer  |
 | mypy   | v1.15.0   | Static type checker              |
-| bandit | 1.7.7     | Security checker on `src/` only  |
+| bandit | 1.8.3     | Security checker on `src/` only  |
 
 ### Bandit Configuration
 


### PR DESCRIPTION
## Summary
This PR addresses two documentation inconsistencies:

1. **CI Badge Workflow Reference**: Updates README.md CI badge to point to the correct workflow file (ci-test.yml instead of non-existent test.yml)
2. **Development Tool Versions**: Updates development.md to reflect the current tool versions defined in .pre-commit-config.yaml

## Changes
- README.md: Fix CI badge workflow filename
- docs/development.md: Update tool versions to match .pre-commit-config.yaml
  - black: 23.11.0 → 25.1.0
  - ruff: v0.4.4 → v0.11.13
  - bandit: 1.7.7 → 1.8.3
  - mypy: v1.15.0 (no change, already correct)

## Fixes
Closes #51 
Closes #52