### PR TITLE
test(bridge): cover substring-trap regression for route prefix matching

### DIFF
--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -566,3 +566,36 @@ def test_scan_normalizes_prefix_with_trailing_slash() -> None:
     scan_validation_metadata(app, route_prefix="v1/")
 
     assert "post::/v1/users" in get_openapi_registry()
+
+
+def test_scan_does_not_treat_substring_match_as_already_prefixed() -> None:
+    """A route like ``/apiary`` shares ``/api`` as a prefix string but is not
+    actually under the ``/api`` route prefix. The composer must require the
+    prefix be followed by ``/`` (or be an exact match) before treating the
+    route as already prefixed; otherwise ``/apiary`` would be left bare and
+    the deployed URL ``/api/apiary`` would not appear in the spec.
+    """
+    app = _make_app(route="/apiary", metadata={"body": CreateBody})
+
+    scan_validation_metadata(app, route_prefix="/api")
+
+    assert "post::/api/apiary" in get_openapi_registry()
+    assert "post::/apiary" not in get_openapi_registry()
+
+
+def test_scan_does_not_treat_apidocs_as_already_prefixed() -> None:
+    app = _make_app(route="/apidocs", metadata={"body": CreateBody})
+
+    scan_validation_metadata(app, route_prefix="/api")
+
+    assert "post::/api/apidocs" in get_openapi_registry()
+    assert "post::/apidocs" not in get_openapi_registry()
+
+
+def test_scan_treats_exact_prefix_match_as_already_prefixed() -> None:
+    app = _make_app(route="/api", metadata={"body": CreateBody})
+
+    scan_validation_metadata(app, route_prefix="/api")
+
+    assert "post::/api" in get_openapi_registry()
+    assert "post::/api/api" not in get_openapi_registry()


### PR DESCRIPTION
## Summary

Closes #192.

#193 already collapsed the four sequential \`/api\` checks in \`_normalize_path\` into a single prefix composition that correctly requires the prefix be followed by \`/\` (or be an exact match) before treating a route as already prefixed. That fixes the dead-code structure #192 reported, but the *correctness invariant* — the substring trap that #192 explicitly called out (\`/apiary\` must NOT be treated as already-prefixed) — was not pinned by a test. A future contributor simplifying the predicate back to a bare \`startswith(prefix)\` would silently regress.

This PR adds three regression tests against \`scan_validation_metadata\`:

- \`/apiary\` with prefix \`/api\` → \`/api/apiary\` (substring trap)
- \`/apidocs\` with prefix \`/api\` → \`/api/apidocs\` (substring trap)
- \`/api\` itself with prefix \`/api\` → \`/api\` (exact-match idempotency)

No production code changes; the current implementation already passes all three.

## Verification

- \`make lint\` / \`make typecheck\` / \`make test\` / \`make build\` — all green locally (376 tests passed; +3 new).