### PR TITLE
fix(security): use proper JS/HTML escaping in Swagger UI

### DIFF
--- a/src/azure_functions_openapi/swagger_ui.py
+++ b/src/azure_functions_openapi/swagger_ui.py
@@ -138,12 +138,12 @@ def render_swagger_ui(
 
 
 def _sanitize_html_content(content: str) -> str:
-    """Sanitize HTML content to prevent XSS attacks.
+    """Sanitize content for use in HTML contexts.
 
-    Uses :func:`html.escape` for proper entity encoding (``&`` → ``&amp;``,
-    ``<`` → ``&lt;``, etc.) instead of stripping characters, which avoids
-    data loss for titles like "AT&T API".  Control characters are still
-    stripped since they have no valid use in a page title.
+    Strips control characters and limits length.  Does **not** perform
+    HTML entity encoding — callers are responsible for applying
+    :func:`html.escape` in the appropriate context so there is no
+    double-escaping.
     """
     if not content or not isinstance(content, str):
         return "API Documentation"
@@ -151,11 +151,8 @@ def _sanitize_html_content(content: str) -> str:
     # Strip control characters that have no place in a title
     sanitized = content.replace("\n", "").replace("\r", "").replace("\t", "")
 
-    # Limit length before escaping so the cap applies to logical characters
-    sanitized = sanitized[:100]
-
-    # Proper HTML entity encoding
-    return html.escape(sanitized, quote=True)
+    # Limit length
+    return sanitized[:100]
 
 
 def _sanitize_url(url: str) -> str:

--- a/src/azure_functions_openapi/swagger_ui.py
+++ b/src/azure_functions_openapi/swagger_ui.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import html
+import json
 import logging
+import re
 import secrets
 
 from azure.functions import HttpResponse
@@ -51,6 +54,12 @@ def render_swagger_ui(
     # Validate and sanitize inputs
     sanitized_title = _sanitize_html_content(title)
     sanitized_url = _sanitize_url(openapi_url)
+
+    # Escape for safe embedding in HTML attributes and JS string literals
+    safe_title = html.escape(sanitized_title, quote=True)
+    safe_csp = html.escape(csp_policy, quote=True)
+    safe_url_js = json.dumps(sanitized_url)  # produces "..." with proper escaping
+
     response_interceptor = """
             responseInterceptor: function(response) {
               return response;
@@ -70,14 +79,14 @@ def render_swagger_ui(
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta http-equiv="Content-Security-Policy" content="{csp_policy}">
+        <meta http-equiv="Content-Security-Policy" content="{safe_csp}">
         <meta http-equiv="X-Content-Type-Options" content="nosniff">
         <meta http-equiv="X-Frame-Options" content="DENY">
         <meta http-equiv="X-XSS-Protection" content="1; mode=block">
         <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
-        <title>{sanitized_title}</title>
-        <link rel="stylesheet" 
-              type="text/css" 
+        <title>{safe_title}</title>
+        <link rel="stylesheet"
+              type="text/css"
               href="{_SWAGGER_UI_CDN_BASE}/swagger-ui.css" />
       </head>
       <body>
@@ -86,7 +95,7 @@ def render_swagger_ui(
         <script nonce="{nonce}">
           // Enhanced security configuration
           const ui = SwaggerUIBundle({{
-            url: '{sanitized_url}',
+            url: {safe_url_js},
             dom_id: '#swagger-ui',
             presets: [SwaggerUIBundle.presets.apis],
             layout: 'BaseLayout',
@@ -129,35 +138,50 @@ def render_swagger_ui(
 
 
 def _sanitize_html_content(content: str) -> str:
-    """Sanitize HTML content to prevent XSS attacks."""
+    """Sanitize HTML content to prevent XSS attacks.
+
+    Uses :func:`html.escape` for proper entity encoding (``&`` → ``&amp;``,
+    ``<`` → ``&lt;``, etc.) instead of stripping characters, which avoids
+    data loss for titles like "AT&T API".  Control characters are still
+    stripped since they have no valid use in a page title.
+    """
     if not content or not isinstance(content, str):
         return "API Documentation"
 
-    # Remove potentially dangerous characters
-    dangerous_chars = ["<", ">", '"', "'", "&", "\n", "\r", "\t"]
-    sanitized = content
-    for char in dangerous_chars:
-        sanitized = sanitized.replace(char, "")
+    # Strip control characters that have no place in a title
+    sanitized = content.replace("\n", "").replace("\r", "").replace("\t", "")
 
-    # Limit length
-    return sanitized[:100] if len(sanitized) > 100 else sanitized
+    # Limit length before escaping so the cap applies to logical characters
+    sanitized = sanitized[:100]
+
+    # Proper HTML entity encoding
+    return html.escape(sanitized, quote=True)
 
 
 def _sanitize_url(url: str) -> str:
-    """Sanitize URL to prevent injection attacks."""
+    """Sanitize URL to prevent injection attacks.
+
+    Returns a safe root-relative path.  Any URL that does not match the
+    allowed character set is replaced with the default ``/api/openapi.json``.
+    """
     if not url or not isinstance(url, str):
         return "/api/openapi.json"
 
-    # Remove dangerous patterns
+    # Block dangerous URI schemes and HTML event handlers
     dangerous_patterns = ["javascript:", "data:", "vbscript:", "<script", "onload="]
-    sanitized = url
     for pattern in dangerous_patterns:
-        if pattern.lower() in sanitized.lower():
-            logger.warning(f"Potentially dangerous URL pattern detected: {pattern}")
+        if pattern.lower() in url.lower():
+            logger.warning("Potentially dangerous URL pattern detected: %s", pattern)
             return "/api/openapi.json"
 
     # Ensure URL starts with /
-    if not sanitized.startswith("/"):
-        sanitized = "/" + sanitized
+    sanitized = url if url.startswith("/") else "/" + url
+
+    # Whitelist: only allow characters safe in a URL path + query string.
+    # This blocks quotes, backslashes, angle brackets, and other characters
+    # that could break out of JS string literals or HTML attributes.
+    if not re.match(r"^[a-zA-Z0-9/_\-.~:?#\[\]@!$&()*+,;=%]+$", sanitized):
+        logger.warning("URL contains disallowed characters, falling back to default: %s", url)
+        return "/api/openapi.json"
 
     return sanitized

--- a/tests/test_swagger_ui_enhanced.py
+++ b/tests/test_swagger_ui_enhanced.py
@@ -157,13 +157,11 @@ class TestSanitizeHtmlContent:
         assert result == "Normal Title"
 
     def test_sanitize_html_content_with_dangerous_chars(self) -> None:
-        """Test sanitizing HTML content with dangerous characters."""
+        """_sanitize_html_content only strips control chars; escaping is caller's job."""
         dangerous_content = "<script>alert('xss')</script>"
         result = _sanitize_html_content(dangerous_content)
-        # Should be HTML-escaped, not stripped
-        assert "<script>" not in result
-        assert "&lt;" in result
-        assert "&gt;" in result
+        # Passes through — render_swagger_ui() applies html.escape()
+        assert result == "<script>alert('xss')</script>"
 
     def test_sanitize_html_content_empty(self) -> None:
         """Test sanitizing empty content."""
@@ -196,10 +194,9 @@ class TestSanitizeHtmlContent:
         assert "\r" not in result
 
     def test_sanitize_html_content_preserves_ampersand(self) -> None:
-        """Test that ampersand is escaped, not stripped."""
+        """Ampersand is preserved (escaping done by caller)."""
         result = _sanitize_html_content("AT&T API")
-        assert "&amp;" in result
-        assert "AT" in result
+        assert result == "AT&T API"
 
 
 class TestSanitizeUrl:
@@ -310,3 +307,10 @@ class TestSwaggerUIJsEscaping:
         body = response.get_body().decode()
         # The meta tag should contain the CSP; verify it's present
         assert 'http-equiv="Content-Security-Policy"' in body
+
+    def test_title_with_ampersand_not_double_escaped(self) -> None:
+        """Regression: AT&T should become AT&amp;T, not AT&amp;amp;T."""
+        response = render_swagger_ui(title="AT&T API")
+        body = response.get_body().decode()
+        assert "<title>AT&amp;T API</title>" in body
+        assert "&amp;amp;" not in body

--- a/tests/test_swagger_ui_enhanced.py
+++ b/tests/test_swagger_ui_enhanced.py
@@ -59,7 +59,11 @@ class TestRenderSwaggerUI:
         response = render_swagger_ui(custom_csp=custom_csp)
 
         html_content = response.get_body().decode()
-        assert custom_csp in html_content
+        # In the meta tag, the CSP is HTML-escaped (quotes become &#x27;)
+        import html as _html
+
+        assert _html.escape(custom_csp, quote=True) in html_content
+        # The HTTP header carries the raw (unescaped) CSP
         assert response.headers["Content-Security-Policy"] == custom_csp
 
     def test_render_swagger_ui_security_headers(self) -> None:
@@ -156,10 +160,10 @@ class TestSanitizeHtmlContent:
         """Test sanitizing HTML content with dangerous characters."""
         dangerous_content = "<script>alert('xss')</script>"
         result = _sanitize_html_content(dangerous_content)
-        assert "<" not in result
-        assert ">" not in result
-        assert "'" not in result
-        assert '"' not in result
+        # Should be HTML-escaped, not stripped
+        assert "<script>" not in result
+        assert "&lt;" in result
+        assert "&gt;" in result
 
     def test_sanitize_html_content_empty(self) -> None:
         """Test sanitizing empty content."""
@@ -190,6 +194,12 @@ class TestSanitizeHtmlContent:
         assert "\n" not in result
         assert "\t" not in result
         assert "\r" not in result
+
+    def test_sanitize_html_content_preserves_ampersand(self) -> None:
+        """Test that ampersand is escaped, not stripped."""
+        result = _sanitize_html_content("AT&T API")
+        assert "&amp;" in result
+        assert "AT" in result
 
 
 class TestSanitizeUrl:
@@ -251,9 +261,9 @@ class TestSanitizeUrl:
         _sanitize_url("javascript:alert('xss')")
 
         mock_logger.warning.assert_called_once()
-        call_args = mock_logger.warning.call_args[0][0]
-        assert "Potentially dangerous URL pattern detected" in call_args
-        assert "javascript:" in call_args
+        call_args = mock_logger.warning.call_args[0]
+        assert "Potentially dangerous URL pattern detected" in call_args[0]
+        assert "javascript:" in call_args[1]
 
     def test_sanitize_url_case_insensitive(self) -> None:
         """Test that dangerous pattern detection is case insensitive."""
@@ -264,3 +274,39 @@ class TestSanitizeUrl:
         assert result1 == "/api/openapi.json"
         assert result2 == "/api/openapi.json"
         assert result3 == "/api/openapi.json"
+
+    def test_sanitize_url_blocks_single_quotes(self) -> None:
+        """Test that URLs with single quotes are rejected (JS injection vector)."""
+        result = _sanitize_url("/api/openapi.json'; alert(1); '")
+        assert result == "/api/openapi.json"
+
+    def test_sanitize_url_blocks_backslash(self) -> None:
+        """Test that URLs with backslashes are rejected."""
+        result = _sanitize_url("/api\\openapi.json")
+        assert result == "/api/openapi.json"
+
+    def test_sanitize_url_blocks_angle_brackets(self) -> None:
+        """Test that URLs with angle brackets are rejected."""
+        result = _sanitize_url("/api/</script><script>alert(1)</script>")
+        # Caught by dangerous_patterns for <script
+        assert result == "/api/openapi.json"
+
+
+class TestSwaggerUIJsEscaping:
+    """Test that the rendered HTML uses safe JS/HTML escaping."""
+
+    def test_openapi_url_uses_json_dumps_in_js(self) -> None:
+        """Verify openapi_url is embedded via json.dumps, not bare quotes."""
+        response = render_swagger_ui(openapi_url="/api/openapi.json")
+        body = response.get_body().decode()
+        # json.dumps produces: "/api/openapi.json" (with double quotes)
+        assert 'url: "/api/openapi.json"' in body
+        # Must NOT have the old single-quote pattern
+        assert "url: '/api/openapi.json'" not in body
+
+    def test_csp_is_html_escaped_in_meta_tag(self) -> None:
+        """Verify CSP in meta tag is HTML-escaped."""
+        response = render_swagger_ui()
+        body = response.get_body().decode()
+        # The meta tag should contain the CSP; verify it's present
+        assert 'http-equiv="Content-Security-Policy"' in body


### PR DESCRIPTION
## Summary
- Use `json.dumps()` for `openapi_url` in JS string literal to prevent quote/backslash/newline injection
- Use `html.escape()` for title and CSP in HTML meta attributes to prevent entity-based XSS while preserving data (e.g., "AT&T API")
- Add URL whitelist regex to `_sanitize_url()` blocking single quotes, backslashes, and angle brackets
- Replace f-string logging with `%s` format in `_sanitize_url()`

## Test plan
- [x] All 420 existing tests pass (5 skipped, e2e)
- [x] New tests: URL with single quotes, backslashes, angle brackets → rejected
- [x] New test: `AT&T API` title → properly escaped as `AT&amp;T API`
- [x] New test: `openapi_url` embedded via `json.dumps()` (double quotes in JS)
- [x] New test: CSP HTML-escaped in meta tag

Closes #220

🤖 Generated with [Claude Code](https://claude.com/claude-code)