### PR TITLE
feat: add SBOM workflow with latest action versions

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,28 @@
+name: Generate SBOM
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0.22.1
+        with:
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: sbom
+          path: sbom.spdx.json


### PR DESCRIPTION
This PR adds the SBOM workflow file using the latest versions of actions:

- Uses anchore/sbom-action@v0.22.1
- Uses actions/upload-artifact@v6

This replaces the conflicting PRs #77 and #78, combining both changes into a single PR that should resolve the test failures in both.