### PR TITLE
chore: fix project metadata URLs to match the actual repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://yeongseon.github.io/azure-functions-openapi/
+    url: https://yeongseon.github.io/azure-functions-openapi-python/
     about: Check our documentation for usage guides and examples
   - name: Security Advisories
     url: /security/advisories/new

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   stale-issues:
     runs-on: ubuntu-latest
-    if: github.repository == 'yeongseon/azure-functions-openapi'
+    if: github.repository == 'yeongseon/azure-functions-openapi-python'
 
     steps:
       - name: "Stale issues and PRs"
@@ -32,7 +32,7 @@ jobs:
 
   stale-branches:
     runs-on: ubuntu-latest
-    if: github.repository == 'yeongseon/azure-functions-openapi'
+    if: github.repository == 'yeongseon/azure-functions-openapi-python'
 
     steps:
       - name: "Checkout code"

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
 [![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml)
+[![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
@@ -155,7 +155,7 @@ func start
 
 ## Documentation
 
-- 全ドキュメント: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi-python/)
+- 全ドキュメント: [yeongseon.github.io/azure-functions-openapi-python](https://yeongseon.github.io/azure-functions-openapi-python/)
 - スモークテスト済みサンプル: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,12 +2,12 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
-[![CI](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/release.yml)
-[![Security Scans](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi)
+[![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
+[![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml)
+[![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
@@ -155,7 +155,7 @@ func start
 
 ## Documentation
 
-- 全ドキュメント: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi/)
+- 全ドキュメント: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi-python/)
 - スモークテスト済みサンプル: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -2,12 +2,12 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
-[![CI](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/release.yml)
-[![Security Scans](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi)
+[![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
+[![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml)
+[![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -155,7 +155,7 @@ func start
 
 ## Documentation
 
-- 전체 문서: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi/)
+- 전체 문서: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi-python/)
 - 스모크 테스트된 예제: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
 [![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml)
+[![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
@@ -155,7 +155,7 @@ func start
 
 ## Documentation
 
-- 전체 문서: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi-python/)
+- 전체 문서: [yeongseon.github.io/azure-functions-openapi-python](https://yeongseon.github.io/azure-functions-openapi-python/)
 - 스모크 테스트된 예제: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ The web preview below is generated from the same representative example and capt
 
 ## Documentation
 
-- Full docs: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi-python/)
+- Full docs: [yeongseon.github.io/azure-functions-openapi-python](https://yeongseon.github.io/azure-functions-openapi-python/)
 - Smoke-tested examples: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
-[![CI](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/publish-pypi.yml)
-[![Security Scans](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi)
+[![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
+[![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml)
+[![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -301,7 +301,7 @@ The web preview below is generated from the same representative example and capt
 
 ## Documentation
 
-- Full docs: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi/)
+- Full docs: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi-python/)
 - Smoke-tested examples: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -3,7 +3,7 @@
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
 [![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml)
+[![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
@@ -155,7 +155,7 @@ func start
 
 ## Documentation
 
-- 完整文档: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi-python/)
+- 完整文档: [yeongseon.github.io/azure-functions-openapi-python](https://yeongseon.github.io/azure-functions-openapi-python/)
 - 经过 smoke test 的示例: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,12 +2,12 @@
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
-[![CI](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/ci-test.yml)
-[![Release](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/release.yml)
-[![Security Scans](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi)
+[![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
+[![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/release.yml)
+[![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi/)
+[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
@@ -155,7 +155,7 @@ func start
 
 ## Documentation
 
-- 完整文档: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi/)
+- 完整文档: [yeongseon.github.io/azure-functions-openapi](https://yeongseon.github.io/azure-functions-openapi-python/)
 - 经过 smoke test 的示例: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,7 +7,7 @@ responsibly and avoid public disclosure until a fix is available.
 
 ### Preferred: GitHub Security Advisory
 
-1. Go to the [Security Advisories page](https://github.com/yeongseon/azure-functions-openapi/security/advisories/new)
+1. Go to the [Security Advisories page](https://github.com/yeongseon/azure-functions-openapi-python/security/advisories/new)
 2. Click "Report a vulnerability"
 3. Submit the details in the private advisory
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -193,4 +193,4 @@ Open an issue on GitHub with:
 
 ## Code of Conduct
 
-Be respectful and inclusive. See the [Code of Conduct](https://github.com/yeongseon/azure-functions-openapi/blob/main/CODE_OF_CONDUCT.md) for details.
+Be respectful and inclusive. See the [Code of Conduct](https://github.com/yeongseon/azure-functions-openapi-python/blob/main/CODE_OF_CONDUCT.md) for details.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,7 +47,7 @@ In this guide, you deploy example apps that provide:
 | Azure Functions Core Tools v4 | `func --version` | [Install Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools) |
 | Python 3.10-3.13 | `python3 --version` | [python.org](https://www.python.org/downloads/) |
 | Package examples available | `ls examples` | Clone this repo again if missing |
-| Local example works | `func start` + local `curl` | See [README](https://github.com/yeongseon/azure-functions-openapi/blob/main/README.md) |
+| Local example works | `func start` + local `curl` | See [README](https://github.com/yeongseon/azure-functions-openapi-python/blob/main/README.md) |
 
 > Verify locally first. If it fails locally, deployment troubleshooting is much harder.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,7 +51,7 @@ azure-functions-openapi/
 
 1. **Clone the repository**:
     ```bash
-    git clone https://github.com/yeongseon/azure-functions-openapi.git
+    git clone https://github.com/yeongseon/azure-functions-openapi-python.git
     cd azure-functions-openapi
     ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -67,7 +67,7 @@ pydantic>=2.0
 Clone the repository and create a virtual environment:
 
 ```bash
-git clone https://github.com/yeongseon/azure-functions-openapi.git
+git clone https://github.com/yeongseon/azure-functions-openapi-python.git
 cd azure-functions-openapi
 python -m venv .venv
 source .venv/bin/activate   # Windows: .venv\Scripts\activate

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -115,7 +115,7 @@ pip install --index-url https://test.pypi.org/simple/ azure-functions-openapi
 
 ## Related
 
-- [CHANGELOG.md](https://github.com/yeongseon/azure-functions-openapi/blob/main/CHANGELOG.md)
+- [CHANGELOG.md](https://github.com/yeongseon/azure-functions-openapi-python/blob/main/CHANGELOG.md)
 - [Development Guide](development.md)
 - [Contributing](contributing.md)
 - [PyPI Publishing with Hatch](https://hatch.pypa.io/latest/publishing/)

--- a/docs/security.md
+++ b/docs/security.md
@@ -2,7 +2,7 @@
 
 # Security Guide
 
-The canonical security policy is maintained in the root [SECURITY.md](https://github.com/yeongseon/azure-functions-openapi/blob/main/SECURITY.md).
+The canonical security policy is maintained in the root [SECURITY.md](https://github.com/yeongseon/azure-functions-openapi-python/blob/main/SECURITY.md).
 
 #### Operation ID Sanitization
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -9,7 +9,7 @@
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.github.io/azure-functions-openapi-python/
-- Repository: https://github.com/yeongseon/azure-functions-openapi
+- Repository: https://github.com/yeongseon/azure-functions-openapi-python
 - Azure Functions programming model: v2
 
 ## Installation

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 - Version: 0.16.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-openapi/
+- Docs: https://yeongseon.github.io/azure-functions-openapi-python/
 - Repository: https://github.com/yeongseon/azure-functions-openapi
 - Azure Functions programming model: v2
 

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@
 - Python: >=3.10, <3.15
 - License: MIT
 - Docs: https://yeongseon.github.io/azure-functions-openapi-python/
-- Repository: https://github.com/yeongseon/azure-functions-openapi
+- Repository: https://github.com/yeongseon/azure-functions-openapi-python
 
 ## What It Does
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 - Version: 0.16.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-openapi/
+- Docs: https://yeongseon.github.io/azure-functions-openapi-python/
 - Repository: https://github.com/yeongseon/azure-functions-openapi
 
 ## What It Does
@@ -62,10 +62,10 @@ def openapi_spec(req: func.HttpRequest) -> func.HttpResponse:
 
 ## Documentation
 
-- [Installation](https://yeongseon.github.io/azure-functions-openapi/installation/)
-- [Usage Guide](https://yeongseon.github.io/azure-functions-openapi/usage/)
-- [API Reference](https://yeongseon.github.io/azure-functions-openapi/api/)
-- [CLI Guide](https://yeongseon.github.io/azure-functions-openapi/cli/)
+- [Installation](https://yeongseon.github.io/azure-functions-openapi-python/installation/)
+- [Usage Guide](https://yeongseon.github.io/azure-functions-openapi-python/usage/)
+- [API Reference](https://yeongseon.github.io/azure-functions-openapi-python/api/)
+- [CLI Guide](https://yeongseon.github.io/azure-functions-openapi-python/cli/)
 
 ## Ecosystem
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Azure Functions OpenAPI
 site_description: OpenAPI (Swagger) integration for Python-based Azure Functions
 site_author: Yeongseon Choe
-site_url: https://yeongseon.github.io/azure-functions-openapi/
+site_url: https://yeongseon.github.io/azure-functions-openapi-python/
 repo_url: https://github.com/yeongseon/azure-functions-openapi
 edit_uri: edit/main/docs/
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Azure Functions OpenAPI
 site_description: OpenAPI (Swagger) integration for Python-based Azure Functions
 site_author: Yeongseon Choe
 site_url: https://yeongseon.github.io/azure-functions-openapi-python/
-repo_url: https://github.com/yeongseon/azure-functions-openapi
+repo_url: https://github.com/yeongseon/azure-functions-openapi-python
 edit_uri: edit/main/docs/
 
 theme:
@@ -77,7 +77,7 @@ plugins:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/yeongseon/azure-functions-openapi
+      link: https://github.com/yeongseon/azure-functions-openapi-python
   copyright: |
     © 2026 Yeongseon Choe – MIT Licensed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,10 @@ dependencies = [
 ]
 
     [project.urls]
-    Homepage = "https://yeongseon.github.io/azure-functions-openapi/"
-    Documentation = "https://yeongseon.github.io/azure-functions-openapi/"
-    Repository = "https://github.com/yeongseon/azure-functions-openapi"
-Issues = "https://github.com/yeongseon/azure-functions-openapi/issues"
+    Homepage = "https://yeongseon.github.io/azure-functions-openapi-python/"
+    Documentation = "https://yeongseon.github.io/azure-functions-openapi-python/"
+    Repository = "https://github.com/yeongseon/azure-functions-openapi-python"
+Issues = "https://github.com/yeongseon/azure-functions-openapi-python/issues"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary

Closes #189. Fixes project metadata URLs and README/docs references that pointed to `yeongseon/azure-functions-openapi` (the legacy slug) instead of the actual repository `yeongseon/azure-functions-openapi-python`.

## Why

User-visible breakage:

- **PyPI**: clicking *Repository* or *Issues* on the project page lands on the wrong repo / 404.
- **README badges**: CI / Release / Security / codecov / Docs badges all reference the wrong slug — broken images, broken click-throughs.
- The repo's GitHub *About* homepage URL had the same drift and was already corrected in the repo settings; the in-tree files still carried the old URLs.

## Changes

Mechanical URL replacement in 16 files (no logic changes):

| File | What |
|------|------|
| `pyproject.toml` | `[project.urls]` Homepage / Documentation / Repository / Issues |
| `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md` | All 5 broken badges + docs link |
| `mkdocs.yml` | `site_url` |
| `llms.txt`, `llms-full.txt` | docs base URL + 4 deep links |
| `SECURITY.md` | Security advisory link |
| `.github/ISSUE_TEMPLATE/config.yml` | docs contact link |
| `docs/{contributing,deployment,development,installation,release_process,security}.md` | inline references |

The PyPI distribution name (`name = "azure-functions-openapi"` in `pyproject.toml`) is intentionally distinct from the GitHub repo slug and is **not** changed.

## Verification

- `make lint` — clean
- `make typecheck` — clean (30 source files)
- `make test` — 361 passed, 28 skipped (skips are `azure-functions-validation` optional dep)
- `make build` — sdist + wheel produced
- Built wheel `METADATA` confirms corrected Project-URL entries:
  ```
  Project-URL: Homepage, https://yeongseon.github.io/azure-functions-openapi-python/
  Project-URL: Documentation, https://yeongseon.github.io/azure-functions-openapi-python/
  Project-URL: Repository, https://github.com/yeongseon/azure-functions-openapi-python
  Project-URL: Issues, https://github.com/yeongseon/azure-functions-openapi-python/issues
  ```

## Risk

None for runtime/users of the installed package — pure metadata/docs change. Next PyPI release will start showing the correct links on the project page. Existing release artifacts on PyPI cannot be retroactively fixed but were already published with the old URLs, so no regression for current installs.