### PR TITLE
fix(swagger-ui): pin swagger-ui-dist CDN version (#191)

### DIFF
--- a/src/azure_functions_openapi/swagger_ui.py
+++ b/src/azure_functions_openapi/swagger_ui.py
@@ -7,6 +7,11 @@ from azure.functions import HttpResponse
 
 logger = logging.getLogger(__name__)
 
+# Pinned to avoid supply-chain drift from the unpinned `latest` tag on jsDelivr.
+# Bump intentionally; verify releases at https://github.com/swagger-api/swagger-ui/releases.
+_SWAGGER_UI_DIST_VERSION = "5.32.4"
+_SWAGGER_UI_CDN_BASE = f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{_SWAGGER_UI_DIST_VERSION}"
+
 
 def render_swagger_ui(
     title: str = "API Documentation",
@@ -73,11 +78,11 @@ def render_swagger_ui(
         <title>{sanitized_title}</title>
         <link rel="stylesheet" 
               type="text/css" 
-              href="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui.css" />
+              href="{_SWAGGER_UI_CDN_BASE}/swagger-ui.css" />
       </head>
       <body>
         <div id="swagger-ui"></div>
-        <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui-bundle.js"></script>
+        <script src="{_SWAGGER_UI_CDN_BASE}/swagger-ui-bundle.js"></script>
         <script nonce="{nonce}">
           // Enhanced security configuration
           const ui = SwaggerUIBundle({{

--- a/tests/test_swagger_ui.py
+++ b/tests/test_swagger_ui.py
@@ -1,4 +1,7 @@
-from azure_functions_openapi.swagger_ui import render_swagger_ui
+from azure_functions_openapi.swagger_ui import (
+    _SWAGGER_UI_DIST_VERSION,
+    render_swagger_ui,
+)
 
 
 def test_render_swagger_ui_returns_html_response() -> None:
@@ -13,3 +16,17 @@ def test_render_swagger_ui_returns_html_response() -> None:
     assert b'<div id="swagger-ui"></div>' in response.get_body()
     assert b"SwaggerUIBundle" in response.get_body()
     assert b"/api/openapi.json" in response.get_body()
+
+
+def test_render_swagger_ui_pins_swagger_ui_dist_version() -> None:
+    # Given
+    response = render_swagger_ui()
+    body = response.get_body()
+    pinned_base = (
+        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{_SWAGGER_UI_DIST_VERSION}".encode()
+    )
+
+    # Then
+    assert pinned_base + b"/swagger-ui.css" in body
+    assert pinned_base + b"/swagger-ui-bundle.js" in body
+    assert b"swagger-ui-dist/swagger-ui" not in body

--- a/tests/test_swagger_ui.py
+++ b/tests/test_swagger_ui.py
@@ -1,7 +1,4 @@
-from azure_functions_openapi.swagger_ui import (
-    _SWAGGER_UI_DIST_VERSION,
-    render_swagger_ui,
-)
+from azure_functions_openapi.swagger_ui import render_swagger_ui
 
 
 def test_render_swagger_ui_returns_html_response() -> None:
@@ -22,11 +19,10 @@ def test_render_swagger_ui_pins_swagger_ui_dist_version() -> None:
     # Given
     response = render_swagger_ui()
     body = response.get_body()
-    pinned_base = (
-        f"https://cdn.jsdelivr.net/npm/swagger-ui-dist@{_SWAGGER_UI_DIST_VERSION}".encode()
-    )
 
     # Then
-    assert pinned_base + b"/swagger-ui.css" in body
-    assert pinned_base + b"/swagger-ui-bundle.js" in body
-    assert b"swagger-ui-dist/swagger-ui" not in body
+    # Assert literal pinned URLs so a stray bump of the module-level constant
+    # is caught here instead of silently propagating to every Function App.
+    assert b"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.4/swagger-ui.css" in body
+    assert b"https://cdn.jsdelivr.net/npm/swagger-ui-dist@5.32.4/swagger-ui-bundle.js" in body
+    assert b"https://cdn.jsdelivr.net/npm/swagger-ui-dist/swagger-ui" not in body


### PR DESCRIPTION
## Summary

Closes #191.

`render_swagger_ui()` previously referenced `swagger-ui-dist` assets via the unpinned jsDelivr URL (`/npm/swagger-ui-dist/swagger-ui.css` and `/swagger-ui-bundle.js`). Any upstream change to the package's `latest` tag was automatically picked up by every Function App rendering Swagger UI, exposing users to silent UI breakage and weakening the supply-chain posture that the existing CSP/nonce hardening is meant to provide.

## Changes

- Add module-level constants `_SWAGGER_UI_DIST_VERSION = "5.32.4"` and `_SWAGGER_UI_CDN_BASE` in `src/azure_functions_openapi/swagger_ui.py`.
- Substitute them into the rendered HTML so the served URLs resolve to immutable jsDelivr paths (`/npm/swagger-ui-dist@5.32.4/...`).
- Add a regression test asserting both pinned URLs (CSS + JS bundle) appear in the rendered HTML and the unpinned form does not leak back in.

`5.32.4` is the latest `swagger-ui` release at the time of writing (verified against the upstream GitHub release feed).

## Out of Scope

SRI `integrity` attributes are intentionally deferred per the follow-up note in #191; pinning the version is a prerequisite for adding stable hashes later.

## Verification

- `make lint` / `make typecheck` / `make test` / `make build` — all green locally (362 tests passed).