### PR TITLE
refactor: rename metadata attr to _azure_functions_metadata

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -127,11 +127,11 @@ def scan_validation_metadata(app: Any) -> None: ...
 
 **Purpose**: Scan a FunctionApp's registered HTTP functions for `@validate_http` metadata and auto-register them in the OpenAPI registry.
 
-**No extra dependencies**: `scan_validation_metadata()` reads the convention-based `_azure_functions_toolkit_metadata` attribute — no import from `azure-functions-validation` is needed.
+**No extra dependencies**: `scan_validation_metadata()` reads the convention-based `_azure_functions_metadata` attribute — no import from `azure-functions-validation` is needed.
 
 **Behavior**:
 - Iterates `app._function_builders` to find HTTP-triggered functions
-- Checks each handler for `_azure_functions_toolkit_metadata["validation"]` dict (falls back to legacy `_af_validation_metadata`)
+- Checks each handler for `_azure_functions_metadata["validation"]` dict (falls back to previous `_azure_functions_toolkit_metadata` for migration)
 - Extracts body, query, path, headers, and response_model from validation metadata
 - Registers discovered models in the OpenAPI registry via `register_openapi_metadata()`
 - Explicit `@openapi` always takes precedence over discovered metadata

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -200,17 +200,17 @@ def _discovered_operation(
 # Packages in the Azure Functions Python DX Toolkit write per-namespace
 # dicts into this attribute so consumers can discover metadata without
 # importing the producing package.
-_HANDLER_METADATA_ATTR = "_azure_functions_toolkit_metadata"
+_HANDLER_METADATA_ATTR = "_azure_functions_metadata"
 
-# Legacy attribute written by azure-functions-validation <0.7.
-_LEGACY_METADATA_ATTR = "_af_validation_metadata"
+# Previous attribute name kept for one-release migration period.
+_LEGACY_HANDLER_METADATA_ATTR = "_azure_functions_toolkit_metadata"
 
 
 def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
     """Read validation hints from a handler using the convention attribute.
 
-    Falls back to the legacy ``_af_validation_metadata`` attribute for
-    backward compatibility with azure-functions-validation <0.7.
+    Also checks the previous ``_azure_functions_toolkit_metadata`` attribute
+    for backward compatibility during the migration period.
 
     Returns a plain dict with keys matching ValidationHintsV1 (body, query,
     path, headers, response_model) or ``None`` if no metadata is found.
@@ -221,16 +221,12 @@ def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
         if isinstance(hints, dict):
             return hints
 
-    # Legacy fallback: azure-functions-validation <0.7 wrote a dataclass.
-    legacy = getattr(handler, _LEGACY_METADATA_ATTR, None)
-    if legacy is not None:
-        return {
-            "body": getattr(legacy, "body", None),
-            "query": getattr(legacy, "query", None),
-            "path": getattr(legacy, "path", None),
-            "headers": getattr(legacy, "headers", None),
-            "response_model": getattr(legacy, "response_model", None),
-        }
+    # Migration fallback: previous attribute name.
+    legacy_meta = getattr(handler, _LEGACY_HANDLER_METADATA_ATTR, None)
+    if isinstance(legacy_meta, dict):
+        hints = legacy_meta.get("validation")
+        if isinstance(hints, dict):
+            return hints
 
     return None
 
@@ -238,7 +234,7 @@ def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
 def scan_validation_metadata(app: Any) -> None:
     """Scan function builders for validation metadata and register OpenAPI operations.
 
-    This function reads the convention-based ``_azure_functions_toolkit_metadata``
+    This function reads the convention-based ``_azure_functions_metadata``
     attribute (namespace ``"validation"``) from each handler.  No import from
     ``azure-functions-validation`` is required.
     """

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -291,21 +291,20 @@ def test_type_to_schema_without_components() -> None:
     assert "anyOf" in schema or "oneOf" in schema or "type" in schema
 
 
-def test_legacy_af_validation_metadata_fallback() -> None:
-    """Handlers with only the legacy _af_validation_metadata attribute are still discovered."""
-
-    @dataclass(frozen=True)
-    class LegacyMeta:
-        body: Any = None
-        query: Any = None
-        path: Any = None
-        headers: Any = None
-        response_model: Any = None
+def test_legacy_toolkit_metadata_attr_fallback() -> None:
+    """Handlers using the previous _azure_functions_toolkit_metadata attr are still discovered."""
 
     def handler(req: Any) -> Any:
         return req
 
-    setattr(handler, "_af_validation_metadata", LegacyMeta(body=CreateBody))
+    metadata = {
+        "body": CreateBody,
+        "query": None,
+        "path": None,
+        "headers": None,
+        "response_model": None,
+    }
+    setattr(handler, "_azure_functions_toolkit_metadata", {"validation": metadata})
     binding = MockBinding(route="users", methods=["POST"])
     fn = MockFunction(_name="create_user", _func=handler, _bindings=[binding])
     app = MockApp(_function_builders=[MockBuilder(_function=fn)])


### PR DESCRIPTION
## Summary

- Rename convention attribute from `_azure_functions_toolkit_metadata` → `_azure_functions_metadata` for third-party decorator neutrality
- Add migration fallback reading the old attribute name for one release cycle
- Remove legacy `_af_validation_metadata` support entirely
- Update tests and `llms-full.txt`

Closes #170

Supersedes #169 (legacy fallback removal — now included in this broader rename)