### PR TITLE
fix(spec): convert Pydantic v2 schemas to OpenAPI 3.0 format

### DIFF
--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -52,6 +52,99 @@ def _ensure_default_response(
     }
 
 
+def _convert_anyof_null_to_nullable(schema: dict[str, Any]) -> dict[str, Any]:
+    """Convert Pydantic v2 ``anyOf`` nullable patterns to OpenAPI 3.0 ``nullable``.
+
+    Pydantic v2 emits ``{"anyOf": [{"type": "string"}, {"type": "null"}]}``
+    for ``Optional[str]``.  OpenAPI 3.0 represents this as
+    ``{"type": "string", "nullable": true}``.
+
+    Only converts the pattern when *exactly* two elements are present and one
+    of them is ``{"type": "null"}``.  More complex unions are left unchanged.
+    """
+    result = schema.copy()
+    any_of = result.get("anyOf")
+    if not isinstance(any_of, list) or len(any_of) != 2:
+        return result
+
+    null_entries = [s for s in any_of if isinstance(s, dict) and s.get("type") == "null"]
+    non_null_entries = [s for s in any_of if isinstance(s, dict) and s.get("type") != "null"]
+
+    if len(null_entries) == 1 and len(non_null_entries) == 1:
+        non_null = non_null_entries[0]
+        del result["anyOf"]
+        result.update(non_null)
+        result["nullable"] = True
+
+    return result
+
+
+def _convert_schema_to_3_0(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively downgrade a JSON Schema 2020-12 / OpenAPI 3.1 schema to 3.0.
+
+    Handles:
+    - ``anyOf: [{type: T}, {type: null}]`` → ``{type: T, nullable: true}``
+    - ``type: [T, "null"]`` array → ``{type: T, nullable: true}``
+    - ``examples`` array → ``example`` (first element)
+    - ``const`` → ``enum: [value]``
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    result = _convert_anyof_null_to_nullable(schema)
+
+    # type: ["string", "null"] → {type: "string", nullable: true}
+    type_val = result.get("type")
+    if isinstance(type_val, list):
+        non_null = [t for t in type_val if t != "null"]
+        has_null = "null" in type_val
+        if len(non_null) == 1:
+            result["type"] = non_null[0]
+            if has_null:
+                result["nullable"] = True
+        elif len(non_null) == 0 and has_null:
+            result["type"] = "string"
+            result["nullable"] = True
+
+    # examples → example (3.0 uses singular)
+    if "examples" in result and "example" not in result:
+        examples = result.pop("examples")
+        if isinstance(examples, list) and examples:
+            result["example"] = examples[0]
+
+    # const → enum (3.0 doesn't have const)
+    if "const" in result:
+        result["enum"] = [result.pop("const")]
+
+    # Recurse into nested structures
+    if "properties" in result:
+        result["properties"] = {
+            k: _convert_schema_to_3_0(v) for k, v in result["properties"].items()
+        }
+
+    if "items" in result:
+        result["items"] = _convert_schema_to_3_0(result["items"])
+
+    if "allOf" in result:
+        result["allOf"] = [_convert_schema_to_3_0(s) for s in result["allOf"]]
+
+    if "anyOf" in result:
+        result["anyOf"] = [_convert_schema_to_3_0(s) for s in result["anyOf"]]
+
+    if "oneOf" in result:
+        result["oneOf"] = [_convert_schema_to_3_0(s) for s in result["oneOf"]]
+
+    if "additionalProperties" in result and isinstance(result["additionalProperties"], dict):
+        result["additionalProperties"] = _convert_schema_to_3_0(result["additionalProperties"])
+
+    return result
+
+
+def _convert_schemas_to_3_0(schemas: dict[str, Any]) -> dict[str, Any]:
+    """Convert all schemas in components to OpenAPI 3.0 format."""
+    return {name: _convert_schema_to_3_0(schema) for name, schema in schemas.items()}
+
+
 def _convert_nullable_to_type_array(schema: dict[str, Any]) -> dict[str, Any]:
     """Convert OpenAPI 3.0 nullable to 3.1 type array syntax."""
     result = schema.copy()
@@ -282,7 +375,9 @@ def generate_openapi_spec(
             components["securitySchemes"] = all_security_schemes
 
         if components.get("schemas"):
-            if openapi_version == OPENAPI_VERSION_3_1:
+            if openapi_version == OPENAPI_VERSION_3_0:
+                components["schemas"] = _convert_schemas_to_3_0(components["schemas"])
+            elif openapi_version == OPENAPI_VERSION_3_1:
                 components["schemas"] = _convert_schemas_to_3_1(components["schemas"])
 
         if components.get("schemas") or components.get("securitySchemes"):

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -106,10 +106,10 @@ def _convert_schema_to_3_0(schema: dict[str, Any]) -> dict[str, Any]:
             result["type"] = "string"
             result["nullable"] = True
 
-    # examples → example (3.0 uses singular)
-    if "examples" in result and "example" not in result:
+    # examples → example (3.0 uses singular; always remove examples)
+    if "examples" in result:
         examples = result.pop("examples")
-        if isinstance(examples, list) and examples:
+        if "example" not in result and isinstance(examples, list) and examples:
             result["example"] = examples[0]
 
     # const → enum (3.0 doesn't have const)

--- a/tests/snapshots/notification_request_openapi.json
+++ b/tests/snapshots/notification_request_openapi.json
@@ -104,17 +104,11 @@
             "type": "string"
           },
           "body_html": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "default": null,
             "description": "Optional HTML email body.",
-            "title": "Body Html"
+            "title": "Body Html",
+            "type": "string",
+            "nullable": true
           },
           "priority": {
             "default": "normal",
@@ -169,17 +163,11 @@
             "type": "string"
           },
           "delivered_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "default": null,
             "description": "Delivery timestamp.",
-            "title": "Delivered At"
+            "title": "Delivered At",
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [

--- a/tests/snapshots/report_jobs_openapi.json
+++ b/tests/snapshots/report_jobs_openapi.json
@@ -223,30 +223,18 @@
             "type": "integer"
           },
           "download_url": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "default": null,
             "description": "Available when status=completed.",
-            "title": "Download Url"
+            "title": "Download Url",
+            "type": "string",
+            "nullable": true
           },
           "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
             "default": null,
             "description": "Error message when status=failed.",
-            "title": "Error"
+            "title": "Error",
+            "type": "string",
+            "nullable": true
           }
         },
         "required": [

--- a/tests/test_openapi_3_1.py
+++ b/tests/test_openapi_3_1.py
@@ -5,13 +5,122 @@ import pytest
 from azure_functions_openapi.spec import (
     OPENAPI_VERSION_3_0,
     OPENAPI_VERSION_3_1,
+    _convert_anyof_null_to_nullable,
     _convert_nullable_to_type_array,
+    _convert_schema_to_3_0,
     _convert_schema_to_3_1,
+    _convert_schemas_to_3_0,
     _convert_schemas_to_3_1,
     generate_openapi_spec,
     get_openapi_json,
     get_openapi_yaml,
 )
+
+
+class TestConvertAnyOfNullToNullable:
+    """Test Pydantic v2 anyOf-null → OpenAPI 3.0 nullable conversion."""
+
+    def test_anyof_string_null(self) -> None:
+        schema = {"anyOf": [{"type": "string"}, {"type": "null"}]}
+        result = _convert_anyof_null_to_nullable(schema)
+        assert result == {"type": "string", "nullable": True}
+
+    def test_anyof_integer_null(self) -> None:
+        schema = {"anyOf": [{"type": "integer"}, {"type": "null"}]}
+        result = _convert_anyof_null_to_nullable(schema)
+        assert result == {"type": "integer", "nullable": True}
+
+    def test_anyof_null_first(self) -> None:
+        schema = {"anyOf": [{"type": "null"}, {"type": "number"}]}
+        result = _convert_anyof_null_to_nullable(schema)
+        assert result == {"type": "number", "nullable": True}
+
+    def test_anyof_three_types_not_converted(self) -> None:
+        schema = {"anyOf": [{"type": "string"}, {"type": "integer"}, {"type": "null"}]}
+        result = _convert_anyof_null_to_nullable(schema)
+        assert "anyOf" in result  # not converted — complex union
+
+    def test_anyof_no_null_not_converted(self) -> None:
+        schema = {"anyOf": [{"type": "string"}, {"type": "integer"}]}
+        result = _convert_anyof_null_to_nullable(schema)
+        assert "anyOf" in result
+
+    def test_no_anyof(self) -> None:
+        schema = {"type": "string"}
+        result = _convert_anyof_null_to_nullable(schema)
+        assert result == {"type": "string"}
+
+    def test_preserves_extra_keys(self) -> None:
+        schema = {"anyOf": [{"type": "string"}, {"type": "null"}], "default": None, "title": "X"}
+        result = _convert_anyof_null_to_nullable(schema)
+        assert result["type"] == "string"
+        assert result["nullable"] is True
+        assert result["default"] is None
+        assert result["title"] == "X"
+        assert "anyOf" not in result
+
+
+class TestConvertSchemaTo30:
+    """Test recursive OpenAPI 3.1 → 3.0 downgrade."""
+
+    def test_anyof_nullable_in_properties(self) -> None:
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": None},
+            },
+        }
+        result = _convert_schema_to_3_0(schema)
+        prop = result["properties"]["name"]
+        assert prop["type"] == "string"
+        assert prop["nullable"] is True
+        assert "anyOf" not in prop
+
+    def test_type_array_with_null(self) -> None:
+        schema = {"type": ["string", "null"]}
+        result = _convert_schema_to_3_0(schema)
+        assert result == {"type": "string", "nullable": True}
+
+    def test_examples_to_example(self) -> None:
+        schema = {"type": "string", "examples": ["foo", "bar"]}
+        result = _convert_schema_to_3_0(schema)
+        assert result["example"] == "foo"
+        assert "examples" not in result
+
+    def test_const_to_enum(self) -> None:
+        schema = {"const": "fixed_value"}
+        result = _convert_schema_to_3_0(schema)
+        assert result == {"enum": ["fixed_value"]}
+
+    def test_nested_items(self) -> None:
+        schema = {"type": "array", "items": {"anyOf": [{"type": "string"}, {"type": "null"}]}}
+        result = _convert_schema_to_3_0(schema)
+        assert result["items"] == {"type": "string", "nullable": True}
+
+    def test_nested_allof(self) -> None:
+        schema = {"allOf": [{"anyOf": [{"type": "string"}, {"type": "null"}]}]}
+        result = _convert_schema_to_3_0(schema)
+        assert result["allOf"][0] == {"type": "string", "nullable": True}
+
+    def test_non_dict_passthrough(self) -> None:
+        result = _convert_schema_to_3_0("not a dict")  # type: ignore[arg-type]
+        assert result == "not a dict"  # type: ignore[comparison-overlap]
+
+
+class TestConvertSchemasTo30:
+    def test_converts_multiple_schemas(self) -> None:
+        schemas = {
+            "User": {
+                "type": "object",
+                "properties": {
+                    "email": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                },
+            },
+            "Item": {"type": "string", "examples": ["a"]},
+        }
+        result = _convert_schemas_to_3_0(schemas)
+        assert result["User"]["properties"]["email"] == {"type": "string", "nullable": True}
+        assert result["Item"]["example"] == "a"
 
 
 class TestConvertNullableToTypeArray:

--- a/tests/test_openapi_3_1.py
+++ b/tests/test_openapi_3_1.py
@@ -106,6 +106,13 @@ class TestConvertSchemaTo30:
         result = _convert_schema_to_3_0("not a dict")  # type: ignore[arg-type]
         assert result == "not a dict"  # type: ignore[comparison-overlap]
 
+    def test_examples_always_removed_even_when_example_exists(self) -> None:
+        """examples is invalid in 3.0 and must always be removed."""
+        schema = {"type": "string", "example": "keep", "examples": ["discard"]}
+        result = _convert_schema_to_3_0(schema)
+        assert result["example"] == "keep"
+        assert "examples" not in result
+
 
 class TestConvertSchemasTo30:
     def test_converts_multiple_schemas(self) -> None:


### PR DESCRIPTION
## Summary
- Add `_convert_schema_to_3_0()` that downgrades Pydantic v2 JSON Schema 2020-12 output to OpenAPI 3.0:
  - `anyOf: [{type: T}, {type: null}]` → `{type: T, nullable: true}`
  - `type: [T, "null"]` → `{type: T, nullable: true}`
  - `examples: [...]` → `example: first_element`
  - `const: value` → `enum: [value]`
- Apply 3.0 conversion in `generate_openapi_spec()` when target version is `3.0.0`
- Update 2 snapshot files to reflect correct 3.0 nullable format

## Background
Pydantic v2's `model_json_schema()` produces JSON Schema Draft 2020-12 output. For `Optional[str]`, it emits `anyOf: [{type: string}, {type: null}]`. This is valid in OpenAPI 3.1 but not in 3.0, which uses the `nullable: true` keyword. Since the library defaults to OpenAPI 3.0, all Pydantic models with optional fields produced invalid specs.

## Test plan
- [x] 15 new unit tests for `_convert_anyof_null_to_nullable`, `_convert_schema_to_3_0`, `_convert_schemas_to_3_0`
- [x] Updated snapshots pass
- [x] All 424 tests pass (5 skipped e2e, 6 deselected pre-existing)

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)