### PR TITLE
fix: resolve `openapi` package attribute to the decorator (#187)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,9 @@ known-first-party = ["azure_functions_openapi"]
 force-sort-within-sections = true
 section-order = ["future", "standard-library", "third-party", "first-party", "local-folder"]
 
+[tool.ruff.lint.per-file-ignores]
+"src/azure_functions_openapi/__init__.py" = ["I001"]
+
 [tool.mypy]
 python_version = "3.10"
 strict = true

--- a/src/azure_functions_openapi/__init__.py
+++ b/src/azure_functions_openapi/__init__.py
@@ -1,11 +1,5 @@
 # src/azure_functions_openapi/__init__.py
-
 import azure_functions_openapi.bridge as _bridge
-from azure_functions_openapi.decorator import (
-    clear_openapi_registry,
-    openapi,
-    register_openapi_metadata,
-)
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
 from azure_functions_openapi.openapi import (
     OPENAPI_VERSION_3_0,
@@ -16,6 +10,17 @@ from azure_functions_openapi.openapi import (
 )
 from azure_functions_openapi.swagger_ui import render_swagger_ui
 from azure_functions_openapi.types import OpenAPIOperationMetadata
+
+# The `.decorator` import MUST stay last. Importing the `.openapi` submodule
+# above sets it as the `openapi` attribute on this package; importing the
+# decorator named `openapi` last rebinds that attribute to the callable so
+# `from azure_functions_openapi import openapi` resolves to the decorator,
+# matching `__all__` and `docs/api.md`.
+from azure_functions_openapi.decorator import (
+    clear_openapi_registry,
+    openapi,
+    register_openapi_metadata,
+)
 
 __version__ = "0.17.1"
 scan_validation_metadata = _bridge.scan_validation_metadata

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,4 +1,5 @@
 # tests/test_openapi.py
+import importlib
 import json
 from typing import Any
 from unittest.mock import patch
@@ -14,6 +15,8 @@ from azure_functions_openapi.openapi import (
     get_openapi_json,
     get_openapi_yaml,
 )
+
+OPENAPI_MODULE = importlib.import_module("azure_functions_openapi.openapi")
 
 
 def _register_http_trigger() -> None:
@@ -425,6 +428,7 @@ def test_generate_openapi_spec_keeps_explicit_non_200_responses_without_adding_2
 
 def test_generate_openapi_spec_with_security_schemes_param() -> None:
     """Test that security_schemes param adds components.securitySchemes."""
+
     @openapi(
         route="/secure-param",
         summary="Secured with param",
@@ -449,6 +453,7 @@ def test_generate_openapi_spec_with_security_schemes_param() -> None:
 
 def test_generate_openapi_spec_with_decorator_security_scheme() -> None:
     """Test that security_scheme in @openapi decorator adds components.securitySchemes."""
+
     @openapi(
         route="/secure-decorator",
         summary="Secured with decorator scheme",
@@ -471,19 +476,22 @@ def test_generate_openapi_spec_with_decorator_security_scheme() -> None:
 
 def test_generate_openapi_spec_merges_security_schemes() -> None:
     """Test that security schemes from both param and decorators are merged."""
+
     @openapi(
         route="/secure-merged",
         summary="Merged schemes",
         security=[{"OAuth2": ["read"]}],
-        security_scheme={"OAuth2": {
-            "type": "oauth2",
-            "flows": {
-                "implicit": {
-                    "authorizationUrl": "https://example.com/auth",
-                    "scopes": {"read": "Read"},
+        security_scheme={
+            "OAuth2": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://example.com/auth",
+                        "scopes": {"read": "Read"},
+                    },
                 },
-            },
-        }},
+            }
+        },
         response={200: {"description": "OK"}},
     )
     def secure_merged_endpoint() -> None:
@@ -499,6 +507,7 @@ def test_generate_openapi_spec_merges_security_schemes() -> None:
 
 def test_security_schemes_in_json_output() -> None:
     """Test that security schemes appear in JSON output."""
+
     @openapi(
         route="/secure-json",
         summary="Secured JSON",
@@ -514,6 +523,8 @@ def test_security_schemes_in_json_output() -> None:
     )
     spec = json.loads(json_str)
     assert "securitySchemes" in spec.get("components", {})
+
+
 def test_response_model_with_content_not_dict() -> None:
     """When existing 200 response has content that is not a dict, it gets replaced."""
 
@@ -586,8 +597,9 @@ def test_response_model_schema_generation_failure_no_200() -> None:
     def schema_fail_no_200_func() -> None:
         pass
 
-    with patch(
-        "azure_functions_openapi.openapi.model_to_schema",
+    with patch.object(
+        OPENAPI_MODULE,
+        "model_to_schema",
         side_effect=Exception("schema generation failed"),
     ):
         spec = generate_openapi_spec()
@@ -612,8 +624,9 @@ def test_response_model_schema_generation_failure_with_200() -> None:
     def schema_fail_with_200_func() -> None:
         pass
 
-    with patch(
-        "azure_functions_openapi.openapi.model_to_schema",
+    with patch.object(
+        OPENAPI_MODULE,
+        "model_to_schema",
         side_effect=Exception("schema generation failed"),
     ):
         spec = generate_openapi_spec()
@@ -649,8 +662,9 @@ def test_malformed_registry_entry_skipped() -> None:
         "response": {200: 42},  # detail=42 → dict(42) raises TypeError
     }
 
-    with patch(
-        "azure_functions_openapi.openapi.get_openapi_registry",
+    with patch.object(
+        OPENAPI_MODULE,
+        "get_openapi_registry",
         return_value=malformed_registry,
     ):
         spec = generate_openapi_spec()
@@ -675,6 +689,7 @@ def test_security_scheme_collision_raises_value_error() -> None:
         pass
 
     from azure_functions_openapi.decorator import get_openapi_registry
+
     real_registry = get_openapi_registry()
     conflicting = dict(real_registry)
     # Inject a second entry that redefines SharedAuth with a *different* definition
@@ -696,8 +711,9 @@ def test_security_scheme_collision_raises_value_error() -> None:
         "_function_id": "tests.test_openapi.collision_func_b",
     }
 
-    with patch(
-        "azure_functions_openapi.openapi.get_openapi_registry",
+    with patch.object(
+        OPENAPI_MODULE,
+        "get_openapi_registry",
         return_value=conflicting,
     ):
         with pytest.raises(ValueError, match="Conflicting security scheme definition"):
@@ -706,6 +722,7 @@ def test_security_scheme_collision_raises_value_error() -> None:
 
 def test_generate_openapi_spec_with_delete_request_body() -> None:
     """DELETE endpoints can have a requestBody when one is specified."""
+
     @openapi(
         route="/items/{id}",
         method="delete",
@@ -726,6 +743,7 @@ def test_generate_openapi_spec_with_delete_request_body() -> None:
 
 def test_generate_openapi_spec_request_body_required_false() -> None:
     """request_body_required=False is reflected in the generated spec."""
+
     @openapi(
         route="/optional-body-spec",
         method="post",
@@ -746,35 +764,59 @@ def _make_conflicting_registry() -> dict[str, Any]:
     """Return a registry with two entries that define the same security scheme differently."""
     empty_scopes: list[str] = []
     return {
-        "fn_a": {"route": "/a", "method": "get", "summary": "", "description": "",
-                 "tags": ["default"], "operation_id": None, "parameters": [],
-                 "security": [{"Auth": empty_scopes}],
-                 "security_scheme": {"Auth": {"type": "http", "scheme": "bearer"}},
-                 "request_model": None, "request_body": None, "request_body_required": True,
-                 "response_model": None, "response": {200: {"description": "OK"}},
-                 "function_name": "fn_a", "_function_id": "fn_a"},
-        "fn_b": {"route": "/b", "method": "get", "summary": "", "description": "",
-                 "tags": ["default"], "operation_id": None, "parameters": [],
-                 "security": [{"Auth": empty_scopes}],
-                 "security_scheme": {"Auth": {"type": "apiKey", "in": "header", "name": "X-Key"}},
-                 "request_model": None, "request_body": None, "request_body_required": True,
-                 "response_model": None, "response": {200: {"description": "OK"}},
-                 "function_name": "fn_b", "_function_id": "fn_b"},
+        "fn_a": {
+            "route": "/a",
+            "method": "get",
+            "summary": "",
+            "description": "",
+            "tags": ["default"],
+            "operation_id": None,
+            "parameters": [],
+            "security": [{"Auth": empty_scopes}],
+            "security_scheme": {"Auth": {"type": "http", "scheme": "bearer"}},
+            "request_model": None,
+            "request_body": None,
+            "request_body_required": True,
+            "response_model": None,
+            "response": {200: {"description": "OK"}},
+            "function_name": "fn_a",
+            "_function_id": "fn_a",
+        },
+        "fn_b": {
+            "route": "/b",
+            "method": "get",
+            "summary": "",
+            "description": "",
+            "tags": ["default"],
+            "operation_id": None,
+            "parameters": [],
+            "security": [{"Auth": empty_scopes}],
+            "security_scheme": {"Auth": {"type": "apiKey", "in": "header", "name": "X-Key"}},
+            "request_model": None,
+            "request_body": None,
+            "request_body_required": True,
+            "response_model": None,
+            "response": {200: {"description": "OK"}},
+            "function_name": "fn_b",
+            "_function_id": "fn_b",
+        },
     }
 
 
 def test_get_openapi_json_propagates_value_error() -> None:
     """get_openapi_json must not swallow ValueError from collision detection."""
-    with patch("azure_functions_openapi.openapi.get_openapi_registry",
-               return_value=_make_conflicting_registry()):
+    with patch.object(
+        OPENAPI_MODULE, "get_openapi_registry", return_value=_make_conflicting_registry()
+    ):
         with pytest.raises(ValueError, match="Conflicting security scheme definition"):
             get_openapi_json()
 
 
 def test_get_openapi_yaml_propagates_value_error() -> None:
     """get_openapi_yaml must not swallow ValueError from collision detection."""
-    with patch("azure_functions_openapi.openapi.get_openapi_registry",
-               return_value=_make_conflicting_registry()):
+    with patch.object(
+        OPENAPI_MODULE, "get_openapi_registry", return_value=_make_conflicting_registry()
+    ):
         with pytest.raises(ValueError, match="Conflicting security scheme definition"):
             get_openapi_yaml()
 

--- a/tests/test_openapi_enhanced.py
+++ b/tests/test_openapi_enhanced.py
@@ -1,5 +1,6 @@
 # tests/test_openapi_enhanced.py
 
+import importlib
 from typing import Any, Dict
 from unittest.mock import patch
 
@@ -11,6 +12,8 @@ from azure_functions_openapi.openapi import (
     get_openapi_json,
     get_openapi_yaml,
 )
+
+OPENAPI_MODULE = importlib.import_module("azure_functions_openapi.openapi")
 
 
 class SampleRequestModel(BaseModel):
@@ -50,9 +53,7 @@ class TestGenerateOpenAPISpecEnhanced:
             }
         }
 
-        with patch(
-            "azure_functions_openapi.openapi.get_openapi_registry", return_value=mock_registry
-        ):
+        with patch.object(OPENAPI_MODULE, "get_openapi_registry", return_value=mock_registry):
             spec = generate_openapi_spec("Test API", "1.0.0")
 
             assert spec["openapi"] == "3.0.0"
@@ -79,10 +80,8 @@ class TestGenerateOpenAPISpecEnhanced:
             }
         }
 
-        with patch(
-            "azure_functions_openapi.openapi.get_openapi_registry", return_value=mock_registry
-        ):
-            with patch("azure_functions_openapi.openapi.model_to_schema") as mock_model_to_schema:
+        with patch.object(OPENAPI_MODULE, "get_openapi_registry", return_value=mock_registry):
+            with patch.object(OPENAPI_MODULE, "model_to_schema") as mock_model_to_schema:
                 # First call succeeds, second call fails
                 mock_model_to_schema.side_effect = [{"type": "object"}, Exception("Schema error")]
 
@@ -129,10 +128,8 @@ class TestGenerateOpenAPISpecEnhanced:
             },
         }
 
-        with patch(
-            "azure_functions_openapi.openapi.get_openapi_registry", return_value=mock_registry
-        ):
-            with patch("azure_functions_openapi.openapi.logger"):
+        with patch.object(OPENAPI_MODULE, "get_openapi_registry", return_value=mock_registry):
+            with patch.object(OPENAPI_MODULE, "logger"):
                 # Mock the processing to fail for bad_func
                 original_spec = generate_openapi_spec("Test API", "1.0.0")
 
@@ -143,7 +140,7 @@ class TestGenerateOpenAPISpecEnhanced:
 
     def test_generate_openapi_spec_general_error(self) -> None:
         """Test OpenAPI spec generation with general error."""
-        with patch("azure_functions_openapi.openapi.get_openapi_registry") as mock_registry:
+        with patch.object(OPENAPI_MODULE, "get_openapi_registry") as mock_registry:
             mock_registry.side_effect = Exception("Registry error")
 
             with pytest.raises(RuntimeError) as exc_info:
@@ -159,10 +156,8 @@ class TestGenerateOpenAPISpecEnhanced:
             "func2": {"summary": "Function 2", "route": "/func2", "method": "post"},
         }
 
-        with patch(
-            "azure_functions_openapi.openapi.get_openapi_registry", return_value=mock_registry
-        ):
-            with patch("azure_functions_openapi.openapi.logger") as mock_logger:
+        with patch.object(OPENAPI_MODULE, "get_openapi_registry", return_value=mock_registry):
+            with patch.object(OPENAPI_MODULE, "logger") as mock_logger:
                 generate_openapi_spec("Test API", "1.0.0")
 
                 # Should log successful generation
@@ -178,7 +173,7 @@ class TestGetOpenAPIJSONEnhanced:
 
     def test_get_openapi_json_success(self) -> None:
         """Test successful JSON generation."""
-        with patch("azure_functions_openapi.openapi.generate_openapi_spec") as mock_generate:
+        with patch.object(OPENAPI_MODULE, "generate_openapi_spec") as mock_generate:
             mock_generate.return_value = {"openapi": "3.0.0", "info": {"title": "Test API"}}
 
             result = get_openapi_json("Test API", "1.0.0")
@@ -197,7 +192,7 @@ class TestGetOpenAPIJSONEnhanced:
 
     def test_get_openapi_json_error(self) -> None:
         """Test JSON generation with error."""
-        with patch("azure_functions_openapi.openapi.generate_openapi_spec") as mock_generate:
+        with patch.object(OPENAPI_MODULE, "generate_openapi_spec") as mock_generate:
             mock_generate.side_effect = Exception("Spec error")
 
             with pytest.raises(RuntimeError) as exc_info:
@@ -208,7 +203,7 @@ class TestGetOpenAPIJSONEnhanced:
 
     def test_get_openapi_json_passes_custom_description(self) -> None:
         """Test custom description forwarding for JSON generation."""
-        with patch("azure_functions_openapi.openapi.generate_openapi_spec") as mock_generate:
+        with patch.object(OPENAPI_MODULE, "generate_openapi_spec") as mock_generate:
             mock_generate.return_value = {"openapi": "3.0.0", "info": {"title": "Test API"}}
 
             get_openapi_json("Test API", "1.0.0", description="Custom description")
@@ -223,10 +218,10 @@ class TestGetOpenAPIJSONEnhanced:
 
     def test_get_openapi_json_logging(self) -> None:
         """Test that JSON generation logs errors."""
-        with patch("azure_functions_openapi.openapi.generate_openapi_spec") as mock_generate:
+        with patch.object(OPENAPI_MODULE, "generate_openapi_spec") as mock_generate:
             mock_generate.side_effect = Exception("Spec error")
 
-            with patch("azure_functions_openapi.openapi.logger") as mock_logger:
+            with patch.object(OPENAPI_MODULE, "logger") as mock_logger:
                 with pytest.raises(RuntimeError):
                     get_openapi_json("Test API", "1.0.0")
 
@@ -240,7 +235,7 @@ class TestGetOpenAPIYAMLEnhanced:
 
     def test_get_openapi_yaml_success(self) -> None:
         """Test successful YAML generation."""
-        with patch("azure_functions_openapi.openapi.generate_openapi_spec") as mock_generate:
+        with patch.object(OPENAPI_MODULE, "generate_openapi_spec") as mock_generate:
             mock_generate.return_value = {"openapi": "3.0.0", "info": {"title": "Test API"}}
 
             result = get_openapi_yaml("Test API", "1.0.0")
@@ -258,7 +253,7 @@ class TestGetOpenAPIYAMLEnhanced:
 
     def test_get_openapi_yaml_error(self) -> None:
         """Test YAML generation with error."""
-        with patch("azure_functions_openapi.openapi.generate_openapi_spec") as mock_generate:
+        with patch.object(OPENAPI_MODULE, "generate_openapi_spec") as mock_generate:
             mock_generate.side_effect = Exception("Spec error")
 
             with pytest.raises(RuntimeError) as exc_info:
@@ -269,7 +264,7 @@ class TestGetOpenAPIYAMLEnhanced:
 
     def test_get_openapi_yaml_passes_custom_description(self) -> None:
         """Test custom description forwarding for YAML generation."""
-        with patch("azure_functions_openapi.openapi.generate_openapi_spec") as mock_generate:
+        with patch.object(OPENAPI_MODULE, "generate_openapi_spec") as mock_generate:
             mock_generate.return_value = {"openapi": "3.0.0", "info": {"title": "Test API"}}
 
             get_openapi_yaml("Test API", "1.0.0", description="Custom description")
@@ -284,10 +279,10 @@ class TestGetOpenAPIYAMLEnhanced:
 
     def test_get_openapi_yaml_logging(self) -> None:
         """Test that YAML generation logs errors."""
-        with patch("azure_functions_openapi.openapi.generate_openapi_spec") as mock_generate:
+        with patch.object(OPENAPI_MODULE, "generate_openapi_spec") as mock_generate:
             mock_generate.side_effect = Exception("Spec error")
 
-            with patch("azure_functions_openapi.openapi.logger") as mock_logger:
+            with patch.object(OPENAPI_MODULE, "logger") as mock_logger:
                 with pytest.raises(RuntimeError):
                     get_openapi_yaml("Test API", "1.0.0")
 
@@ -329,10 +324,8 @@ class TestOpenAPISpecComplexScenarios:
             }
         }
 
-        with patch(
-            "azure_functions_openapi.openapi.get_openapi_registry", return_value=mock_registry
-        ):
-            with patch("azure_functions_openapi.openapi.model_to_schema") as mock_model_to_schema:
+        with patch.object(OPENAPI_MODULE, "get_openapi_registry", return_value=mock_registry):
+            with patch.object(OPENAPI_MODULE, "model_to_schema") as mock_model_to_schema:
                 mock_model_to_schema.return_value = {
                     "type": "object",
                     "properties": {"name": {"type": "string"}},
@@ -400,9 +393,7 @@ class TestOpenAPISpecComplexScenarios:
             },
         }
 
-        with patch(
-            "azure_functions_openapi.openapi.get_openapi_registry", return_value=mock_registry
-        ):
+        with patch.object(OPENAPI_MODULE, "get_openapi_registry", return_value=mock_registry):
             spec = generate_openapi_spec("User API", "1.0.0")
 
             # Check that all methods are on the same path
@@ -429,8 +420,9 @@ class TestDeterministicOrdering:
             "func_a": {"route": "/a", "method": "get", "response": {}, "tags": ["t"]},
             "func_m": {"route": "/m", "method": "get", "response": {}, "tags": ["t"]},
         }
-        with patch(
-            "azure_functions_openapi.openapi.get_openapi_registry",
+        with patch.object(
+            OPENAPI_MODULE,
+            "get_openapi_registry",
             return_value=mock_registry,
         ):
             spec = generate_openapi_spec("Test", "1.0.0")
@@ -463,8 +455,9 @@ class TestDeterministicOrdering:
                 "tags": ["t"],
             },
         }
-        with patch(
-            "azure_functions_openapi.openapi.get_openapi_registry",
+        with patch.object(
+            OPENAPI_MODULE,
+            "get_openapi_registry",
             return_value=mock_registry,
         ):
             spec = generate_openapi_spec("Test", "1.0.0")
@@ -474,8 +467,9 @@ class TestDeterministicOrdering:
 
     def test_empty_registry_produces_sorted_empty_paths(self) -> None:
         """Empty registry produces an empty (but sorted) paths dict."""
-        with patch(
-            "azure_functions_openapi.openapi.get_openapi_registry",
+        with patch.object(
+            OPENAPI_MODULE,
+            "get_openapi_registry",
             return_value={},
         ):
             spec = generate_openapi_spec("Test", "1.0.0")

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -50,6 +50,15 @@ class TestAPISurface:
 
         assert azure_functions_openapi.openapi is decorator_openapi
 
+    def test_openapi_submodule_is_importable_via_importlib(self) -> None:
+        import importlib
+        import types
+
+        openapi_module = importlib.import_module("azure_functions_openapi.openapi")
+
+        assert isinstance(openapi_module, types.ModuleType)
+        assert openapi_module.generate_openapi_spec is azure_functions_openapi.generate_openapi_spec
+
     def test_generate_openapi_spec_is_callable(self) -> None:
         assert callable(azure_functions_openapi.generate_openapi_spec)
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -45,9 +45,10 @@ class TestAPISurface:
             scan_validation_metadata,
         )
 
-    def test_openapi_is_importable_module(self) -> None:
-        import types
-        assert isinstance(azure_functions_openapi.openapi, types.ModuleType)
+    def test_openapi_root_export_is_decorator(self) -> None:
+        from azure_functions_openapi.decorator import openapi as decorator_openapi
+
+        assert azure_functions_openapi.openapi is decorator_openapi
 
     def test_generate_openapi_spec_is_callable(self) -> None:
         assert callable(azure_functions_openapi.generate_openapi_spec)


### PR DESCRIPTION
## Summary

Fixes #187. `from azure_functions_openapi import openapi` returned the `openapi.py` submodule instead of the `@openapi` decorator, raising `TypeError: 'module' object is not callable` for the import path documented in `docs/api.md`, `docs/getting-started.md`, `docs/index.md`, and `docs/usage.md`.

## Root cause

`src/azure_functions_openapi/__init__.py` imported the decorator name `openapi` from `.decorator`, then imported symbols from the `.openapi` submodule. The submodule import binds itself as the `openapi` attribute on the package, silently overwriting the decorator binding from the previous line.

`tests/test_public_api.py::test_openapi_is_importable_module` then asserted the buggy behavior (`isinstance(openapi, types.ModuleType)`) as if intended, freezing the bug in CI.

## Changes

1. **`src/azure_functions_openapi/__init__.py`** — reordered imports so `.decorator` is imported **last**, with an inline comment documenting the import-order invariant.
2. **`pyproject.toml`** — added `[tool.ruff.lint.per-file-ignores]` entry for `__init__.py` to suppress `I001`. `# noqa: I001` did not silence Ruff's whole-block isort check; per-file ignore is the supported way and prevents an autoformatter from silently re-breaking the order.
3. **`tests/test_public_api.py`** — replaced `test_openapi_is_importable_module` with `test_openapi_root_export_is_decorator`, asserting `azure_functions_openapi.openapi is azure_functions_openapi.decorator.openapi`. Added `test_openapi_submodule_is_importable_via_importlib` to make the two-part import contract explicit (root attribute = decorator, importlib lookup = submodule) and guard future refactors.
4. **`tests/test_openapi_enhanced.py`** (24 sites) and **`tests/test_openapi.py`** (6 sites) — migrated `mock.patch("azure_functions_openapi.openapi.<symbol>")` to `patch.object(OPENAPI_MODULE, "<symbol>")`, where `OPENAPI_MODULE = importlib.import_module("azure_functions_openapi.openapi")`. `mock.patch`'s string form walks attributes from the top-level package via `getattr`; once the package attribute `openapi` resolves to the decorator function, dotted-string patching of submodule names raises `AttributeError`. `patch.object` against the explicit submodule object is robust and survives this and any future shadowing.

## Verification

- `make lint` — clean
- `make typecheck` — clean (30 source files)
- `make test` — 361 passed, 28 skipped (baseline 360 + 1 new contract test; skips are `azure-functions-validation` optional dep)
- `make build` — sdist + wheel produced
- Manual: `python -c "from azure_functions_openapi import openapi; print(callable(openapi))"` → `True`

## Risk

`from azure_functions_openapi import openapi` now correctly returns the decorator.

However, code that treats `azure_functions_openapi.openapi` as a *package attribute* for the internal submodule will break. In particular, the following forms now resolve to the decorator function rather than the submodule:

```python
import azure_functions_openapi.openapi as openapi_module   # binds the decorator
import azure_functions_openapi.openapi                     # azure_functions_openapi.openapi → decorator
mock.patch("azure_functions_openapi.openapi.<symbol>")     # AttributeError on getattr walk
```

Use one of the following safe forms instead:

```python
from azure_functions_openapi.openapi import generate_openapi_spec
```

or:

```python
import importlib
openapi_module = importlib.import_module("azure_functions_openapi.openapi")
```

For mocking, prefer `mock.patch.object(submodule, "<symbol>")` over the dotted-string form.

The `from`-import and `importlib.import_module` forms are unaffected because both bypass `getattr` and resolve the submodule directly via `sys.modules`. The repo's own `README.md`, `examples/*/function_app.py`, and internal modules already use the safe `from`-import form.

## Out of scope

Renaming the `openapi.py` submodule (e.g. to `spec.py`) would eliminate the shadowing risk class entirely but is breaking for any caller importing internal symbols via `azure_functions_openapi.openapi.<symbol>`. Track separately if pursued.