### PR TITLE
refactor: remove legacy _azure_functions_toolkit_metadata fallback from bridge

### DIFF
--- a/llms-full.txt
+++ b/llms-full.txt
@@ -131,7 +131,7 @@ def scan_validation_metadata(app: Any) -> None: ...
 
 **Behavior**:
 - Iterates `app._function_builders` to find HTTP-triggered functions
-- Checks each handler for `_azure_functions_metadata["validation"]` dict (falls back to previous `_azure_functions_toolkit_metadata` for migration)
+- Checks each handler for `_azure_functions_metadata["validation"]` dict
 - Extracts body, query, path, headers, and response_model from validation metadata
 - Registers discovered models in the OpenAPI registry via `register_openapi_metadata()`
 - Explicit `@openapi` always takes precedence over discovered metadata

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -202,15 +202,9 @@ def _discovered_operation(
 # importing the producing package.
 _HANDLER_METADATA_ATTR = "_azure_functions_metadata"
 
-# Previous attribute name kept for one-release migration period.
-_LEGACY_HANDLER_METADATA_ATTR = "_azure_functions_toolkit_metadata"
-
 
 def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
     """Read validation hints from a handler using the convention attribute.
-
-    Also checks the previous ``_azure_functions_toolkit_metadata`` attribute
-    for backward compatibility during the migration period.
 
     Returns a plain dict with keys matching ValidationHintsV1 (body, query,
     path, headers, response_model) or ``None`` if no metadata is found.
@@ -218,13 +212,6 @@ def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
     toolkit_meta = getattr(handler, _HANDLER_METADATA_ATTR, None)
     if isinstance(toolkit_meta, dict):
         hints = toolkit_meta.get("validation")
-        if isinstance(hints, dict):
-            return hints
-
-    # Migration fallback: previous attribute name.
-    legacy_meta = getattr(handler, _LEGACY_HANDLER_METADATA_ATTR, None)
-    if isinstance(legacy_meta, dict):
-        hints = legacy_meta.get("validation")
         if isinstance(hints, dict):
             return hints
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -290,27 +290,3 @@ def test_type_to_schema_without_components() -> None:
     schema = type_to_schema(ResponseModel | None)
     assert "anyOf" in schema or "oneOf" in schema or "type" in schema
 
-
-def test_legacy_toolkit_metadata_attr_fallback() -> None:
-    """Handlers using the previous _azure_functions_toolkit_metadata attr are still discovered."""
-
-    def handler(req: Any) -> Any:
-        return req
-
-    metadata = {
-        "body": CreateBody,
-        "query": None,
-        "path": None,
-        "headers": None,
-        "response_model": None,
-    }
-    setattr(handler, "_azure_functions_toolkit_metadata", {"validation": metadata})
-    binding = MockBinding(route="users", methods=["POST"])
-    fn = MockFunction(_name="create_user", _func=handler, _bindings=[binding])
-    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
-
-    scan_validation_metadata(app)
-
-    schema = get_openapi_registry()["post::/api/users"]["request_body"]
-    assert schema["type"] == "object"
-    assert "name" in schema["properties"]


### PR DESCRIPTION
## Summary

Closes #168

Removes the one-release migration fallback that read `_azure_functions_toolkit_metadata` from handlers. The convention-based `_azure_functions_metadata` is now the sole integration surface.

## Changes

- **`src/azure_functions_openapi/bridge.py`**: Removed `_LEGACY_HANDLER_METADATA_ATTR` constant, legacy fallback block in `_read_validation_hints()`, and updated docstring
- **`tests/test_bridge.py`**: Removed `test_legacy_toolkit_metadata_attr_fallback` test

## Validation

- `make test` — 368 passed (1 legacy test removed), 93.01% coverage
- `make lint` — clean
- `make typecheck` — clean

## Note

Users running older `azure-functions-validation` versions that still write `_azure_functions_toolkit_metadata` will lose auto-discovery of validation metadata in the OpenAPI bridge. All writer packages have shipped the rename — this is cleanup after the migration period.