### PR TITLE
feat(cli): expose --description option for generated OpenAPI info

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -85,10 +85,13 @@ azure-functions-openapi generate --app function_app --pretty --output openapi.js
 | `--app` | - | `module` or `module:var` | - | Import module before generating so `@openapi` decorators register routes |
 | `--title` | - | any string | `API` | OpenAPI `info.title` |
 | `--version` | - | any string | `1.0.0` | OpenAPI `info.version` |
+| `--description` | - | any string | library default | OpenAPI `info.description` (Markdown / CommonMark supported) |
 | `--output` | `-o` | file path | stdout | Write generated content to file |
 | `--format` | `-f` | `json`, `yaml` | `json` | Output serialization format |
 | `--openapi-version` | - | `3.0`, `3.1` | `3.0` | OpenAPI schema version |
 | `--pretty` | `-p` | flag | `false` | Pretty-print JSON output (adds indentation); no effect on YAML |
+| `--route-prefix` | - | any string (or `""`) | `/api` | HTTP route prefix from `host.json` `extensions.http.routePrefix`. See [Route Prefix](route-prefix.md). |
+| `--fail-on-empty-paths` | - | flag | `false` | Exit with code 1 if the generated spec has no paths |
 
 ## Exit codes
 

--- a/src/azure_functions_openapi/cli.py
+++ b/src/azure_functions_openapi/cli.py
@@ -155,8 +155,6 @@ def handle_generate(args: argparse.Namespace) -> int:
             OPENAPI_VERSION_3_1 if args.openapi_version == "3.1" else OPENAPI_VERSION_3_0
         )
 
-        # Check for empty paths before serialising — gives a clear signal
-        # instead of silently producing a spec with no routes.
         description = getattr(args, "description", None)
         if not isinstance(description, str):
             description = DEFAULT_OPENAPI_INFO_DESCRIPTION
@@ -168,6 +166,8 @@ def handle_generate(args: argparse.Namespace) -> int:
             description=description,
             route_prefix=getattr(args, "route_prefix", "/api"),
         )
+        # Check for empty paths before serialising — gives a clear signal
+        # instead of silently producing a spec with no routes.
         if not spec.get("paths"):
             print(
                 "Warning: No routes found in the OpenAPI registry. "

--- a/src/azure_functions_openapi/cli.py
+++ b/src/azure_functions_openapi/cli.py
@@ -8,6 +8,7 @@ import sys
 
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
 from azure_functions_openapi.openapi import (
+    DEFAULT_OPENAPI_INFO_DESCRIPTION,
     OPENAPI_VERSION_3_0,
     OPENAPI_VERSION_3_1,
     generate_openapi_spec,
@@ -80,6 +81,14 @@ Examples:
     )
     generate_parser.add_argument("--title", default="API", help="API title (default: API)")
     generate_parser.add_argument("--version", default="1.0.0", help="API version (default: 1.0.0)")
+    generate_parser.add_argument(
+        "--description",
+        default=None,
+        help=(
+            "API description placed in info.description (Markdown supported, "
+            "CommonMark). When omitted, the library default is used."
+        ),
+    )
     generate_parser.add_argument("--output", "-o", help="Output file path")
     generate_parser.add_argument(
         "--format",
@@ -148,10 +157,15 @@ def handle_generate(args: argparse.Namespace) -> int:
 
         # Check for empty paths before serialising — gives a clear signal
         # instead of silently producing a spec with no routes.
+        description = getattr(args, "description", None)
+        if not isinstance(description, str):
+            description = DEFAULT_OPENAPI_INFO_DESCRIPTION
+
         spec = generate_openapi_spec(
             args.title,
             args.version,
             openapi_version,
+            description=description,
             route_prefix=getattr(args, "route_prefix", "/api"),
         )
         if not spec.get("paths"):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -740,3 +740,67 @@ class TestRoutePrefix:
 
         _, kwargs = mock_gen.call_args
         assert kwargs.get("route_prefix") == ""
+
+
+class TestDescription:
+    def test_description_default_uses_library_default(self) -> None:
+        from azure_functions_openapi.openapi import DEFAULT_OPENAPI_INFO_DESCRIPTION
+
+        with mock.patch.object(sys, "argv", ["azure-functions-openapi", "generate"]):
+            with mock.patch("azure_functions_openapi.cli.generate_openapi_spec") as mock_gen:
+                mock_gen.return_value = {"paths": {"/api/users": {}}}
+                with mock.patch("builtins.print"):
+                    main()
+
+        _, kwargs = mock_gen.call_args
+        assert kwargs.get("description") == DEFAULT_OPENAPI_INFO_DESCRIPTION
+
+    def test_description_flag_passes_value(self) -> None:
+        with mock.patch.object(
+            sys,
+            "argv",
+            [
+                "azure-functions-openapi",
+                "generate",
+                "--description",
+                "Custom CLI description with **markdown**",
+            ],
+        ):
+            with mock.patch("azure_functions_openapi.cli.generate_openapi_spec") as mock_gen:
+                mock_gen.return_value = {"paths": {"/api/users": {}}}
+                with mock.patch("builtins.print"):
+                    main()
+
+        _, kwargs = mock_gen.call_args
+        assert kwargs.get("description") == "Custom CLI description with **markdown**"
+
+    def test_description_appears_in_generated_output(self) -> None:
+        from azure_functions_openapi.decorator import (
+            clear_openapi_registry,
+            register_openapi_metadata,
+        )
+
+        clear_openapi_registry()
+        register_openapi_metadata(path="/users", method="get")
+
+        captured: list[str] = []
+
+        def _capture(*args: object, **_kw: object) -> None:
+            captured.append(" ".join(str(x) for x in args))
+
+        with mock.patch.object(
+            sys,
+            "argv",
+            [
+                "azure-functions-openapi",
+                "generate",
+                "--description",
+                "Spec for the Users API",
+            ],
+        ):
+            with mock.patch("builtins.print", side_effect=_capture):
+                rc = main()
+
+        assert rc == 0
+        joined = "\n".join(captured)
+        assert "Spec for the Users API" in joined


### PR DESCRIPTION
## Summary

Closes #190.

\`generate_openapi_spec()\` already accepts a \`description\` argument that populates \`info.description\` in the generated document. The CLI did not expose it, so CLI-generated specs always carried the library default and could not match programmatic output produced by callers that pass a custom description.

## Changes

### Code

- \`src/azure_functions_openapi/cli.py\`: add \`--description\` to the \`generate\` subparser; forward it to \`generate_openapi_spec(..., description=...)\`. When the flag is omitted, the existing \`DEFAULT_OPENAPI_INFO_DESCRIPTION\` is used so output is unchanged for current callers. The fallback uses an explicit \`isinstance(str)\` guard so a \`mock.Mock()\` args namespace (the dominant pattern in this repo's existing CLI tests) does not leak a Mock object into the spec generator.

### Tests

- \`tests/test_cli.py::TestDescription\`:
  - default falls back to \`DEFAULT_OPENAPI_INFO_DESCRIPTION\`.
  - \`--description "..."\` is forwarded to \`generate_openapi_spec\`.
  - End-to-end: \`--description\` text appears in the printed spec output.

### Docs

- \`docs/cli.md\`: document \`--description\`. Also document the previously-undocumented \`--route-prefix\` and \`--fail-on-empty-paths\` flags so the table matches the implementation (drive-by; both already exist in the parser but were missing from the table).

## Verification

- \`make lint\` / \`make typecheck\` / \`make test\` / \`make build\` — all green locally (379 tests passed; +3 new).