### PR TITLE
docs: remove duplicate SUBSCRIPTION_ID in deployment guide

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -108,7 +108,6 @@ Stop the local server with `Ctrl+C`.
 az login
 az account list -o table
 SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
-SUBSCRIPTION_ID="$(az account show --query id -o tsv)"
 az account set --subscription "$SUBSCRIPTION_ID"
 ```
 


### PR DESCRIPTION
## Summary
Remove duplicated `SUBSCRIPTION_ID` assignment in Example 2 (with_validation). The variable was defined twice on consecutive lines after the previous fix added it for Example 2 carry-over.

Follow-up to #151 / PR #152.