### PR TITLE
feat(route-prefix): make Azure Functions route prefix configurable (#193)

### DIFF
--- a/docs/route-prefix.md
+++ b/docs/route-prefix.md
@@ -1,0 +1,91 @@
+# Route Prefix Policy
+
+Azure Functions exposes HTTP-triggered functions under a configurable URL prefix
+controlled by `host.json` (`extensions.http.routePrefix`). This page documents
+how `azure-functions-openapi` reflects that prefix in generated OpenAPI specs
+so the documented URLs match what your Function App actually serves.
+
+## The default `/api` prefix
+
+By default, Azure Functions serves HTTP triggers under `/api/<route>`. The
+prefix is set in `host.json`:
+
+```json
+{
+  "version": "2.0",
+  "extensions": {
+    "http": {
+      "routePrefix": "api"
+    }
+  }
+}
+```
+
+To match this default, `azure-functions-openapi` uses `"/api"` as the default
+`route_prefix` in:
+
+- `generate_openapi_spec(..., route_prefix="/api")`
+- `scan_validation_metadata(app, route_prefix="/api")`
+- The CLI flag `azure-functions-openapi generate --route-prefix /api`
+
+## Authoring routes with `@openapi`
+
+You can author routes in `@openapi(route=...)` either with or without the
+prefix; the spec generator is **idempotent** with respect to the configured
+`route_prefix`:
+
+```python
+@openapi(route="/users", method="get")        # → /api/users
+@openapi(route="/api/users", method="get")    # → /api/users (no double prefix)
+```
+
+The recommended form is **without** the prefix (`route="/users"`) so the same
+decorated handler works against any `host.json` deployment by passing a
+different `--route-prefix` at spec generation time.
+
+## Customising the prefix
+
+### No prefix
+
+If `host.json` sets `routePrefix` to an empty string, pass `""` so the
+generated spec drops the prefix:
+
+```bash
+azure-functions-openapi generate --app function_app --route-prefix ""
+```
+
+```python
+spec = generate_openapi_spec(route_prefix="")
+scan_validation_metadata(app, route_prefix="")
+```
+
+### Custom prefix
+
+For a non-default prefix such as `v1`:
+
+```bash
+azure-functions-openapi generate --app function_app --route-prefix /v1
+```
+
+```python
+spec = generate_openapi_spec(route_prefix="/v1")
+scan_validation_metadata(app, route_prefix="/v1")
+```
+
+The prefix is normalized: leading slash is added if missing, trailing slashes
+are stripped (`v1/` and `/v1` both produce `/v1`).
+
+## Consistency across registration paths
+
+The same `route_prefix` applies to all three registration paths so a
+FunctionApp that mixes them produces a single, consistent `paths` map:
+
+| Registration path                    | Where prefix is applied              |
+| ------------------------------------ | ------------------------------------ |
+| `@openapi(route=...)` decorator      | `generate_openapi_spec(route_prefix=)` at spec-build time |
+| `register_openapi_metadata(path=...)`| `generate_openapi_spec(route_prefix=)` at spec-build time |
+| Validation bridge auto-discovery     | `scan_validation_metadata(route_prefix=)` at scan time and `generate_openapi_spec(route_prefix=)` at spec-build time |
+
+To keep the bridge-discovered registry entries and the final spec aligned,
+pass the **same** `route_prefix` to both `scan_validation_metadata()` and
+`generate_openapi_spec()` (or the CLI `--route-prefix`).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,9 @@ This guide shows how to document Azure Functions Python v2 HTTP handlers with `a
 
 See [Installation](installation.md) and [Getting Started](getting-started.md) first.
 
+For configurable URL prefixes (custom or empty `host.json` `routePrefix`),
+see [Route Prefix](route-prefix.md).
+
 ## End-to-end baseline
 
 ```python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
   - User Guide:
       - Usage: usage.md
       - CLI: cli.md
+      - Route Prefix: route-prefix.md
       - Architecture: architecture.md
   - Deployment:
       - Choose a Plan: choose-a-plan.md

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -13,6 +13,7 @@ from azure_functions_openapi.decorator import (
     register_openapi_metadata,
 )
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+from azure_functions_openapi.routes import DEFAULT_ROUTE_PREFIX, normalize_route_prefix
 from azure_functions_openapi.utils import type_to_schema
 
 logger = logging.getLogger(__name__)
@@ -29,23 +30,6 @@ def _normalize_method(method: Any) -> str:
     return str(value).lower()
 
 
-DEFAULT_ROUTE_PREFIX = "/api"
-
-
-def _normalize_route_prefix(route_prefix: str) -> str:
-    """Normalize a user-supplied ``route_prefix`` to canonical form.
-
-    The Azure Functions ``host.json`` contract treats the prefix as a path
-    segment without a trailing slash; an empty string means "no prefix".
-    """
-    prefix = (route_prefix or "").strip()
-    if not prefix:
-        return ""
-    if not prefix.startswith("/"):
-        prefix = f"/{prefix}"
-    return prefix.rstrip("/")
-
-
 def _normalize_path(
     route: str | None,
     function_name: str,
@@ -58,7 +42,7 @@ def _normalize_path(
     serves. Pass ``""`` for hosts that disable the prefix and any other
     value (e.g. ``"/v1"``) for custom prefixes.
     """
-    prefix = _normalize_route_prefix(route_prefix)
+    prefix = normalize_route_prefix(route_prefix)
     raw = (route or function_name or "").strip()
     if not raw:
         raw = function_name

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -29,19 +29,46 @@ def _normalize_method(method: Any) -> str:
     return str(value).lower()
 
 
-def _normalize_path(route: str | None, function_name: str) -> str:
+DEFAULT_ROUTE_PREFIX = "/api"
+
+
+def _normalize_route_prefix(route_prefix: str) -> str:
+    """Normalize a user-supplied ``route_prefix`` to canonical form.
+
+    The Azure Functions ``host.json`` contract treats the prefix as a path
+    segment without a trailing slash; an empty string means "no prefix".
+    """
+    prefix = (route_prefix or "").strip()
+    if not prefix:
+        return ""
+    if not prefix.startswith("/"):
+        prefix = f"/{prefix}"
+    return prefix.rstrip("/")
+
+
+def _normalize_path(
+    route: str | None,
+    function_name: str,
+    route_prefix: str = DEFAULT_ROUTE_PREFIX,
+) -> str:
+    """Compose a path key for the OpenAPI registry from a binding route.
+
+    ``route_prefix`` mirrors ``host.json`` ``extensions.http.routePrefix`` so
+    that scans stay consistent with the runtime URLs Azure Functions actually
+    serves. Pass ``""`` for hosts that disable the prefix and any other
+    value (e.g. ``"/v1"``) for custom prefixes.
+    """
+    prefix = _normalize_route_prefix(route_prefix)
     raw = (route or function_name or "").strip()
     if not raw:
         raw = function_name
     if not raw.startswith("/"):
         raw = f"/{raw}"
-    if raw == "/api" or raw.startswith("/api/"):
+    if not prefix:
         return raw
-    if raw.startswith("/api/"):
+    if raw == prefix or raw.startswith(f"{prefix}/"):
         return raw
-    if raw.startswith("/api") and len(raw) > 4 and raw[4] == "/":
-        return raw
-    return f"/api{raw}"
+    return f"{prefix}{raw}"
 
 
 def _extract_http_binding(function_obj: Any) -> Any | None:
@@ -178,9 +205,7 @@ def _model_to_parameters(model_cls: type, location: str) -> list[dict[str, Any]]
 def _discovered_operation(
     function_name: str, metadata: dict[str, Any], path: str, method: str
 ) -> dict[str, Any]:
-    request_body = (
-        type_to_schema(metadata["body"]) if metadata.get("body") is not None else None
-    )
+    request_body = type_to_schema(metadata["body"]) if metadata.get("body") is not None else None
     parameters: list[dict[str, Any]] = []
     if metadata.get("query") is not None:
         parameters.extend(_model_to_parameters(metadata["query"], "query"))
@@ -196,6 +221,7 @@ def _discovered_operation(
         "parameters": parameters,
         "response_model": metadata.get("response_model"),
     }
+
 
 # Convention-based handler metadata attribute name.
 # Packages in the Azure Functions Python DX Toolkit write per-namespace
@@ -235,8 +261,7 @@ def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
             if raw_version is not None:
                 if type(raw_version) is not int or raw_version not in _SUPPORTED_VERSIONS:
                     logger.warning(
-                        "Skipping metadata on %r: unsupported version %r"
-                        " (supported: %s)",
+                        "Skipping metadata on %r: unsupported version %r (supported: %s)",
                         current,
                         raw_version,
                         ", ".join(str(v) for v in sorted(_SUPPORTED_VERSIONS)),
@@ -260,12 +285,16 @@ def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
     return None
 
 
-def scan_validation_metadata(app: Any) -> None:
+def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -> None:
     """Scan function builders for validation metadata and register OpenAPI operations.
 
     This function reads the convention-based ``_azure_functions_metadata``
     attribute (namespace ``"validation"``) from each handler.  No import from
     ``azure-functions-validation`` is required.
+
+    ``route_prefix`` mirrors ``host.json`` ``extensions.http.routePrefix``
+    (default ``"/api"``). Pass ``""`` for hosts that disable the prefix or
+    a custom value such as ``"/v1"`` to match a non-default deployment.
     """
     builders = getattr(app, "_function_builders", None)
     if not builders:
@@ -291,7 +320,7 @@ def scan_validation_metadata(app: Any) -> None:
             )
             continue
 
-        path = _normalize_path(getattr(binding, "route", None), function_name)
+        path = _normalize_path(getattr(binding, "route", None), function_name, route_prefix)
         methods = _extract_methods(binding)
 
         for method in methods:

--- a/src/azure_functions_openapi/cli.py
+++ b/src/azure_functions_openapi/cli.py
@@ -101,6 +101,15 @@ Examples:
         default="3.0",
         help="OpenAPI version (default: 3.0)",
     )
+    generate_parser.add_argument(
+        "--route-prefix",
+        default="/api",
+        help=(
+            "HTTP route prefix from host.json extensions.http.routePrefix "
+            "(default: /api). Pass an empty string for hosts that disable "
+            "the prefix, or a custom value such as /v1 for a custom deployment."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -139,7 +148,12 @@ def handle_generate(args: argparse.Namespace) -> int:
 
         # Check for empty paths before serialising — gives a clear signal
         # instead of silently producing a spec with no routes.
-        spec = generate_openapi_spec(args.title, args.version, openapi_version)
+        spec = generate_openapi_spec(
+            args.title,
+            args.version,
+            openapi_version,
+            route_prefix=getattr(args, "route_prefix", "/api"),
+        )
         if not spec.get("paths"):
             print(
                 "Warning: No routes found in the OpenAPI registry. "

--- a/src/azure_functions_openapi/openapi.py
+++ b/src/azure_functions_openapi/openapi.py
@@ -19,6 +19,30 @@ OPENAPI_VERSION_3_1 = "3.1.0"
 DEFAULT_OPENAPI_INFO_DESCRIPTION = (
     "Auto-generated OpenAPI documentation. Markdown supported in descriptions (CommonMark)."
 )
+DEFAULT_ROUTE_PREFIX = "/api"
+
+
+def _normalize_route_prefix(route_prefix: str) -> str:
+    """Canonicalize a route prefix (no trailing slash; ``""`` means no prefix)."""
+    prefix = (route_prefix or "").strip()
+    if not prefix:
+        return ""
+    if not prefix.startswith("/"):
+        prefix = f"/{prefix}"
+    return prefix.rstrip("/")
+
+
+def _apply_route_prefix(path: str, prefix: str) -> str:
+    """Prepend ``prefix`` to ``path`` unless ``path`` is already prefixed.
+
+    Idempotent so that authors who write ``route="/api/users"`` are not
+    double-prefixed when the spec is generated with the default ``/api``.
+    """
+    if not prefix:
+        return path
+    if path == prefix or path.startswith(f"{prefix}/"):
+        return path
+    return f"{prefix}{path}"
 
 
 def _ensure_default_response(
@@ -106,6 +130,7 @@ def generate_openapi_spec(
     openapi_version: str = OPENAPI_VERSION_3_0,
     description: str = DEFAULT_OPENAPI_INFO_DESCRIPTION,
     security_schemes: dict[str, dict[str, Any]] | None = None,
+    route_prefix: str = DEFAULT_ROUTE_PREFIX,
 ) -> dict[str, Any]:
     """
     Compile an OpenAPI specification from the registry.
@@ -117,6 +142,11 @@ def generate_openapi_spec(
         description: Description for the OpenAPI info object
         security_schemes: Security scheme definitions for components.securitySchemes.
             Example: {"BearerAuth": {"type": "http", "scheme": "bearer"}}
+        route_prefix: HTTP route prefix from ``host.json``
+            (``extensions.http.routePrefix``). Defaults to ``"/api"``. Pass
+            ``""`` for hosts that disable the prefix or a custom value such
+            as ``"/v1"``. Routes that already start with the prefix are not
+            re-prefixed.
 
     Returns:
         OpenAPI specification dictionary
@@ -127,6 +157,8 @@ def generate_openapi_spec(
             f"{OPENAPI_VERSION_3_0}, {OPENAPI_VERSION_3_1}"
         )
 
+    normalized_prefix = _normalize_route_prefix(route_prefix)
+
     try:
         registry = get_openapi_registry()
         paths: dict[str, dict[str, Any]] = {}
@@ -136,7 +168,8 @@ def generate_openapi_spec(
             try:
                 logical_name = meta.get("function_name") or func_name
                 # route & method --------------------------------------------------
-                path = f"/{(meta.get('route') or logical_name).lstrip('/')}"
+                raw_path = f"/{(meta.get('route') or logical_name).lstrip('/')}"
+                path = _apply_route_prefix(raw_path, normalized_prefix)
                 method = (meta.get("method") or "get").lower()
 
                 # responses -------------------------------------------------------
@@ -324,7 +357,9 @@ def get_openapi_json(
     """
     try:
         spec = generate_openapi_spec(
-            title, version, openapi_version,
+            title,
+            version,
+            openapi_version,
             description=description,
             security_schemes=security_schemes,
         )
@@ -357,7 +392,9 @@ def get_openapi_yaml(
     """
     try:
         spec = generate_openapi_spec(
-            title, version, openapi_version,
+            title,
+            version,
+            openapi_version,
             description=description,
             security_schemes=security_schemes,
         )

--- a/src/azure_functions_openapi/openapi.py
+++ b/src/azure_functions_openapi/openapi.py
@@ -9,6 +9,11 @@ import yaml
 
 from azure_functions_openapi.decorator import get_openapi_registry
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+from azure_functions_openapi.routes import (
+    DEFAULT_ROUTE_PREFIX,
+    apply_route_prefix,
+    normalize_route_prefix,
+)
 from azure_functions_openapi.utils import model_to_schema
 
 logger = logging.getLogger(__name__)
@@ -19,30 +24,6 @@ OPENAPI_VERSION_3_1 = "3.1.0"
 DEFAULT_OPENAPI_INFO_DESCRIPTION = (
     "Auto-generated OpenAPI documentation. Markdown supported in descriptions (CommonMark)."
 )
-DEFAULT_ROUTE_PREFIX = "/api"
-
-
-def _normalize_route_prefix(route_prefix: str) -> str:
-    """Canonicalize a route prefix (no trailing slash; ``""`` means no prefix)."""
-    prefix = (route_prefix or "").strip()
-    if not prefix:
-        return ""
-    if not prefix.startswith("/"):
-        prefix = f"/{prefix}"
-    return prefix.rstrip("/")
-
-
-def _apply_route_prefix(path: str, prefix: str) -> str:
-    """Prepend ``prefix`` to ``path`` unless ``path`` is already prefixed.
-
-    Idempotent so that authors who write ``route="/api/users"`` are not
-    double-prefixed when the spec is generated with the default ``/api``.
-    """
-    if not prefix:
-        return path
-    if path == prefix or path.startswith(f"{prefix}/"):
-        return path
-    return f"{prefix}{path}"
 
 
 def _ensure_default_response(
@@ -157,7 +138,7 @@ def generate_openapi_spec(
             f"{OPENAPI_VERSION_3_0}, {OPENAPI_VERSION_3_1}"
         )
 
-    normalized_prefix = _normalize_route_prefix(route_prefix)
+    normalized_prefix = normalize_route_prefix(route_prefix)
 
     try:
         registry = get_openapi_registry()
@@ -169,7 +150,7 @@ def generate_openapi_spec(
                 logical_name = meta.get("function_name") or func_name
                 # route & method --------------------------------------------------
                 raw_path = f"/{(meta.get('route') or logical_name).lstrip('/')}"
-                path = _apply_route_prefix(raw_path, normalized_prefix)
+                path = apply_route_prefix(raw_path, normalized_prefix)
                 method = (meta.get("method") or "get").lower()
 
                 # responses -------------------------------------------------------
@@ -342,6 +323,7 @@ def get_openapi_json(
     openapi_version: str = OPENAPI_VERSION_3_0,
     description: str = DEFAULT_OPENAPI_INFO_DESCRIPTION,
     security_schemes: dict[str, dict[str, Any]] | None = None,
+    route_prefix: str = DEFAULT_ROUTE_PREFIX,
 ) -> str:
     """Return the spec as pretty-printed JSON (UTF-8).
 
@@ -351,6 +333,10 @@ def get_openapi_json(
         openapi_version: OpenAPI specification version ("3.0.0" or "3.1.0")
         description: Description for the OpenAPI info object
         security_schemes: Security scheme definitions for components.securitySchemes.
+        route_prefix: HTTP route prefix from ``host.json``
+            (``extensions.http.routePrefix``). Defaults to ``"/api"``. Pass
+            ``""`` for hosts that disable the prefix or a custom value such
+            as ``"/v1"``.
 
     Returns:
         OpenAPI spec in JSON format.
@@ -362,6 +348,7 @@ def get_openapi_json(
             openapi_version,
             description=description,
             security_schemes=security_schemes,
+            route_prefix=route_prefix,
         )
         return json.dumps(spec, indent=2, ensure_ascii=False)
     except OpenAPISpecConfigError:
@@ -377,6 +364,7 @@ def get_openapi_yaml(
     openapi_version: str = OPENAPI_VERSION_3_0,
     description: str = DEFAULT_OPENAPI_INFO_DESCRIPTION,
     security_schemes: dict[str, dict[str, Any]] | None = None,
+    route_prefix: str = DEFAULT_ROUTE_PREFIX,
 ) -> str:
     """Return the spec as YAML.
 
@@ -386,6 +374,10 @@ def get_openapi_yaml(
         openapi_version: OpenAPI specification version ("3.0.0" or "3.1.0")
         description: Description for the OpenAPI info object
         security_schemes: Security scheme definitions for components.securitySchemes.
+        route_prefix: HTTP route prefix from ``host.json``
+            (``extensions.http.routePrefix``). Defaults to ``"/api"``. Pass
+            ``""`` for hosts that disable the prefix or a custom value such
+            as ``"/v1"``.
 
     Returns:
         OpenAPI spec in YAML format.
@@ -397,6 +389,7 @@ def get_openapi_yaml(
             openapi_version,
             description=description,
             security_schemes=security_schemes,
+            route_prefix=route_prefix,
         )
         return yaml.safe_dump(spec, sort_keys=False, allow_unicode=True)
     except OpenAPISpecConfigError:

--- a/src/azure_functions_openapi/routes.py
+++ b/src/azure_functions_openapi/routes.py
@@ -1,0 +1,37 @@
+"""Single source of truth for the Azure Functions HTTP route prefix policy.
+
+Shared by the spec generator, the validation bridge, the CLI, and the
+public ``get_openapi_*`` helpers so they cannot drift apart.
+"""
+
+from __future__ import annotations
+
+DEFAULT_ROUTE_PREFIX = "/api"
+
+
+def normalize_route_prefix(route_prefix: str) -> str:
+    """Canonicalize a user-supplied prefix.
+
+    The Azure Functions ``host.json`` contract treats the prefix as a
+    path segment without a trailing slash; an empty string means
+    "no prefix is served".
+    """
+    prefix = (route_prefix or "").strip()
+    if not prefix:
+        return ""
+    if not prefix.startswith("/"):
+        prefix = f"/{prefix}"
+    return prefix.rstrip("/")
+
+
+def apply_route_prefix(path: str, prefix: str) -> str:
+    """Prepend ``prefix`` to ``path`` unless ``path`` is already prefixed.
+
+    Idempotent so that authors who write ``route="/api/users"`` are not
+    double-prefixed when the spec is generated with the default ``/api``.
+    """
+    if not prefix:
+        return path
+    if path == prefix or path.startswith(f"{prefix}/"):
+        return path
+    return f"{prefix}{path}"

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -97,9 +97,7 @@ def _make_app(
 
 
 def test_scan_discovers_validation_metadata() -> None:
-    app = _make_app(
-        metadata={"body": CreateBody, "response_model": ResponseModel}
-    )
+    app = _make_app(metadata={"body": CreateBody, "response_model": ResponseModel})
 
     scan_validation_metadata(app)
 
@@ -119,14 +117,13 @@ def test_scan_skips_non_validated_functions() -> None:
 
 def test_explicit_openapi_wins() -> None:
     register_openapi_metadata(path="/api/users", method="post", summary="explicit")
-    app = _make_app(
-        metadata={"body": CreateBody, "response_model": ResponseModel}
-    )
+    app = _make_app(metadata={"body": CreateBody, "response_model": ResponseModel})
 
     scan_validation_metadata(app)
 
     entry = get_openapi_registry()["post::/api/users"]
     assert entry["summary"] == "explicit"
+
 
 def test_body_model_registered_as_request_body() -> None:
     app = _make_app(metadata={"body": CreateBody})
@@ -148,9 +145,7 @@ def test_query_model_registered_as_parameters() -> None:
 
 
 def test_path_model_registered_as_parameters() -> None:
-    app = _make_app(
-        route="users/{user_id}", metadata={"path": PathModel}
-    )
+    app = _make_app(route="users/{user_id}", metadata={"path": PathModel})
 
     scan_validation_metadata(app)
 
@@ -373,10 +368,14 @@ class TestVersionValidation:
     def test_version_1_accepted(self) -> None:
         """Explicit version=1 is accepted."""
         handler = lambda req: req  # noqa: E731
-        setattr(handler, _HANDLER_METADATA_ATTR, {
-            "version": 1,
-            "validation": {"body": CreateBody},
-        })
+        setattr(
+            handler,
+            _HANDLER_METADATA_ATTR,
+            {
+                "version": 1,
+                "validation": {"body": CreateBody},
+            },
+        )
 
         result = _read_validation_hints(handler)
         assert result is not None
@@ -385,10 +384,14 @@ class TestVersionValidation:
     def test_unsupported_version_skipped(self) -> None:
         """Unsupported integer version emits warning and returns None."""
         handler = lambda req: req  # noqa: E731
-        setattr(handler, _HANDLER_METADATA_ATTR, {
-            "version": 999,
-            "validation": {"body": CreateBody},
-        })
+        setattr(
+            handler,
+            _HANDLER_METADATA_ATTR,
+            {
+                "version": 999,
+                "validation": {"body": CreateBody},
+            },
+        )
 
         result = _read_validation_hints(handler)
         assert result is None
@@ -396,10 +399,14 @@ class TestVersionValidation:
     def test_malformed_version_string_skipped(self) -> None:
         """Non-int version (e.g. string) emits warning and returns None."""
         handler = lambda req: req  # noqa: E731
-        setattr(handler, _HANDLER_METADATA_ATTR, {
-            "version": "1",
-            "validation": {"body": CreateBody},
-        })
+        setattr(
+            handler,
+            _HANDLER_METADATA_ATTR,
+            {
+                "version": "1",
+                "validation": {"body": CreateBody},
+            },
+        )
 
         result = _read_validation_hints(handler)
         assert result is None
@@ -407,10 +414,14 @@ class TestVersionValidation:
     def test_malformed_version_float_skipped(self) -> None:
         """Float version is rejected (only int accepted)."""
         handler = lambda req: req  # noqa: E731
-        setattr(handler, _HANDLER_METADATA_ATTR, {
-            "version": 1.0,
-            "validation": {"body": CreateBody},
-        })
+        setattr(
+            handler,
+            _HANDLER_METADATA_ATTR,
+            {
+                "version": 1.0,
+                "validation": {"body": CreateBody},
+            },
+        )
 
         result = _read_validation_hints(handler)
         assert result is None
@@ -418,10 +429,14 @@ class TestVersionValidation:
     def test_unsupported_version_warning_logged(self, caplog: pytest.LogCaptureFixture) -> None:
         """Warning is logged with handler repr and unsupported version."""
         handler = lambda req: req  # noqa: E731
-        setattr(handler, _HANDLER_METADATA_ATTR, {
-            "version": 42,
-            "validation": {"body": CreateBody},
-        })
+        setattr(
+            handler,
+            _HANDLER_METADATA_ATTR,
+            {
+                "version": 42,
+                "validation": {"body": CreateBody},
+            },
+        )
 
         with caplog.at_level("WARNING", logger="azure_functions_openapi.bridge"):
             _read_validation_hints(handler)
@@ -429,20 +444,27 @@ class TestVersionValidation:
         assert any("unsupported version" in m for m in caplog.messages)
         assert any("42" in m for m in caplog.messages)
 
-
     def test_outer_invalid_version_inner_valid_discovered(self) -> None:
         """Invalid version on outer should not block valid inner metadata."""
         inner: Any = lambda req: req  # noqa: E731
-        setattr(inner, _HANDLER_METADATA_ATTR, {
-            "version": 1,
-            "validation": {"body": CreateBody},
-        })
+        setattr(
+            inner,
+            _HANDLER_METADATA_ATTR,
+            {
+                "version": 1,
+                "validation": {"body": CreateBody},
+            },
+        )
 
         outer: Any = lambda req: inner(req)  # noqa: E731
-        setattr(outer, _HANDLER_METADATA_ATTR, {
-            "version": 999,
-            "validation": {"body": ResponseModel},
-        })
+        setattr(
+            outer,
+            _HANDLER_METADATA_ATTR,
+            {
+                "version": 999,
+                "validation": {"body": ResponseModel},
+            },
+        )
         outer.__wrapped__ = inner
 
         result = _read_validation_hints(outer)
@@ -453,13 +475,18 @@ class TestVersionValidation:
     def test_boolean_version_rejected(self) -> None:
         """version=True is a bool, not int — should be rejected."""
         handler = lambda req: req  # noqa: E731
-        setattr(handler, _HANDLER_METADATA_ATTR, {
-            "version": True,
-            "validation": {"body": CreateBody},
-        })
+        setattr(
+            handler,
+            _HANDLER_METADATA_ATTR,
+            {
+                "version": True,
+                "validation": {"body": CreateBody},
+            },
+        )
 
         result = _read_validation_hints(handler)
         assert result is None
+
 
 class TestDeepCopyMutationSafety:
     """Returned hints are deep copies — mutating them doesn't affect the handler."""
@@ -483,9 +510,13 @@ class TestDeepCopyMutationSafety:
 
     def test_successive_reads_are_independent(self) -> None:
         handler = lambda req: req  # noqa: E731
-        setattr(handler, _HANDLER_METADATA_ATTR, {
-            "validation": {"body": CreateBody, "extra": {"key": "original"}},
-        })
+        setattr(
+            handler,
+            _HANDLER_METADATA_ATTR,
+            {
+                "validation": {"body": CreateBody, "extra": {"key": "original"}},
+            },
+        )
 
         first = _read_validation_hints(handler)
         assert first is not None
@@ -494,3 +525,44 @@ class TestDeepCopyMutationSafety:
         second = _read_validation_hints(handler)
         assert second is not None
         assert second["extra"]["key"] == "original"
+
+
+def test_scan_uses_default_api_prefix() -> None:
+    app = _make_app(metadata={"body": CreateBody})
+
+    scan_validation_metadata(app)
+
+    assert "post::/api/users" in get_openapi_registry()
+
+
+def test_scan_supports_empty_prefix_for_disabled_host_prefix() -> None:
+    app = _make_app(metadata={"body": CreateBody})
+
+    scan_validation_metadata(app, route_prefix="")
+
+    assert "post::/users" in get_openapi_registry()
+
+
+def test_scan_supports_custom_prefix() -> None:
+    app = _make_app(metadata={"body": CreateBody})
+
+    scan_validation_metadata(app, route_prefix="/v1")
+
+    assert "post::/v1/users" in get_openapi_registry()
+
+
+def test_scan_does_not_double_apply_prefix() -> None:
+    app = _make_app(route="/api/users", metadata={"body": CreateBody})
+
+    scan_validation_metadata(app, route_prefix="/api")
+
+    assert "post::/api/users" in get_openapi_registry()
+    assert "post::/api/api/users" not in get_openapi_registry()
+
+
+def test_scan_normalizes_prefix_with_trailing_slash() -> None:
+    app = _make_app(metadata={"body": CreateBody})
+
+    scan_validation_metadata(app, route_prefix="v1/")
+
+    assert "post::/v1/users" in get_openapi_registry()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,9 +76,7 @@ class TestHandleGenerate:
             "info": {"title": "Test API", "version": "1.0.0"},
             "paths": {"/hello": {"get": {"responses": {"200": {"description": "ok"}}}}},
         }
-        with mock.patch(
-            "azure_functions_openapi.cli.generate_openapi_spec", return_value=_spec
-        ):
+        with mock.patch("azure_functions_openapi.cli.generate_openapi_spec", return_value=_spec):
             with mock.patch("builtins.print") as mock_print:
                 result = handle_generate(args)
 
@@ -130,9 +128,7 @@ class TestHandleGenerate:
             "info": {"title": "YAML API", "version": "2.0.0"},
             "paths": {"/hello": {"get": {"responses": {"200": {"description": "ok"}}}}},
         }
-        with mock.patch(
-            "azure_functions_openapi.cli.generate_openapi_spec", return_value=_spec
-        ):
+        with mock.patch("azure_functions_openapi.cli.generate_openapi_spec", return_value=_spec):
             with mock.patch("builtins.print") as mock_print:
                 result = handle_generate(args)
 
@@ -141,6 +137,7 @@ class TestHandleGenerate:
         output = mock_print.call_args[0][0]
         assert "openapi:" in output
         assert "YAML API" in output
+
     def test_generate_openapi_version_3_1(self) -> None:
         """Test OpenAPI 3.1 generation."""
         args = mock.Mock()
@@ -157,9 +154,7 @@ class TestHandleGenerate:
             "info": {"title": "API 3.1", "version": "1.0.0"},
             "paths": {"/hello": {"get": {"responses": {"200": {"description": "ok"}}}}},
         }
-        with mock.patch(
-            "azure_functions_openapi.cli.generate_openapi_spec", return_value=_spec
-        ):
+        with mock.patch("azure_functions_openapi.cli.generate_openapi_spec", return_value=_spec):
             with mock.patch("builtins.print") as mock_print:
                 result = handle_generate(args)
 
@@ -356,9 +351,7 @@ class TestMainExceptionHandling:
 
     def test_main_catches_exception_from_handle_generate(self) -> None:
         """When handle_generate raises, main() catches and returns 1."""
-        with mock.patch.object(
-            sys, "argv", ["azure-functions-openapi", "generate"]
-        ):
+        with mock.patch.object(sys, "argv", ["azure-functions-openapi", "generate"]):
             with mock.patch(
                 "azure_functions_openapi.cli.handle_generate",
                 side_effect=RuntimeError("boom"),
@@ -443,15 +436,15 @@ class TestImportAppModule:
         """ImportError from a missing module propagates to caller."""
         with pytest.raises(ImportError):
             _import_app_module("nonexistent_module_xyz_12345")
+
     def test_nonexistent_variable_raises_attribute_error(self) -> None:
         """'module:nonexistent' raises AttributeError with a clear message."""
         import types
+
         fake_mod = types.ModuleType("fake_mod")
         with mock.patch("importlib.import_module", return_value=fake_mod):
             with pytest.raises(AttributeError, match="no attribute 'nonexistent'"):
                 _import_app_module("fake_mod:nonexistent")
-
-
 
 
 class TestHandleGenerateWithApp:
@@ -493,6 +486,7 @@ class TestHandleGenerateWithApp:
             result = handle_generate(args)
 
         assert result == 1
+
     def test_app_attribute_error_returns_1(self) -> None:
         """If the named variable does not exist, handle_generate returns exit code 1."""
         args = mock.Mock()
@@ -511,7 +505,6 @@ class TestHandleGenerateWithApp:
             result = handle_generate(args)
 
         assert result == 1
-
 
     def test_no_app_option_skips_import(self) -> None:
         """When --app is not provided, no import is attempted."""
@@ -588,6 +581,7 @@ class TestEmptyPathsWarning:
             return_value=spec_with_paths,
         ):
             import io
+
             fake_stderr = io.StringIO()
             with mock.patch("sys.stderr", fake_stderr):
                 with mock.patch("builtins.print"):
@@ -706,3 +700,43 @@ class TestFailOnEmptyPaths:
                     result = main()
 
         assert result == 1
+
+
+class TestRoutePrefix:
+    def test_route_prefix_default_is_api(self) -> None:
+        with mock.patch.object(sys, "argv", ["azure-functions-openapi", "generate"]):
+            with mock.patch("azure_functions_openapi.cli.generate_openapi_spec") as mock_gen:
+                mock_gen.return_value = {"paths": {"/api/users": {}}}
+                with mock.patch("builtins.print"):
+                    main()
+
+        _, kwargs = mock_gen.call_args
+        assert kwargs.get("route_prefix") == "/api"
+
+    def test_route_prefix_flag_passes_value(self) -> None:
+        with mock.patch.object(
+            sys,
+            "argv",
+            ["azure-functions-openapi", "generate", "--route-prefix", "/v1"],
+        ):
+            with mock.patch("azure_functions_openapi.cli.generate_openapi_spec") as mock_gen:
+                mock_gen.return_value = {"paths": {"/v1/users": {}}}
+                with mock.patch("builtins.print"):
+                    main()
+
+        _, kwargs = mock_gen.call_args
+        assert kwargs.get("route_prefix") == "/v1"
+
+    def test_route_prefix_flag_accepts_empty_string(self) -> None:
+        with mock.patch.object(
+            sys,
+            "argv",
+            ["azure-functions-openapi", "generate", "--route-prefix", ""],
+        ):
+            with mock.patch("azure_functions_openapi.cli.generate_openapi_spec") as mock_gen:
+                mock_gen.return_value = {"paths": {"/users": {}}}
+                with mock.patch("builtins.print"):
+                    main()
+
+        _, kwargs = mock_gen.call_args
+        assert kwargs.get("route_prefix") == ""

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -102,7 +102,7 @@ def test_openapi_accepts_function_builder_when_decorator_is_outermost() -> None:
     assert registry["hello"]["summary"] == "Hello"
     assert registry["hello"]["description"] == "Returns plain text."
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     assert "/hello" in spec["paths"]
 
 
@@ -274,9 +274,8 @@ def test_openapi_raises_error_when_requests_and_request_model_provided() -> None
         def conflicting_requests_func() -> None:
             pass
 
-    assert (
-        "Cannot provide both 'requests' and 'request_model'/'request_body'."
-        in str(exc_info.value)
+    assert "Cannot provide both 'requests' and 'request_model'/'request_body'." in str(
+        exc_info.value
     )
 
 
@@ -298,6 +297,7 @@ def test_openapi_raises_error_when_responses_and_response_model_provided() -> No
 
 def test_openapi_registers_request_body_required_default() -> None:
     """request_body_required defaults to True and is stored in registry."""
+
     @openapi(
         summary="Required body by default",
         method="post",
@@ -329,6 +329,6 @@ def test_openapi_registers_request_body_required_false() -> None:
     registry = get_openapi_registry()
     assert registry["optional_body_func"]["request_body_required"] is False
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     rb = spec["paths"]["/optional-body"]["post"]["requestBody"]
     assert rb["required"] is False

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -58,7 +58,7 @@ def test_generate_openapi_spec_structure() -> None:
     def sample_func() -> None:
         pass
 
-    spec = generate_openapi_spec(title="My API", version="1.2.3")
+    spec = generate_openapi_spec(title="My API", version="1.2.3", route_prefix="")
 
     assert spec["openapi"] == "3.0.0"
     assert spec["info"]["title"] == "My API"
@@ -84,7 +84,7 @@ def test_get_openapi_json_output() -> None:
 
 
 def test_generate_openapi_spec_uses_default_info_description() -> None:
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
 
     assert spec["info"]["description"] == DEFAULT_OPENAPI_INFO_DESCRIPTION
 
@@ -118,7 +118,7 @@ def test_generate_openapi_spec_with_request_body() -> None:
     def func_with_body() -> None:
         pass
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     rb = spec["paths"]["/func_with_body"]["post"]["requestBody"]
     schema = rb["content"]["application/json"]["schema"]
     assert {"username", "password"} <= schema["properties"].keys()
@@ -152,7 +152,7 @@ def test_response_schema_and_examples() -> None:
     def greet() -> None:
         pass
 
-    op = generate_openapi_spec()["paths"]["/greet"]["get"]
+    op = generate_openapi_spec(route_prefix="")["paths"]["/greet"]["get"]
     assert (
         op["responses"]["200"]["content"]["application/json"]["examples"]["sample"]["value"][
             "message"
@@ -172,7 +172,7 @@ def test_generate_openapi_spec_with_route_and_method() -> None:
     def custom_func() -> None:
         pass
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     assert "post" in spec["paths"]["/custom-path"]
 
 
@@ -186,7 +186,7 @@ def test_generate_openapi_spec_normalizes_route_without_leading_slash() -> None:
     def hello() -> None:
         pass
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     assert "/hello" in spec["paths"]
     assert "hello" not in spec["paths"]
     assert "post" in spec["paths"]["/hello"]
@@ -200,7 +200,7 @@ def test_generate_openapi_spec_normalizes_default_function_path() -> None:
     def default_path_func() -> None:
         pass
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     assert "/default_path_func" in spec["paths"]
 
 
@@ -222,13 +222,13 @@ def test_generate_spec_with_pydantic_models() -> None:
     def login() -> None:
         pass
 
-    op = generate_openapi_spec()["paths"]["/login"]["post"]
+    op = generate_openapi_spec(route_prefix="")["paths"]["/login"]["post"]
     schema_req = op["requestBody"]["content"]["application/json"]["schema"]
     schema_resp = op["responses"]["200"]["content"]["application/json"]["schema"]
     assert schema_req == {"$ref": "#/components/schemas/RequestModel"}
     assert schema_resp == {"$ref": "#/components/schemas/ResponseModel"}
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     components = spec.get("components", {})
     schemas = components.get("schemas", {})
     assert "RequestModel" in schemas
@@ -262,7 +262,9 @@ def test_response_200_is_preserved_when_response_model_exists() -> None:
     def merge_response_func() -> None:
         pass
 
-    response_200 = generate_openapi_spec()["paths"]["/merge-response"]["get"]["responses"]["200"]
+    response_200 = generate_openapi_spec(route_prefix="")["paths"]["/merge-response"]["get"][
+        "responses"
+    ]["200"]
     assert response_200["description"] == "Custom 200"
     assert "X-Trace-Id" in response_200["headers"]
     assert "sample" in response_200["content"]["application/json"]["examples"]
@@ -285,7 +287,9 @@ def test_response_model_uses_explicit_first_success_status_code() -> None:
     def created_with_model_func() -> None:
         pass
 
-    responses = generate_openapi_spec()["paths"]["/created-with-model"]["post"]["responses"]
+    responses = generate_openapi_spec(route_prefix="")["paths"]["/created-with-model"]["post"][
+        "responses"
+    ]
     assert "200" not in responses
     assert responses["201"]["description"] == "Created"
     assert responses["201"]["content"]["application/json"]["schema"] == {
@@ -306,7 +310,9 @@ def test_response_model_defaults_to_200_when_no_success_response_declared() -> N
     def response_model_default_200_func() -> None:
         pass
 
-    responses = generate_openapi_spec()["paths"]["/response-model-default-200"]["get"]["responses"]
+    responses = generate_openapi_spec(route_prefix="")["paths"]["/response-model-default-200"][
+        "get"
+    ]["responses"]
     assert "200" in responses
     assert responses["200"]["description"] == "Successful Response"
     assert responses["200"]["content"]["application/json"]["schema"] == {
@@ -327,7 +333,9 @@ def test_response_model_uses_explicit_200_when_declared() -> None:
     def response_model_explicit_200_func() -> None:
         pass
 
-    responses = generate_openapi_spec()["paths"]["/response-model-explicit-200"]["get"]["responses"]
+    responses = generate_openapi_spec(route_prefix="")["paths"]["/response-model-explicit-200"][
+        "get"
+    ]["responses"]
     assert responses["200"]["description"] == "OK"
     assert responses["200"]["content"]["application/json"]["schema"] == {
         "$ref": "#/components/schemas/Explicit200Model"
@@ -372,7 +380,7 @@ def test_generate_openapi_spec_with_cookie_parameter() -> None:
     def cookie_test() -> None:
         pass
 
-    params = generate_openapi_spec()["paths"]["/cookie_test"]["get"]["parameters"]
+    params = generate_openapi_spec(route_prefix="")["paths"]["/cookie_test"]["get"]["parameters"]
     cookie_param = next(p for p in params if p["in"] == "cookie")
     assert cookie_param["name"] == "session_id"
 
@@ -387,7 +395,7 @@ def test_generate_openapi_spec_with_security() -> None:
     def secure_endpoint() -> None:
         pass
 
-    op = generate_openapi_spec()["paths"]["/secure"]["get"]
+    op = generate_openapi_spec(route_prefix="")["paths"]["/secure"]["get"]
     assert op["security"] == [{"BearerAuth": []}]
 
 
@@ -404,7 +412,9 @@ def test_generate_openapi_spec_adds_default_200_response_when_missing() -> None:
     def default_response_func() -> None:
         pass
 
-    responses = generate_openapi_spec()["paths"]["/default-response"]["post"]["responses"]
+    responses = generate_openapi_spec(route_prefix="")["paths"]["/default-response"]["post"][
+        "responses"
+    ]
     assert responses["200"] == {
         "description": "Successful Response",
         "content": {"application/json": {"schema": {"type": "object"}}},
@@ -421,7 +431,9 @@ def test_generate_openapi_spec_keeps_explicit_non_200_responses_without_adding_2
     def created_response_func() -> None:
         pass
 
-    responses = generate_openapi_spec()["paths"]["/created-response"]["post"]["responses"]
+    responses = generate_openapi_spec(route_prefix="")["paths"]["/created-response"]["post"][
+        "responses"
+    ]
     assert "200" not in responses
     assert responses["201"] == {"description": "Created"}
 
@@ -440,6 +452,7 @@ def test_generate_openapi_spec_with_security_schemes_param() -> None:
 
     spec = generate_openapi_spec(
         security_schemes={"BearerAuth": {"type": "http", "scheme": "bearer"}},
+        route_prefix="",
     )
     assert "components" in spec
     assert "securitySchemes" in spec["components"]
@@ -464,7 +477,7 @@ def test_generate_openapi_spec_with_decorator_security_scheme() -> None:
     def secure_decorator_endpoint() -> None:
         pass
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     assert "components" in spec
     assert "securitySchemes" in spec["components"]
     assert spec["components"]["securitySchemes"]["ApiKeyAuth"] == {
@@ -499,6 +512,7 @@ def test_generate_openapi_spec_merges_security_schemes() -> None:
 
     spec = generate_openapi_spec(
         security_schemes={"BearerAuth": {"type": "http", "scheme": "bearer"}},
+        route_prefix="",
     )
     schemes = spec["components"]["securitySchemes"]
     assert "BearerAuth" in schemes
@@ -545,7 +559,7 @@ def test_response_model_with_content_not_dict() -> None:
     def content_not_dict_func() -> None:
         pass
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     resp_200 = spec["paths"]["/content-not-dict"]["get"]["responses"]["200"]
     assert resp_200["description"] == "OK"
     # content should have been replaced with a proper dict containing the schema
@@ -576,7 +590,7 @@ def test_response_model_with_json_content_not_dict() -> None:
     def json_content_not_dict_func() -> None:
         pass
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     resp_200 = spec["paths"]["/json-content-not-dict"]["get"]["responses"]["200"]
     json_content = resp_200["content"]["application/json"]
     assert isinstance(json_content, dict)
@@ -602,7 +616,7 @@ def test_response_model_schema_generation_failure_no_200() -> None:
         "model_to_schema",
         side_effect=Exception("schema generation failed"),
     ):
-        spec = generate_openapi_spec()
+        spec = generate_openapi_spec(route_prefix="")
 
     resp_200 = spec["paths"]["/schema-fail-no-200"]["get"]["responses"]["200"]
     assert resp_200["description"] == "Successful Response"
@@ -629,7 +643,7 @@ def test_response_model_schema_generation_failure_with_200() -> None:
         "model_to_schema",
         side_effect=Exception("schema generation failed"),
     ):
-        spec = generate_openapi_spec()
+        spec = generate_openapi_spec(route_prefix="")
 
     # Since 200 already exists, the fallback shouldn't overwrite it (L138 check)
     resp_200 = spec["paths"]["/schema-fail-with-200"]["get"]["responses"]["200"]
@@ -667,7 +681,7 @@ def test_malformed_registry_entry_skipped() -> None:
         "get_openapi_registry",
         return_value=malformed_registry,
     ):
-        spec = generate_openapi_spec()
+        spec = generate_openapi_spec(route_prefix="")
 
     # Valid endpoint should still be present
     assert "/valid-endpoint" in spec["paths"]
@@ -717,7 +731,7 @@ def test_security_scheme_collision_raises_value_error() -> None:
         return_value=conflicting,
     ):
         with pytest.raises(ValueError, match="Conflicting security scheme definition"):
-            generate_openapi_spec()
+            generate_openapi_spec(route_prefix="")
 
 
 def test_generate_openapi_spec_with_delete_request_body() -> None:
@@ -733,7 +747,7 @@ def test_generate_openapi_spec_with_delete_request_body() -> None:
     def delete_with_body_func() -> None:
         pass
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     op = spec["paths"]["/items/{id}"]["delete"]
     assert "requestBody" in op
     assert op["requestBody"]["required"] is True
@@ -755,7 +769,7 @@ def test_generate_openapi_spec_request_body_required_false() -> None:
     def optional_body_spec_func() -> None:
         pass
 
-    spec = generate_openapi_spec()
+    spec = generate_openapi_spec(route_prefix="")
     rb = spec["paths"]["/optional-body-spec"]["post"]["requestBody"]
     assert rb["required"] is False
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -6,8 +6,13 @@ from unittest.mock import patch
 
 from pydantic import BaseModel
 import pytest
+import yaml
 
-from azure_functions_openapi.decorator import openapi
+from azure_functions_openapi.decorator import (
+    clear_openapi_registry,
+    openapi,
+    register_openapi_metadata,
+)
 from azure_functions_openapi.openapi import (
     DEFAULT_OPENAPI_INFO_DESCRIPTION,
     _ensure_default_response,
@@ -870,3 +875,32 @@ def test_ensure_default_response_noop_with_non_200_entry() -> None:
     _ensure_default_response(existing)
     assert "200" not in existing
     assert "404" in existing
+
+
+def test_get_openapi_json_accepts_empty_route_prefix() -> None:
+    clear_openapi_registry()
+    register_openapi_metadata(path="/users", method="get")
+
+    spec = json.loads(get_openapi_json(route_prefix=""))
+
+    assert "/users" in spec["paths"]
+    assert "/api/users" not in spec["paths"]
+
+
+def test_get_openapi_yaml_accepts_custom_route_prefix() -> None:
+    clear_openapi_registry()
+    register_openapi_metadata(path="/users", method="get")
+
+    spec = yaml.safe_load(get_openapi_yaml(route_prefix="/v1"))
+
+    assert "/v1/users" in spec["paths"]
+    assert "/api/users" not in spec["paths"]
+
+
+def test_get_openapi_json_default_route_prefix_matches_runtime_url() -> None:
+    clear_openapi_registry()
+    register_openapi_metadata(path="/users", method="get")
+
+    spec = json.loads(get_openapi_json())
+
+    assert "/api/users" in spec["paths"]

--- a/tests/test_openapi_enhanced.py
+++ b/tests/test_openapi_enhanced.py
@@ -188,6 +188,7 @@ class TestGetOpenAPIJSONEnhanced:
                 description="Auto-generated OpenAPI documentation. "
                 "Markdown supported in descriptions (CommonMark).",
                 security_schemes=None,
+                route_prefix="/api",
             )
 
     def test_get_openapi_json_error(self) -> None:
@@ -214,6 +215,7 @@ class TestGetOpenAPIJSONEnhanced:
                 "3.0.0",
                 description="Custom description",
                 security_schemes=None,
+                route_prefix="/api",
             )
 
     def test_get_openapi_json_logging(self) -> None:
@@ -249,6 +251,7 @@ class TestGetOpenAPIYAMLEnhanced:
                 description="Auto-generated OpenAPI documentation. "
                 "Markdown supported in descriptions (CommonMark).",
                 security_schemes=None,
+                route_prefix="/api",
             )
 
     def test_get_openapi_yaml_error(self) -> None:
@@ -275,6 +278,7 @@ class TestGetOpenAPIYAMLEnhanced:
                 "3.0.0",
                 description="Custom description",
                 security_schemes=None,
+                route_prefix="/api",
             )
 
     def test_get_openapi_yaml_logging(self) -> None:

--- a/tests/test_openapi_enhanced.py
+++ b/tests/test_openapi_enhanced.py
@@ -54,7 +54,7 @@ class TestGenerateOpenAPISpecEnhanced:
         }
 
         with patch.object(OPENAPI_MODULE, "get_openapi_registry", return_value=mock_registry):
-            spec = generate_openapi_spec("Test API", "1.0.0")
+            spec = generate_openapi_spec("Test API", "1.0.0", route_prefix="")
 
             assert spec["openapi"] == "3.0.0"
             assert spec["info"]["title"] == "Test API"
@@ -85,7 +85,7 @@ class TestGenerateOpenAPISpecEnhanced:
                 # First call succeeds, second call fails
                 mock_model_to_schema.side_effect = [{"type": "object"}, Exception("Schema error")]
 
-                spec = generate_openapi_spec("Test API", "1.0.0")
+                spec = generate_openapi_spec("Test API", "1.0.0", route_prefix="")
 
                 assert spec["openapi"] == "3.0.0"
                 assert "/test" in spec["paths"]
@@ -131,7 +131,7 @@ class TestGenerateOpenAPISpecEnhanced:
         with patch.object(OPENAPI_MODULE, "get_openapi_registry", return_value=mock_registry):
             with patch.object(OPENAPI_MODULE, "logger"):
                 # Mock the processing to fail for bad_func
-                original_spec = generate_openapi_spec("Test API", "1.0.0")
+                original_spec = generate_openapi_spec("Test API", "1.0.0", route_prefix="")
 
                 # Should still generate spec for good functions
                 assert original_spec["openapi"] == "3.0.0"
@@ -331,7 +331,7 @@ class TestOpenAPISpecComplexScenarios:
                     "properties": {"name": {"type": "string"}},
                 }
 
-                spec = generate_openapi_spec("Complex API", "2.0.0")
+                spec = generate_openapi_spec("Complex API", "2.0.0", route_prefix="")
 
                 assert spec["openapi"] == "3.0.0"
                 assert spec["info"]["title"] == "Complex API"
@@ -394,7 +394,7 @@ class TestOpenAPISpecComplexScenarios:
         }
 
         with patch.object(OPENAPI_MODULE, "get_openapi_registry", return_value=mock_registry):
-            spec = generate_openapi_spec("User API", "1.0.0")
+            spec = generate_openapi_spec("User API", "1.0.0", route_prefix="")
 
             # Check that all methods are on the same path
             assert "/users/{id}" in spec["paths"]
@@ -425,7 +425,7 @@ class TestDeterministicOrdering:
             "get_openapi_registry",
             return_value=mock_registry,
         ):
-            spec = generate_openapi_spec("Test", "1.0.0")
+            spec = generate_openapi_spec("Test", "1.0.0", route_prefix="")
 
         assert list(spec["paths"].keys()) == ["/a", "/m", "/z"]
 
@@ -460,7 +460,7 @@ class TestDeterministicOrdering:
             "get_openapi_registry",
             return_value=mock_registry,
         ):
-            spec = generate_openapi_spec("Test", "1.0.0")
+            spec = generate_openapi_spec("Test", "1.0.0", route_prefix="")
 
         schema_keys = list(spec["components"]["schemas"].keys())
         assert schema_keys == sorted(schema_keys)
@@ -472,6 +472,6 @@ class TestDeterministicOrdering:
             "get_openapi_registry",
             return_value={},
         ):
-            spec = generate_openapi_spec("Test", "1.0.0")
+            spec = generate_openapi_spec("Test", "1.0.0", route_prefix="")
 
         assert spec["paths"] == {}


### PR DESCRIPTION
## Summary

Closes #193.

Three code paths construct OpenAPI `paths` keys today and only one of them (the validation bridge) injected the Azure Functions `/api` prefix. This was implicit, undocumented, and outright incorrect for any deployment whose `host.json` set a non-default `extensions.http.routePrefix`.

This PR introduces a single `route_prefix` parameter that flows through every code path that builds an OpenAPI path key, with `"/api"` as the default to match Azure Functions' default `host.json`.

## Changes

### Code

- **`scan_validation_metadata(app, route_prefix="/api")`** — the four-branch hard-coded prefix-detection logic in `_normalize_path` is replaced by a single prefix-aware composition that is idempotent against routes already containing the prefix.
- **`generate_openapi_spec(..., route_prefix="/api")`** — applied to every registry entry while assembling `spec["paths"]`, so decorator-registered routes and bridge-discovered routes end up in the same prefix space.
- **CLI** — `azure-functions-openapi generate --route-prefix /api` (same default).

Idempotency is the key safety property: authors who already write `route="/api/users"` (as the README Quick Start example does) are not double-prefixed when the spec is generated with the default `/api`.

Pass `""` for hosts that disable the prefix (`extensions.http.routePrefix: ""`) and any other value such as `"/v1"` for custom deployments. The prefix is normalized: leading slash added if missing, trailing slashes stripped.

### Tests

- New bridge tests cover default, empty, custom, double-prefix, and trailing-slash cases.
- New CLI tests verify the default, custom, and empty-string flag flow.
- Existing tests that asserted unprefixed paths now pass `route_prefix=""` to preserve their original assertion intent; default-prefix behavior is covered explicitly by the new tests.

### Docs

- New `docs/route-prefix.md` documents the policy: default, decorator-authoring guidance, custom-prefix usage for CLI and Python API, and the cross-path consistency rule.
- Linked from `docs/usage.md` and `mkdocs.yml` nav.

## Behavior change note

`generate_openapi_spec()` now applies `/api` by default. Existing apps that author routes with the prefix included (`route="/api/foo"`) are unaffected thanks to idempotency. Apps that author routes without the prefix (`route="/foo"`) will now produce `/api/foo` in the spec — which is what the deployed Function App actually serves under default `host.json`. To opt out, pass `route_prefix=""`.

## Verification

- `make lint` / `make typecheck` / `make test` / `make build` — all green locally (373 tests passed; +11 new).
