### PR TITLE
fix: resolve MkDocs strict-mode failures (#154)

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,7 +47,7 @@ In this guide, you deploy example apps that provide:
 | Azure Functions Core Tools v4 | `func --version` | [Install Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools) |
 | Python 3.10-3.13 | `python3 --version` | [python.org](https://www.python.org/downloads/) |
 | Package examples available | `ls examples` | Clone this repo again if missing |
-| Local example works | `func start` + local `curl` | See [README](../README.md) |
+| Local example works | `func start` + local `curl` | See [README](https://github.com/yeongseon/azure-functions-openapi/blob/main/README.md) |
 
 > Verify locally first. If it fails locally, deployment troubleshooting is much harder.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,9 @@ nav:
       - Usage: usage.md
       - CLI: cli.md
       - Architecture: architecture.md
+  - Deployment:
+      - Choose a Plan: choose-a-plan.md
+      - Deploy to Azure: deployment.md
   - Examples:
       - Hello OpenAPI: examples/hello.md
       - Todo API: examples/todo_crud.md


### PR DESCRIPTION
## Summary
- Add deployment.md, choose-a-plan.md to mkdocs.yml nav under Deployment section
- Replace ../README.md link with GitHub URL (outside docs/)

Verified: hatch run mkdocs build --strict passes clean.

Closes #154