### PR TITLE
docs: rewrite deployment guide for developer-friendly experience

### DIFF
--- a/docs/choose-a-plan.md
+++ b/docs/choose-a-plan.md
@@ -1,0 +1,264 @@
+# Choose an Azure Functions Hosting Plan
+
+This guide helps you pick the right hosting plan **before you deploy anything**.
+You do not need prior Azure experience — just a working Python project and an Azure account.
+
+## Who this guide is for
+
+You know Python, pip, and maybe Flask or FastAPI.
+You may have used AWS Lambda or Google Cloud Functions, or you may have never touched cloud infrastructure at all.
+Either way, this page gives you everything you need to make a confident plan choice.
+
+## If you know AWS Lambda or Google Cloud Functions
+
+Azure Functions is Microsoft's equivalent. The mental model maps like this:
+
+| Concept | AWS | GCP | Azure |
+|---|---|---|---|
+| A single handler/endpoint | Lambda function | Cloud Function | **Function** (a route, timer, or trigger handler) |
+| A deployable unit that groups handlers | — | — | **Function App** (one deployed app, many functions inside) |
+| How your code runs and scales | Lambda configuration | Cloud Function configuration | **Hosting plan** (controls scaling, timeout, cold start, cost) |
+| A billing/lifecycle boundary | AWS Account + Tags | GCP Project | **Resource Group** (a folder you can delete to clean up everything) |
+
+If you have never used any of these, don't worry. The next section explains the Azure terms from scratch.
+
+## The Azure terms you need
+
+| Term | What it means |
+|---|---|
+| **Function** | A single HTTP endpoint, timer job, or event handler. Like a FastAPI route or a Flask view. |
+| **Function App** | A deployed application that contains one or more functions. Like a Flask/FastAPI app that has multiple routes. You deploy once and all your functions go live together. |
+| **Hosting plan** | The compute model that runs your Function App. It controls how your code scales, how long it can run, cold-start behavior, and cost shape. |
+| **Resource Group** | A container for related Azure resources. Think of it as a folder. When you are done testing, delete the resource group and everything inside it goes away. |
+| **Storage Account** | Azure Functions needs a storage account to manage internal state (triggers, logs, deployment packages). You create one, hand it to the Function App, and forget about it. |
+| **Application Insights** | Optional monitoring service. Azure CLI creates one automatically when you create a Function App. You can use it to see logs, traces, and performance data. |
+
+## What a hosting plan actually decides
+
+Your choice of plan affects four things:
+
+1. **Timeout** — How long a single function invocation can run before Azure kills it
+2. **Cold start** — How fast your app responds after being idle
+3. **Scaling** — How many instances spin up under load
+4. **Cost** — Whether you pay per-invocation, per-second, or a fixed monthly amount
+
+The Python code you write does **not** change between plans. Only the infrastructure commands change.
+
+## The plans
+
+Azure Functions offers several hosting plans. These docs cover three:
+
+### Flex Consumption (recommended for most users)
+
+- **Best for**: Learning, prototyping, lightweight HTTP APIs, low-traffic production
+- **Timeout**: 30 minutes default (configurable)
+- **Cold start**: Moderate (a few seconds after idle)
+- **Scaling**: Automatic, scale-to-zero when idle
+- **Cost**: Pay only when your code runs. Lowest entry cost. Scale-to-zero means $0 when idle.
+- **Avoid if**: Your app has a large dependency footprint (>500 MB) or you need sub-second cold starts
+
+### Premium (EP1 / EP2 / EP3)
+
+- **Best for**: LLM/AI workloads, latency-sensitive APIs, apps with large dependencies
+- **Timeout**: 30 minutes default, unlimited maximum
+- **Cold start**: Minimal (always-warm instances available)
+- **Scaling**: Automatic with pre-warmed instances
+- **Cost**: Moderate baseline cost even when idle. You pay for at least one always-on instance.
+- **Avoid if**: You are just learning and want to minimize cost
+
+### Dedicated (App Service Plan — B1 / S1 / P1v2)
+
+- **Best for**: Organizations already using App Service, predictable fixed-cost budgeting
+- **Timeout**: 30 minutes default, unlimited maximum
+- **Cold start**: None (always running)
+- **Scaling**: Manual or autoscale rules (not automatic like Consumption/Premium)
+- **Cost**: Fixed monthly cost regardless of usage. Cheapest SKU (B1) starts around $13/month.
+- **Avoid if**: You want scale-to-zero or automatic scaling
+
+> **Note**: Older Azure documentation may reference "Consumption" plan (classic). Flex Consumption is its successor and is recommended for new projects.
+
+## Quick recommendation
+
+```text
+Start here:
+ └─ Are you running LLM / AI agent workloads?
+     ├─ YES → Premium (EP1)
+     └─ NO
+         └─ Do you need predictable cold starts (< 1 second)?
+             ├─ YES → Premium (EP1)
+             └─ NO
+                 └─ Do you already run Azure App Service with fixed capacity?
+                     ├─ YES → Dedicated (B1 or higher)
+                     └─ NO → Flex Consumption ✅ (start here)
+```
+
+**For most users**: Start with **Flex Consumption**. It costs nothing when idle, handles most workloads well, and you can switch plans later without changing your code.
+
+**For LLM/AI workloads** (like `azure-functions-langgraph`): Start with **Premium EP1**. LLM calls can take 30+ seconds, and cold starts frustrate users. Premium gives you always-warm instances and no hard timeout ceiling.
+
+## Cost at a glance
+
+| Plan | Idle cost | Per-request cost | Best mental model |
+|---|---|---|---|
+| Flex Consumption | $0 (scale-to-zero) | Pay per execution + GB-seconds | Like a taxi — pay only when riding |
+| Premium (EP1) | ~$100-150/month (1 instance) | Included in base cost | Like a car lease — monthly payment, always available |
+| Dedicated (B1) | ~$13/month | Included in base cost | Like renting a server — fixed monthly, always on |
+
+> These are approximate. Actual costs depend on region, usage, and configuration.
+> For exact pricing, see [Azure Functions pricing](https://azure.microsoft.com/pricing/details/functions/).
+
+## Complete deployment commands by plan
+
+Every example below uses these shared variables. Replace the placeholder values with your own:
+
+```bash
+RESOURCE_GROUP="rg-my-app"
+LOCATION="koreacentral"
+STORAGE_ACCOUNT="stmyapp$(date +%s | tail -c 6)"  # Must be globally unique, lowercase, no hyphens, 3–24 characters
+FUNCTIONAPP_NAME="func-my-app"
+```
+
+### Step 1: Sign in and set subscription (all plans)
+
+```bash
+az login
+az account set --subscription "<YOUR_SUBSCRIPTION_ID>"
+```
+
+### Step 2: Create a resource group (all plans)
+
+A resource group is a folder for your Azure resources. Delete it later to clean up everything.
+
+```bash
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION"
+```
+
+### Step 3: Create a storage account (all plans)
+
+Azure Functions requires a storage account for internal state management.
+
+```bash
+az storage account create \
+  --name "$STORAGE_ACCOUNT" \
+  --resource-group "$RESOURCE_GROUP" \
+  --location "$LOCATION" \
+  --sku Standard_LRS
+```
+
+### Step 4: Create the Function App
+
+This is where the plans differ. **Copy the entire block for your chosen plan.**
+
+#### Option A: Flex Consumption (recommended)
+
+```bash
+az functionapp create \
+  --name "$FUNCTIONAPP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --storage-account "$STORAGE_ACCOUNT" \
+  --flexconsumption-location "$LOCATION" \
+  --runtime python \
+  --runtime-version 3.11
+```
+
+> No separate plan creation needed. Azure manages the compute automatically.
+
+#### Option B: Premium (EP1)
+
+```bash
+# First, create the Premium plan
+az functionapp plan create \
+  --name "${FUNCTIONAPP_NAME}-plan" \
+  --resource-group "$RESOURCE_GROUP" \
+  --location "$LOCATION" \
+  --sku EP1 \
+  --is-linux
+
+# Then, create the Function App on that plan
+az functionapp create \
+  --name "$FUNCTIONAPP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --storage-account "$STORAGE_ACCOUNT" \
+  --plan "${FUNCTIONAPP_NAME}-plan" \
+  --runtime python \
+  --runtime-version 3.11 \
+  --os-type Linux
+```
+
+#### Option C: Dedicated (App Service Plan — B1)
+
+```bash
+# First, create the App Service plan
+az appservice plan create \
+  --name "${FUNCTIONAPP_NAME}-plan" \
+  --resource-group "$RESOURCE_GROUP" \
+  --location "$LOCATION" \
+  --sku B1 \
+  --is-linux
+
+# Then, create the Function App on that plan
+az functionapp create \
+  --name "$FUNCTIONAPP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --storage-account "$STORAGE_ACCOUNT" \
+  --plan "${FUNCTIONAPP_NAME}-plan" \
+  --runtime python \
+  --runtime-version 3.11 \
+  --os-type Linux
+```
+
+### Step 5: Deploy your code (all plans)
+
+```bash
+func azure functionapp publish "$FUNCTIONAPP_NAME"
+```
+
+### Step 6: Clean up (all plans)
+
+Delete the resource group to remove **all** resources (Function App, plan, storage, monitoring):
+
+```bash
+az group delete --name "$RESOURCE_GROUP" --yes --no-wait
+```
+
+> ⚠️ **Cost reminder**: Azure resources cost money until deleted. Always clean up after testing.
+
+## When to switch plans
+
+Plan choice is not permanent. Common triggers to revisit:
+
+| Situation | Consider switching to |
+|---|---|
+| Idle cost is too high on Premium | Flex Consumption |
+| Cold starts are hurting user experience | Premium |
+| LLM calls are timing out on Flex | Premium |
+| Your team already manages App Service | Dedicated |
+| You need VNet integration | Premium or Dedicated |
+
+Switching plans does not require code changes — only infrastructure commands.
+
+## Why these repos recommend different defaults
+
+Most `azure-functions-*` repos default to **Flex Consumption** because:
+- Lowest cost for learning and testing
+- Zero idle cost (scale-to-zero)
+- Simple provisioning (no plan creation step)
+- Sufficient timeout (30 min) for most HTTP workloads
+
+**Exception**: `azure-functions-langgraph` defaults to **Premium** because:
+- LLM/agent invocations can take 30+ seconds
+- Cold starts degrade the AI agent user experience
+- Dependency footprint is larger (LangGraph + LLM SDKs)
+- Premium's always-warm instances ensure predictable first response
+
+## Learn more
+
+- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale) — Official plan comparison
+- [Azure Functions pricing](https://azure.microsoft.com/pricing/details/functions/) — Current pricing details
+- [Azure Functions Python developer guide](https://learn.microsoft.com/azure/azure-functions/functions-reference-python) — Python-specific reference
+- [Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan) — Flex Consumption details
+- [Azure Functions Premium plan](https://learn.microsoft.com/azure/azure-functions/functions-premium-plan) — Premium plan details
+
+## See Also
+
+- [Deployment Guide](deployment.md) — Step-by-step deployment for this specific package

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,407 +1,489 @@
-# Deployment Guide
-This guide walks through deploying two `azure-functions-openapi` examples to Azure Functions (`todo_crud` and `with_validation`) and verifying runtime behavior, OpenAPI endpoints, and Swagger UI headers. It also includes CLI-based spec generation for CI workflows. Outputs are representative examples, not guaranteed byte-for-byte.
-## Prerequisites
-| Requirement | Minimum | Notes |
-|---|---|---|
-| Azure subscription | Active | Use `<YOUR_SUBSCRIPTION_ID>` |
-| Azure CLI (`az`) | Current | `az --version` |
-| Azure Functions Core Tools (`func`) | v4 | `func --version` |
-| Python | 3.10+ | Deploy runtime shown is Python 3.11 |
-| `azure-functions-openapi` | v0.16.0 | Install in each example environment |
+# Deploy to Azure
 
-Install dependencies in each example project before deploy:
+This guide walks you through deploying `azure-functions-openapi` to Azure, step by step.
+No Azure experience required.
+
+## Who this guide is for
+
+You know Python and pip, and you can run the examples locally.
+Now you want to deploy to Azure Functions and verify both your API endpoints and OpenAPI docs endpoints.
+
+## What you are deploying
+
+`azure-functions-openapi` adds OpenAPI support to Azure Functions Python apps.
+In this guide, you deploy example apps that provide:
+
+- Runtime API endpoints (`todo_crud`, `with_validation`)
+- Generated OpenAPI documents at `/api/openapi.json` and `/api/openapi.yaml`
+- Swagger UI at `/api/docs`
+- Security-focused response headers on the docs page (`Content-Security-Policy`, `X-Frame-Options`, HSTS, and others)
+
+## Azure concepts you need for this guide
+
+> New to Azure? Read [Choose an Azure Functions Hosting Plan](choose-a-plan.md) first.
+
+| Term | What it means |
+|---|---|
+| **Function App** | Your deployed app in Azure. It can contain multiple HTTP functions. |
+| **Hosting plan** | The compute model for your Function App (scaling, timeout, cost). |
+| **Resource Group** | A container for related resources. Delete it to clean up everything. |
+| **Storage Account** | Required by Azure Functions for runtime state and deployment internals. |
+| **Application Insights** | Monitoring resource Azure creates for logs and telemetry. |
+
+## Recommended plan for this repo
+
+| | |
+|---|---|
+| **Default plan** | Flex Consumption |
+| **Why** | Cheapest entry point, scale-to-zero, and enough timeout for these examples. |
+| **Switch to Premium if** | You need lower cold-start latency or large dependency footprints. |
+
+## Before you start
+
+| Requirement | How to check | Install if missing |
+|---|---|---|
+| Azure account | [portal.azure.com](https://portal.azure.com) | [Create free account](https://azure.microsoft.com/free/) |
+| Azure CLI | `az --version` | [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) |
+| Azure Functions Core Tools v4 | `func --version` | [Install Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools) |
+| Python 3.10-3.13 | `python3 --version` | [python.org](https://www.python.org/downloads/) |
+| Package examples available | `ls examples` | Clone this repo again if missing |
+| Local example works | `func start` + local `curl` | See [README](../README.md) |
+
+> Verify locally first. If it fails locally, deployment troubleshooting is much harder.
+
+## Read these warnings before provisioning
+
+1. **Storage account names are globally unique.** Only lowercase letters and numbers, 3–24 characters.
+2. **Use one region across all resources.** Mixed regions can increase latency and failures.
+3. **Deploy from the correct example directory.** Publishing from the wrong folder gives wrong functions and wrong OpenAPI output.
+4. **OpenAPI and Swagger routes are regular functions.** If `auth_level` for `openapi.json`, `openapi.yaml`, or `docs` is not anonymous, direct `curl` checks can return `401/403`.
+5. **Swagger UI route path is `/api/docs` by default.** If your host config or route prefix changes, docs URL changes too.
+6. **First publish is slower.** Azure performs a remote build and installs dependencies.
+
+---
+
+## Example 1: todo_crud
+
+This is the primary guided path.
+
+### Step 1 — Move into the example project
 
 ```bash
+cd /data/GitHub/azure-functions-openapi/examples/todo_crud
+```
+
+### Step 2 — Create and activate a virtual environment
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+```
+
+### Step 3 — Install dependencies
+
+```bash
+pip install -r requirements.txt
+pip install azure-functions-openapi==0.16.0
+```
+
+### Step 4 — Verify local app starts
+
+```bash
+cp local.settings.json.example local.settings.json
+func start
+```
+
+In another terminal, verify one endpoint:
+
+```bash
+curl -s -i http://localhost:7071/api/list_todos
+```
+
+Stop the local server with `Ctrl+C`.
+
+### Step 5 — Sign in to Azure and select subscription
+
+```bash
+az login
+az account list -o table
+SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
+SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
+az account set --subscription "$SUBSCRIPTION_ID"
+```
+
+### Step 6 — Define deployment variables
+
+```bash
+RESOURCE_GROUP="rg-openapi-todo"
+LOCATION="koreacentral"
+STORAGE_ACCOUNT="stopenapitodo$(date +%s | tail -c 6)"
+FUNCTIONAPP_NAME="func-openapi-todo"
+BASE_URL="https://$FUNCTIONAPP_NAME.azurewebsites.net"
+```
+
+If needed, list Flex Consumption regions:
+
+```bash
+az functionapp list-flexconsumption-locations -o table
+```
+
+### Step 7 — Create Azure resource group
+
+```bash
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION"
+```
+
+### Step 8 — Create storage account
+
+```bash
+az storage account create \
+  --name "$STORAGE_ACCOUNT" \
+  --resource-group "$RESOURCE_GROUP" \
+  --location "$LOCATION" \
+  --sku Standard_LRS
+```
+
+### Step 9 — Create Function App on Flex Consumption
+
+```bash
+az functionapp create \
+  --name "$FUNCTIONAPP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --storage-account "$STORAGE_ACCOUNT" \
+  --flexconsumption-location "$LOCATION" \
+  --runtime python \
+  --runtime-version 3.11
+```
+
+### Step 10 — Publish the app
+
+```bash
+func azure functionapp publish "$FUNCTIONAPP_NAME"
+```
+
+Expected function names include:
+
+- `create_todo`, `list_todos`, `get_todo`, `update_todo`, `delete_todo`
+- `openapi_spec`, `openapi_yaml_spec`, `swagger_ui`
+
+### Step 11 — Verify CRUD API endpoints
+
+Create todo:
+
+```bash
+curl -s -i -X POST "$BASE_URL/api/create_todo" \
+  -H "Content-Type: application/json" \
+  -d '{"title":"Buy groceries"}'
+```
+
+List todos:
+
+```bash
+curl -s -i "$BASE_URL/api/list_todos"
+```
+
+Get todo:
+
+```bash
+curl -s -i "$BASE_URL/api/get_todo?id=1"
+```
+
+Update todo:
+
+```bash
+curl -s -i -X PUT "$BASE_URL/api/update_todo" \
+  -H "Content-Type: application/json" \
+  -d '{"id":1,"title":"Buy groceries","done":true}'
+```
+
+Delete todo:
+
+```bash
+curl -s -i -X DELETE "$BASE_URL/api/delete_todo?id=1"
+```
+
+### Step 12 — Verify OpenAPI JSON, YAML, and Swagger UI
+
+OpenAPI JSON:
+
+```bash
+curl -s -i "$BASE_URL/api/openapi.json"
+```
+
+OpenAPI YAML:
+
+```bash
+curl -s -i "$BASE_URL/api/openapi.yaml"
+```
+
+Swagger UI HTML:
+
+```bash
+curl -s -i "$BASE_URL/api/docs"
+```
+
+For Swagger UI, confirm these headers exist:
+
+- `Content-Security-Policy`
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Strict-Transport-Security`
+
+### Step 13 — Optional: watch live logs
+
+```bash
+func azure functionapp logstream "$FUNCTIONAPP_NAME"
+```
+
+Press `Ctrl+C` to stop log streaming.
+
+---
+
+## Example 2: with_validation
+
+Try another example with request validation powered by `azure-functions-validation`.
+
+### Step 1 — Move into the example project
+
+```bash
+cd /data/GitHub/azure-functions-openapi/examples/with_validation
+```
+
+### Step 2 — Install dependencies
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
 python -m pip install --upgrade pip
 pip install -r requirements.txt
 pip install azure-functions-openapi==0.16.0
 ```
 
-Representative output:
+### Step 3 — Set variables and create resources
 
 ```bash
-Requirement already satisfied: pip in ./.venv/lib/python3.11/site-packages (25.0)
-Collecting azure-functions
-Collecting azure-functions-openapi==0.16.0
-Collecting pydantic
-Successfully installed azure-functions-1.24.0 azure-functions-openapi-0.16.0 pydantic-2.11.3
+RESOURCE_GROUP="rg-openapi-validation"
+LOCATION="koreacentral"
+STORAGE_ACCOUNT="stopenapival$(date +%s | tail -c 6)"
+FUNCTIONAPP_NAME="func-openapi-validation"
+BASE_URL="https://$FUNCTIONAPP_NAME.azurewebsites.net"
+
+az login
+SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
+az account set --subscription "$SUBSCRIPTION_ID"
+
+az group create --name "$RESOURCE_GROUP" --location "$LOCATION"
+
+az storage account create \
+  --name "$STORAGE_ACCOUNT" \
+  --resource-group "$RESOURCE_GROUP" \
+  --location "$LOCATION" \
+  --sku Standard_LRS
+
+az functionapp create \
+  --name "$FUNCTIONAPP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --storage-account "$STORAGE_ACCOUNT" \
+  --flexconsumption-location "$LOCATION" \
+  --runtime python \
+  --runtime-version 3.11
 ```
 
-## Example 1: `todo_crud`
-The `todo_crud` example uses an in-memory store (`TODOS = []`) and starts empty on cold start. The first created item gets `id=1`.
-### Provision Azure resources
+### Step 4 — Publish and verify endpoints
 
 ```bash
-az account set --subscription <YOUR_SUBSCRIPTION_ID>
-az group create --name <YOUR_RESOURCE_GROUP_TODO> --location eastus
-az storage account create --name <YOUR_STORAGE_ACCOUNT_TODO> --resource-group <YOUR_RESOURCE_GROUP_TODO> --location eastus --sku Standard_LRS --kind StorageV2
-az functionapp create --name <YOUR_FUNCTION_APP_TODO> --resource-group <YOUR_RESOURCE_GROUP_TODO> --storage-account <YOUR_STORAGE_ACCOUNT_TODO> --consumption-plan-location eastus --runtime python --runtime-version 3.11 --functions-version 4
+func azure functionapp publish "$FUNCTIONAPP_NAME"
 ```
 
-Representative output:
-
-```json
-{"name":"<YOUR_RESOURCE_GROUP_TODO>","location":"eastus","properties":{"provisioningState":"Succeeded"}}
-{"name":"<YOUR_STORAGE_ACCOUNT_TODO>","kind":"StorageV2","provisioningState":"Succeeded"}
-{"name":"<YOUR_FUNCTION_APP_TODO>","defaultHostName":"<YOUR_FUNCTION_APP_TODO>.azurewebsites.net","provisioningState":"Succeeded","state":"Running"}
-```
-
-### Configure app settings
+Create user:
 
 ```bash
-az storage account show-connection-string --name <YOUR_STORAGE_ACCOUNT_TODO> --resource-group <YOUR_RESOURCE_GROUP_TODO> --query connectionString --output tsv
-az functionapp config appsettings set --name <YOUR_FUNCTION_APP_TODO> --resource-group <YOUR_RESOURCE_GROUP_TODO> --settings AZURE_STORAGE_CONNECTION_STRING="<YOUR_STORAGE_CONNECTION_STRING_TODO>"
+curl -s -i -X POST "$BASE_URL/api/users" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice","email":"alice@example.com"}'
 ```
 
-Representative output:
-
-```text
-<YOUR_STORAGE_CONNECTION_STRING_TODO>
-```
-
-```json
-{"appSettings":[{"name":"AZURE_STORAGE_CONNECTION_STRING","slotSetting":false,"value":""},{"name":"FUNCTIONS_EXTENSION_VERSION","slotSetting":false,"value":"~4"},{"name":"FUNCTIONS_WORKER_RUNTIME","slotSetting":false,"value":"python"}]}
-
-### Publish
-
-From `examples/todo_crud`:
+Get user:
 
 ```bash
-func azure functionapp publish <YOUR_FUNCTION_APP_TODO>
+curl -s -i "$BASE_URL/api/users/1"
 ```
 
-Representative output:
-
-```text
-Getting site publishing info...
-[2026-04-06T10:27:41.021Z] Starting the function app deployment...
-Uploading package...
-Uploading 4.12 MB [#############################################################################]
-Deployment completed successfully.
-Syncing triggers...
-Functions in <YOUR_FUNCTION_APP_TODO>:
-    create_todo - [httpTrigger]
-    list_todos - [httpTrigger]
-    get_todo - [httpTrigger]
-    update_todo - [httpTrigger]
-    delete_todo - [httpTrigger]
-    openapi_spec - [httpTrigger]
-    openapi_yaml_spec - [httpTrigger]
-    swagger_ui - [httpTrigger]
-Deployment successful.
-```
-
-### Verify endpoints
+Invalid payload (validation expected):
 
 ```bash
-export BASE_URL_TODO="https://<YOUR_FUNCTION_APP_TODO>.azurewebsites.net"
+curl -s -i -X POST "$BASE_URL/api/users" \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Alice"}'
 ```
 
-#### `POST /api/create_todo`
+Check docs endpoints:
 
 ```bash
-curl -s -i -X POST "$BASE_URL_TODO/api/create_todo" -H "Content-Type: application/json" -d '{"title":"Buy groceries"}'
+curl -s -i "$BASE_URL/api/openapi.json"
+curl -s -i "$BASE_URL/api/openapi.yaml"
+curl -s -i "$BASE_URL/api/docs"
 ```
 
-Representative response:
-
-```http
-HTTP/1.1 201 Created
-Content-Type: application/json
-
-{"id":1,"title":"Buy groceries","done":false}
-```
-
-#### `GET /api/list_todos`
-
-```bash
-curl -s -i "$BASE_URL_TODO/api/list_todos"
-```
-
-Representative response:
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{"todos":[{"id":1,"title":"Buy groceries","done":false}]}
-```
-
-#### `GET /api/get_todo?id=1`
-
-```bash
-curl -s -i "$BASE_URL_TODO/api/get_todo?id=1"
-```
-
-Representative response:
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{"id":1,"title":"Buy groceries","done":false}
-```
-
-#### `PUT /api/update_todo`
-
-```bash
-curl -s -i -X PUT "$BASE_URL_TODO/api/update_todo" -H "Content-Type: application/json" -d '{"id":1,"title":"Buy groceries","done":true}'
-```
-
-Representative response:
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{"id":1,"title":"Buy groceries","done":true}
-```
-
-#### `DELETE /api/delete_todo?id=1`
-
-```bash
-curl -s -i -X DELETE "$BASE_URL_TODO/api/delete_todo?id=1"
-```
-
-Representative response:
-
-```http
-HTTP/1.1 204 No Content
-Content-Type: text/plain; charset=utf-8
-```
-
-#### `GET /api/openapi.json`
-
-`get_openapi_json()` is called without args in this example, so defaults apply (`title="API"`, `version="1.0.0"`).
-
-```bash
-curl -s -i "$BASE_URL_TODO/api/openapi.json"
-```
-
-Representative response (truncated):
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{
-  "openapi": "3.0.0",
-  "info": {"title": "API", "version": "1.0.0"},
-  "paths": {
-    "/api/create_todo": {"post": {"operationId": "createTodo"}},
-    "/api/list_todos": {"get": {"operationId": "listTodos"}}
-  }
-}
-```
-
-#### `GET /api/openapi.yaml`
-
-```bash
-curl -s -i "$BASE_URL_TODO/api/openapi.yaml"
-```
-
-Representative response (truncated):
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/x-yaml
-
-openapi: 3.0.0
-info: {title: API, version: 1.0.0}
-paths:
-  /api/create_todo: {post: {operationId: createTodo}}
-  /api/list_todos: {get: {operationId: listTodos}}
-```
-
-#### `GET /api/docs`
-
-```bash
-curl -s -i "$BASE_URL_TODO/api/docs"
-```
-
-Representative response (headers + HTML start):
-
-```http
-HTTP/1.1 200 OK
-Content-Type: text/html
-Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-<NONCE>' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; img-src 'self' data: https:; font-src 'self' https://cdn.jsdelivr.net; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'
-X-Content-Type-Options: nosniff
-X-Frame-Options: DENY
-X-XSS-Protection: 1; mode=block
-Referrer-Policy: strict-origin-when-cross-origin
-Strict-Transport-Security: max-age=31536000; includeSubDomains
-Cache-Control: no-cache, no-store, must-revalidate
-
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <title>API Documentation</title>
-```
-
-## Example 2: `with_validation`
-The `with_validation` example uses `azure-functions-validation` (`@validate_http`) and an in-memory user store (`USERS = []`). It starts empty on cold start, so the first created user gets `id=1`.
-### Provision Azure resources
-
-```bash
-az account set --subscription <YOUR_SUBSCRIPTION_ID>
-az group create --name <YOUR_RESOURCE_GROUP_VALIDATION> --location eastus
-az storage account create --name <YOUR_STORAGE_ACCOUNT_VALIDATION> --resource-group <YOUR_RESOURCE_GROUP_VALIDATION> --location eastus --sku Standard_LRS --kind StorageV2
-az functionapp create --name <YOUR_FUNCTION_APP_VALIDATION> --resource-group <YOUR_RESOURCE_GROUP_VALIDATION> --storage-account <YOUR_STORAGE_ACCOUNT_VALIDATION> --consumption-plan-location eastus --runtime python --runtime-version 3.11 --functions-version 4
-```
-
-Representative output:
-
-```json
-{"name":"<YOUR_RESOURCE_GROUP_VALIDATION>","location":"eastus","properties":{"provisioningState":"Succeeded"}}
-{"name":"<YOUR_STORAGE_ACCOUNT_VALIDATION>","kind":"StorageV2","provisioningState":"Succeeded"}
-{"name":"<YOUR_FUNCTION_APP_VALIDATION>","defaultHostName":"<YOUR_FUNCTION_APP_VALIDATION>.azurewebsites.net","provisioningState":"Succeeded","state":"Running"}
-```
-
-### Configure app settings
-
-```bash
-az storage account show-connection-string --name <YOUR_STORAGE_ACCOUNT_VALIDATION> --resource-group <YOUR_RESOURCE_GROUP_VALIDATION> --query connectionString --output tsv
-az functionapp config appsettings set --name <YOUR_FUNCTION_APP_VALIDATION> --resource-group <YOUR_RESOURCE_GROUP_VALIDATION> --settings AZURE_STORAGE_CONNECTION_STRING="<YOUR_STORAGE_CONNECTION_STRING_VALIDATION>"
-```
-
-Representative output:
-
-```text
-<YOUR_STORAGE_CONNECTION_STRING_VALIDATION>
-```
-
-```json
-{"appSettings":[{"name":"AZURE_STORAGE_CONNECTION_STRING","slotSetting":false,"value":""},{"name":"FUNCTIONS_EXTENSION_VERSION","slotSetting":false,"value":"~4"},{"name":"FUNCTIONS_WORKER_RUNTIME","slotSetting":false,"value":"python"}]}
-
-### Publish
-
-From `examples/with_validation`:
-
-```bash
-func azure functionapp publish <YOUR_FUNCTION_APP_VALIDATION>
-```
-
-Representative output:
-
-```text
-Getting site publishing info...
-[2026-04-06T10:47:13.207Z] Starting the function app deployment...
-Uploading package...
-Uploading 4.07 MB [#############################################################################]
-Deployment completed successfully.
-Syncing triggers...
-Functions in <YOUR_FUNCTION_APP_VALIDATION>:
-    create_user - [httpTrigger]
-    get_user - [httpTrigger]
-    openapi_spec - [httpTrigger]
-    openapi_yaml_spec - [httpTrigger]
-    swagger_ui - [httpTrigger]
-Deployment successful.
-```
-
-### Verify endpoints
-
-```bash
-export BASE_URL_VALIDATION="https://<YOUR_FUNCTION_APP_VALIDATION>.azurewebsites.net"
-```
-
-#### `POST /api/users`
-
-`create_user` is decorated with `@validate_http`; at runtime this returns `200 OK` by default even though the OpenAPI `response` block lists `201`.
-
-```bash
-curl -s -i -X POST "$BASE_URL_VALIDATION/api/users" -H "Content-Type: application/json" -d '{"name":"Alice","email":"alice@example.com"}'
-```
-
-Representative response:
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{"id":1,"name":"Alice","email":"alice@example.com"}
-```
-
-#### `GET /api/users/1`
-
-```bash
-curl -s -i "$BASE_URL_VALIDATION/api/users/1"
-```
-
-Representative response:
-
-```http
-HTTP/1.1 200 OK
-Content-Type: application/json
-
-{"id":1,"name":"Alice","email":"alice@example.com"}
-```
-
-#### `POST /api/users` (invalid payload)
-
-```bash
-curl -s -i -X POST "$BASE_URL_VALIDATION/api/users" -H "Content-Type: application/json" -d '{"name":"Alice"}'
-```
-
-Representative response (from `azure-functions-validation`):
-
-```http
-HTTP/1.1 422 Unprocessable Entity
-Content-Type: application/json
-
-{"detail":[{"loc":["email"],"msg":"Field required","type":"missing"}]}
-```
+---
 
 ## CLI spec generation
-Use the CLI to generate a static OpenAPI artifact during CI without manually calling API routes:
-```bash
-azure-functions-openapi generate --app-path ./function_app.py --format json --output ./openapi.json
-```
 
-Representative output:
+After deployment (or in CI), you can generate a static OpenAPI file directly from `function_app.py`.
 
-```text
-Generating OpenAPI spec from ./function_app.py
-Detected Azure Functions routes and OpenAPI decorators
-Wrote OpenAPI JSON to ./openapi.json
-```
-
-You can also output YAML:
+From either example directory:
 
 ```bash
-azure-functions-openapi generate --app-path ./function_app.py --format yaml --output ./openapi.yaml
+azure-functions-openapi generate \
+  --app-path ./function_app.py \
+  --format json \
+  --output ./openapi.json
 ```
 
-Representative output:
+Generate YAML instead:
 
-```text
-Generating OpenAPI spec from ./function_app.py
-Wrote OpenAPI YAML to ./openapi.yaml
-```
-
-For full CLI options and flags, see [`docs/cli.md`](./cli.md).
-
-## Cleanup
 ```bash
-az group delete --name <YOUR_RESOURCE_GROUP_TODO> --yes --no-wait
-az group delete --name <YOUR_RESOURCE_GROUP_VALIDATION> --yes --no-wait
+azure-functions-openapi generate \
+  --app-path ./function_app.py \
+  --format yaml \
+  --output ./openapi.yaml
 ```
 
-Representative output:
+See [`docs/cli.md`](./cli.md) for full CLI options.
 
-```text
-{"status":"Accepted"}
-{"status":"Accepted"}
+## If you need a different plan
+
+This guide uses Flex Consumption. For Premium or Dedicated commands, see [Choose an Azure Functions Hosting Plan](choose-a-plan.md).
+
+### Premium (EP1)
+
+```bash
+az functionapp plan create \
+  --name "${FUNCTIONAPP_NAME}-plan" \
+  --resource-group "$RESOURCE_GROUP" \
+  --location "$LOCATION" \
+  --sku EP1 \
+  --is-linux
+
+az functionapp create \
+  --name "$FUNCTIONAPP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --storage-account "$STORAGE_ACCOUNT" \
+  --plan "${FUNCTIONAPP_NAME}-plan" \
+  --runtime python \
+  --runtime-version 3.11 \
+  --os-type Linux
+```
+
+### Dedicated (B1)
+
+```bash
+az appservice plan create \
+  --name "${FUNCTIONAPP_NAME}-plan" \
+  --resource-group "$RESOURCE_GROUP" \
+  --location "$LOCATION" \
+  --sku B1 \
+  --is-linux
+
+az functionapp create \
+  --name "$FUNCTIONAPP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --storage-account "$STORAGE_ACCOUNT" \
+  --plan "${FUNCTIONAPP_NAME}-plan" \
+  --runtime python \
+  --runtime-version 3.11 \
+  --os-type Linux
+```
+
+## Troubleshooting
+
+### Provisioning failed
+
+| Symptom | Usually means | How to fix |
+|---|---|---|
+| `StorageAccountAlreadyTaken` | Storage account name is already used globally | Change the name suffix and retry |
+| `LocationNotAvailableForResourceType` | Flex Consumption not available in selected region | Run `az functionapp list-flexconsumption-locations -o table` and choose a supported region |
+| `SubscriptionNotFound` | Wrong subscription selected | Run `az account list -o table`, then set `SUBSCRIPTION_ID` again |
+
+### Deployment failed
+
+| Symptom | Usually means | How to fix |
+|---|---|---|
+| `ModuleNotFoundError` during publish | Missing or incomplete dependencies | Reinstall with `pip install -r requirements.txt` and republish |
+| `Can't find app with name` | Function App not ready yet | Wait 30-60 seconds and rerun publish |
+| Publish is very slow | First remote build is still running | Wait, then rerun once if it times out |
+
+### OpenAPI and Swagger issues
+
+| Symptom | Usually means | How to fix |
+|---|---|---|
+| `404` on `/api/docs` | Wrong route prefix or docs route changed | Verify `app.route(route="docs")` and host route prefix |
+| `/api/openapi.json` is empty or missing endpoints | OpenAPI decorators are missing or not imported | Confirm functions use `@openapi` and app starts without import errors |
+| `/api/openapi.yaml` returns `401/403` | Auth level is not anonymous on docs functions | Set `auth_level=func.AuthLevel.ANONYMOUS` for OpenAPI/docs routes and redeploy |
+| Swagger UI loads but fails to fetch spec | Spec URL blocked or wrong path | Confirm `/api/openapi.json` is reachable directly with `curl` |
+| Missing hardening headers on `/api/docs` | Docs response not coming from `render_swagger_ui()` | Ensure docs function returns `render_swagger_ui()` and redeploy |
+
+### Logs and monitoring
+
+```bash
+func azure functionapp logstream "$FUNCTIONAPP_NAME"
+
+az monitor app-insights events show \
+  --app "$FUNCTIONAPP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --type requests \
+  --offset 1h
+```
+
+### Before opening an issue
+
+Share these outputs so maintainers can reproduce quickly:
+
+```bash
+az --version
+func --version
+python3 --version
+pip show azure-functions-openapi
+
+az functionapp show \
+  --name "$FUNCTIONAPP_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --query "{state:state,runtimeVersion:siteConfig.linuxFxVersion}"
+
+curl -s -i "$BASE_URL/api/openapi.json"
+curl -s -i "$BASE_URL/api/docs"
+```
+
+## Clean up resources
+
+Azure resources keep billing until deleted.
+
+```bash
+az group delete --name "rg-openapi-todo" --yes --no-wait
+az group delete --name "rg-openapi-validation" --yes --no-wait
+```
+
+Verify cleanup:
+
+```bash
+az group list --query "[?starts_with(name, 'rg-openapi')]" -o table
 ```
 
 ## Sources
 
-- [Azure Functions Python quickstart](https://learn.microsoft.com/en-us/azure/azure-functions/create-first-function-cli-python)
-- [Azure Functions Core Tools publish reference](https://learn.microsoft.com/en-us/azure/azure-functions/functions-core-tools-reference#func-azure-functionapp-publish)
-- [Function App settings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-how-to-use-azure-function-app-settings)
+- [Azure Functions Python quickstart](https://learn.microsoft.com/azure/azure-functions/create-first-function-cli-python)
+- [Azure Functions Core Tools reference](https://learn.microsoft.com/azure/azure-functions/functions-core-tools-reference)
+- [Azure Functions hosting options](https://learn.microsoft.com/azure/azure-functions/functions-scale)
+- [Flex Consumption plan](https://learn.microsoft.com/azure/azure-functions/flex-consumption-plan)
+- [Azure Functions app settings](https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings)
 
 ## See Also
 
-- [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation)
+- [Choose an Azure Functions Hosting Plan](choose-a-plan.md) — Plan selection guide with decision tree
+- [CLI guide](./cli.md)
 - [`azure-functions-scaffold`](https://github.com/yeongseon/azure-functions-scaffold)
-- [`docs/cli.md`](./cli.md)
+- [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation)
+- [`azure-functions-doctor`](https://github.com/yeongseon/azure-functions-doctor)
+- [`azure-functions-logging`](https://github.com/yeongseon/azure-functions-logging)
+- [`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph)


### PR DESCRIPTION
## Summary

Complete rewrite of `docs/deployment.md` and addition of `docs/choose-a-plan.md` targeting Python developers with zero Azure experience.

Closes #151

## Changes

- **`docs/deployment.md`** — Full rewrite with two guided examples (todo_crud + with_validation), OpenAPI/Swagger verification steps, CLI spec generation section, troubleshooting tables, and before-opening-an-issue checklist
- **`docs/choose-a-plan.md`** (new) — Shared plan comparison guide with decision tree, cost guidance, AWS/GCP mental model mapping, and complete per-plan CLI commands

## Key design decisions

- Default plan: **Flex Consumption** (lowest cost, scale-to-zero, simplest provisioning)
- All CLI commands verified via real Azure deployment
- Two complete examples: `todo_crud` (primary) and `with_validation` (secondary)
- Storage account naming includes 3–24 character constraint warning
- SUBSCRIPTION_ID properly defined in both example sections
- Oracle-reviewed for accuracy and consistency across all 6 azure-functions-* repos