### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-03-21
+
 ### Added
 
+- Unified `requests` and `responses` decorator parameters for cleaner API declarations (#115)
 - Real Azure end-to-end test workflow (`e2e-azure.yml`) deploying to Consumption plan (`koreacentral`)
 - `docs/testing.md` — Real Azure E2E Tests section
 
 ### Changed
 
-- GitHub Actions versions upgraded to Node.js 24 compatible: `checkout@v6`, `setup-python@v6`, `upload-artifact@v7`, `azure/login@v2.3.0`
+- **BREAKING**: Drop Pydantic v1 support, require `pydantic>=2.0,<3.0`
+- GitHub Actions versions upgraded to Node.js 24 compatible versions
+- Repository consistency fixes (AGENTS.md, .gitignore standardization)
+
+### Fixed
+
+- Apply `response_model` schema to first declared success response instead of synthetic 200 (#114)
+
 ## [0.14.0] - 2026-03-15
 
 ### Added

--- a/src/azure_functions_openapi/__init__.py
+++ b/src/azure_functions_openapi/__init__.py
@@ -11,7 +11,7 @@ from azure_functions_openapi.openapi import (
 )
 from azure_functions_openapi.swagger_ui import render_swagger_ui
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"
 
 __all__ = [
     "__version__",

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -19,8 +19,8 @@ class TestAPISurface:
             "render_swagger_ui",
         }
 
-    def test_version_is_0_14_0(self) -> None:
-        assert azure_functions_openapi.__version__ == "0.14.0"
+    def test_version_is_0_15_0(self) -> None:
+        assert azure_functions_openapi.__version__ == "0.15.0"
 
     def test_version_is_string(self) -> None:
         assert isinstance(azure_functions_openapi.__version__, str)


### PR DESCRIPTION
## Summary
- Bump package version to 0.15.0
- Update public API version test for 0.15.0
- Finalize changelog for 0.15.0 release notes