### PR TITLE
chore: bump ruff from 0.15.8 to 0.15.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "ruff==0.15.9",
+    "ruff==0.15.10",
     "types-PyYAML",
     "requests",
     "types-requests",


### PR DESCRIPTION
Bump ruff from 0.15.8 to 0.15.10 for DX Toolkit cross-repo alignment.

Closes #163