### PR TITLE
test: align with_validation snapshots with generated 201 response schema

### DIFF
--- a/tests/snapshots/with_validation_openapi.json
+++ b/tests/snapshots/with_validation_openapi.json
@@ -16,13 +16,7 @@
         ],
         "responses": {
           "201": {
-            "description": "User created"
-          },
-          "422": {
-            "description": "Validation error"
-          },
-          "200": {
-            "description": "Successful Response",
+            "description": "User created",
             "content": {
               "application/json": {
                 "schema": {
@@ -30,6 +24,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation error"
           }
         },
         "requestBody": {

--- a/tests/snapshots/with_validation_openapi_31.json
+++ b/tests/snapshots/with_validation_openapi_31.json
@@ -17,13 +17,7 @@
         ],
         "responses": {
           "201": {
-            "description": "User created"
-          },
-          "422": {
-            "description": "Validation error"
-          },
-          "200": {
-            "description": "Successful Response",
+            "description": "User created",
             "content": {
               "application/json": {
                 "schema": {
@@ -31,6 +25,9 @@
                 }
               }
             }
+          },
+          "422": {
+            "description": "Validation error"
           }
         },
         "requestBody": {


### PR DESCRIPTION
## Summary
- update with_validation OpenAPI snapshots to match current response_model attachment behavior
- keep response_model schema under the first declared 2xx response (`201`) for create_user

## Changes
- updated `tests/snapshots/with_validation_openapi.json`
- updated `tests/snapshots/with_validation_openapi_31.json`

## Validation
- `python -m pytest --no-cov -q tests/test_snapshots.py::TestWithValidationSnapshot::test_openapi_3_0_spec tests/test_snapshots.py::TestWithValidationSnapshot31::test_openapi_3_1_spec`
- `python -m pytest --no-cov -x -q`
- `python -m ruff check src/ tests/`
- `python -m mypy src/`

Closes #133