### PR TITLE
fix: include default 200 response

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
         mimetype="application/json",
     )
 
-
 @app.function_name(name="openapi_json")
 @app.route(route="openapi.json", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
 def openapi_json(req: func.HttpRequest) -> func.HttpResponse:

--- a/src/azure_functions_openapi/openapi.py
+++ b/src/azure_functions_openapi/openapi.py
@@ -135,8 +135,13 @@ def generate_openapi_spec(
                         logger.warning(
                             f"Failed to generate response schema for {func_name}: {str(e)}"
                         )
-                        
-                if "200" not in responses:
+                        if not responses:
+                            responses["200"] = {
+                                "description": "Successful Response",
+                                "content": {"application/json": {"schema": {"type": "object"}}},
+                            }
+
+                if not responses:
                     responses["200"] = {
                         "description": "Successful Response",
                         "content": {"application/json": {"schema": {"type": "object"}}},

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -270,3 +270,38 @@ def test_generate_openapi_spec_with_security() -> None:
 
     op = generate_openapi_spec()["paths"]["/secure"]["get"]
     assert op["security"] == [{"BearerAuth": []}]
+
+
+def test_generate_openapi_spec_adds_default_200_response_when_missing() -> None:
+    @openapi(
+        route="/default-response",
+        method="post",
+        summary="Default response",
+        request_body={
+            "type": "object",
+            "properties": {"name": {"type": "string"}},
+        },
+    )
+    def default_response_func() -> None:
+        pass
+
+    responses = generate_openapi_spec()["paths"]["/default-response"]["post"]["responses"]
+    assert responses["200"] == {
+        "description": "Successful Response",
+        "content": {"application/json": {"schema": {"type": "object"}}},
+    }
+
+
+def test_generate_openapi_spec_keeps_explicit_non_200_responses_without_adding_200() -> None:
+    @openapi(
+        route="/created-response",
+        method="post",
+        summary="Created response",
+        response={201: {"description": "Created"}},
+    )
+    def created_response_func() -> None:
+        pass
+
+    responses = generate_openapi_spec()["paths"]["/created-response"]["post"]["responses"]
+    assert "200" not in responses
+    assert responses["201"] == {"description": "Created"}


### PR DESCRIPTION
## Summary

The example shown at the doc was not working. There were several issues.

Inside `README.md`:
- The `openapi` decorator was above the `FunctionBuilder` decorator.
- The parameters for the `openapi` decorator were incorrect for the first example; `request_model` and `response_model` were given instead of `request_body` and `request`.
- The routes for the `FunctionBuilder` were given with the prefix `/api/` which crashes the application.
- The `response` parameter dictionary in the example was not valid and was not generating a working `openapi.json`.

Inside `openapi.py`:
- The default response was not being created.

## Changes

- Document a working example inside `README.md`.
- Create a generic response 200 if it is not given by the user.

## Type of Change

<!-- Check the relevant option -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Chore (maintenance, dependencies, CI, etc.)

## Checklist

- [X] My code follows the project's code style
- [X] I have run `make check` (lint + typecheck)
- [X] I have run `make test` and all tests pass
- [ ] I have added tests for new functionality (if applicable)
- [X] I have updated documentation (if applicable)
- [X] My changes do not introduce new warnings

## Related Issues

Fixes #92 
Fixes #93
