### PR TITLE
docs: add Azure deployment verification note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ curl -s "https://<your-app>.azurewebsites.net/api/http_trigger" \
 
 The `/api/openapi.json`, `/api/openapi.yaml`, and `/api/docs` endpoints are also available in both environments.
 
-> Response captured from a deployed Azure Function; URL anonymized.
+> Verified against a temporary Azure Functions deployment in koreacentral (Python 3.12, Consumption plan). Response captured and URL anonymized.
 
 ## Demo
 


### PR DESCRIPTION
## Summary

- Update verification note with real Azure deployment details

## Details

Deployed the `hello` example to a temporary Azure Function (Consumption plan, Python 3.12, koreacentral) and verified:

```
POST /api/http_trigger -d '{"name": "World"}'
→ {"message": "Hello, World!"} HTTP 200 ✅
```

Response matches README content exactly. Resources deleted immediately after verification.