### PR TITLE
refactor: remove legacy _af_validation_metadata fallback from bridge

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -202,15 +202,9 @@ def _discovered_operation(
 # importing the producing package.
 _HANDLER_METADATA_ATTR = "_azure_functions_toolkit_metadata"
 
-# Legacy attribute written by azure-functions-validation <0.7.
-_LEGACY_METADATA_ATTR = "_af_validation_metadata"
-
 
 def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
     """Read validation hints from a handler using the convention attribute.
-
-    Falls back to the legacy ``_af_validation_metadata`` attribute for
-    backward compatibility with azure-functions-validation <0.7.
 
     Returns a plain dict with keys matching ValidationHintsV1 (body, query,
     path, headers, response_model) or ``None`` if no metadata is found.
@@ -220,17 +214,6 @@ def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
         hints = toolkit_meta.get("validation")
         if isinstance(hints, dict):
             return hints
-
-    # Legacy fallback: azure-functions-validation <0.7 wrote a dataclass.
-    legacy = getattr(handler, _LEGACY_METADATA_ATTR, None)
-    if legacy is not None:
-        return {
-            "body": getattr(legacy, "body", None),
-            "query": getattr(legacy, "query", None),
-            "path": getattr(legacy, "path", None),
-            "headers": getattr(legacy, "headers", None),
-            "response_model": getattr(legacy, "response_model", None),
-        }
 
     return None
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -290,28 +290,3 @@ def test_type_to_schema_without_components() -> None:
     schema = type_to_schema(ResponseModel | None)
     assert "anyOf" in schema or "oneOf" in schema or "type" in schema
 
-
-def test_legacy_af_validation_metadata_fallback() -> None:
-    """Handlers with only the legacy _af_validation_metadata attribute are still discovered."""
-
-    @dataclass(frozen=True)
-    class LegacyMeta:
-        body: Any = None
-        query: Any = None
-        path: Any = None
-        headers: Any = None
-        response_model: Any = None
-
-    def handler(req: Any) -> Any:
-        return req
-
-    setattr(handler, "_af_validation_metadata", LegacyMeta(body=CreateBody))
-    binding = MockBinding(route="users", methods=["POST"])
-    fn = MockFunction(_name="create_user", _func=handler, _bindings=[binding])
-    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
-
-    scan_validation_metadata(app)
-
-    schema = get_openapi_registry()["post::/api/users"]["request_body"]
-    assert schema["type"] == "object"
-    assert "name" in schema["properties"]


### PR DESCRIPTION
## Summary

Remove the legacy `_af_validation_metadata` fallback path from the OpenAPI bridge. The convention-based `_azure_functions_toolkit_metadata["validation"]` is the sole integration surface.

## Changes

- **bridge.py**: Removed `_LEGACY_METADATA_ATTR` constant and legacy fallback code in `_read_validation_hints()`; updated docstrings
- **tests/test_bridge.py**: Removed `test_legacy_af_validation_metadata_fallback` test

## Companion PR

- yeongseon/azure-functions-validation#155 — removes `ValidationMetadata`, `get_validation_metadata()`, and legacy attribute setting

Closes #168