### PR TITLE
feat(spec): add strict mode for fail-fast on malformed entries

### DIFF
--- a/src/azure_functions_openapi/cli.py
+++ b/src/azure_functions_openapi/cli.py
@@ -119,6 +119,15 @@ Examples:
             "the prefix, or a custom value such as /v1 for a custom deployment."
         ),
     )
+    generate_parser.add_argument(
+        "--strict",
+        action="store_true",
+        default=False,
+        help=(
+            "Fail on any malformed registry entry instead of skipping it. "
+            "Recommended for CI pipelines where a missing path should break the build."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -165,6 +174,7 @@ def handle_generate(args: argparse.Namespace) -> int:
             openapi_version,
             description=description,
             route_prefix=getattr(args, "route_prefix", "/api"),
+            strict=getattr(args, "strict", False),
         )
         # Check for empty paths before serialising — gives a clear signal
         # instead of silently producing a spec with no routes.

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -112,6 +112,7 @@ def generate_openapi_spec(
     description: str = DEFAULT_OPENAPI_INFO_DESCRIPTION,
     security_schemes: dict[str, dict[str, Any]] | None = None,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
+    strict: bool = False,
 ) -> dict[str, Any]:
     """
     Compile an OpenAPI specification from the registry.
@@ -128,6 +129,9 @@ def generate_openapi_spec(
             ``""`` for hosts that disable the prefix or a custom value such
             as ``"/v1"``. Routes that already start with the prefix are not
             re-prefixed.
+        strict: When ``True``, raise on any registry entry processing failure
+            instead of logging and skipping. Useful for CI/build-time
+            validation where a missing path should fail the build.
 
     Returns:
         OpenAPI specification dictionary
@@ -244,8 +248,9 @@ def generate_openapi_spec(
                 paths.setdefault(path, {})[method] = op
 
             except (KeyError, TypeError, ValueError):
+                if strict:
+                    raise
                 logger.exception("Failed to process function %s", func_name)
-                # Continue processing other functions
                 continue
 
         spec: dict[str, Any] = {
@@ -296,7 +301,7 @@ def generate_openapi_spec(
         )
         return spec
 
-    except OpenAPISpecConfigError:
+    except (OpenAPISpecConfigError, KeyError, TypeError, ValueError):
         raise
     except Exception as e:
         logger.error(f"Failed to generate OpenAPI specification: {str(e)}")
@@ -324,6 +329,7 @@ def get_openapi_json(
     description: str = DEFAULT_OPENAPI_INFO_DESCRIPTION,
     security_schemes: dict[str, dict[str, Any]] | None = None,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
+    strict: bool = False,
 ) -> str:
     """Return the spec as pretty-printed JSON (UTF-8).
 
@@ -337,6 +343,7 @@ def get_openapi_json(
             (``extensions.http.routePrefix``). Defaults to ``"/api"``. Pass
             ``""`` for hosts that disable the prefix or a custom value such
             as ``"/v1"``.
+        strict: When ``True``, raise on any registry entry processing failure.
 
     Returns:
         OpenAPI spec in JSON format.
@@ -349,6 +356,7 @@ def get_openapi_json(
             description=description,
             security_schemes=security_schemes,
             route_prefix=route_prefix,
+            strict=strict,
         )
         return json.dumps(spec, indent=2, ensure_ascii=False)
     except OpenAPISpecConfigError:
@@ -365,6 +373,7 @@ def get_openapi_yaml(
     description: str = DEFAULT_OPENAPI_INFO_DESCRIPTION,
     security_schemes: dict[str, dict[str, Any]] | None = None,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
+    strict: bool = False,
 ) -> str:
     """Return the spec as YAML.
 
@@ -378,6 +387,7 @@ def get_openapi_yaml(
             (``extensions.http.routePrefix``). Defaults to ``"/api"``. Pass
             ``""`` for hosts that disable the prefix or a custom value such
             as ``"/v1"``.
+        strict: When ``True``, raise on any registry entry processing failure.
 
     Returns:
         OpenAPI spec in YAML format.
@@ -390,6 +400,7 @@ def get_openapi_yaml(
             description=description,
             security_schemes=security_schemes,
             route_prefix=route_prefix,
+            strict=strict,
         )
         return yaml.safe_dump(spec, sort_keys=False, allow_unicode=True)
     except OpenAPISpecConfigError:

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -249,6 +249,7 @@ def generate_openapi_spec(
 
             except (KeyError, TypeError, ValueError):
                 if strict:
+                    logger.error("Failed to process function %s (strict mode)", func_name)
                     raise
                 logger.exception("Failed to process function %s", func_name)
                 continue
@@ -301,9 +302,11 @@ def generate_openapi_spec(
         )
         return spec
 
-    except (OpenAPISpecConfigError, KeyError, TypeError, ValueError):
+    except OpenAPISpecConfigError:
         raise
     except Exception as e:
+        if strict and isinstance(e, (KeyError, TypeError, ValueError)):
+            raise
         logger.error(f"Failed to generate OpenAPI specification: {str(e)}")
         raise RuntimeError("Failed to generate OpenAPI specification") from e
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -693,6 +693,35 @@ def test_malformed_registry_entry_skipped() -> None:
     # Broken endpoint should be skipped (not crash the whole spec generation)
 
 
+def test_malformed_registry_entry_raises_in_strict_mode() -> None:
+    """In strict mode, a malformed registry entry should raise instead of being skipped."""
+    from azure_functions_openapi.decorator import get_openapi_registry
+
+    @openapi(
+        route="/valid-strict",
+        summary="Valid",
+        response={200: {"description": "OK"}},
+    )
+    def valid_strict_func() -> None:
+        pass
+
+    real_registry = get_openapi_registry()
+    malformed_registry = dict(real_registry)
+    malformed_registry["broken_strict_func"] = {
+        "route": "/broken-strict",
+        "method": "get",
+        "response": {200: 42},  # detail=42 → dict(42) raises TypeError
+    }
+
+    with patch.object(
+        OPENAPI_MODULE,
+        "get_openapi_registry",
+        return_value=malformed_registry,
+    ):
+        with pytest.raises(TypeError):
+            generate_openapi_spec(route_prefix="", strict=True)
+
+
 def test_security_scheme_collision_raises_value_error() -> None:
     """Conflicting security scheme definitions across decorators raise ValueError."""
 

--- a/tests/test_openapi_enhanced.py
+++ b/tests/test_openapi_enhanced.py
@@ -189,6 +189,7 @@ class TestGetOpenAPIJSONEnhanced:
                 "Markdown supported in descriptions (CommonMark).",
                 security_schemes=None,
                 route_prefix="/api",
+                strict=False,
             )
 
     def test_get_openapi_json_error(self) -> None:
@@ -216,6 +217,7 @@ class TestGetOpenAPIJSONEnhanced:
                 description="Custom description",
                 security_schemes=None,
                 route_prefix="/api",
+                strict=False,
             )
 
     def test_get_openapi_json_logging(self) -> None:
@@ -252,6 +254,7 @@ class TestGetOpenAPIYAMLEnhanced:
                 "Markdown supported in descriptions (CommonMark).",
                 security_schemes=None,
                 route_prefix="/api",
+                strict=False,
             )
 
     def test_get_openapi_yaml_error(self) -> None:
@@ -279,6 +282,7 @@ class TestGetOpenAPIYAMLEnhanced:
                 description="Custom description",
                 security_schemes=None,
                 route_prefix="/api",
+                strict=False,
             )
 
     def test_get_openapi_yaml_logging(self) -> None:


### PR DESCRIPTION
## Summary
- Add `strict: bool = False` parameter to `generate_openapi_spec()`, `get_openapi_json()`, `get_openapi_yaml()`
- When `strict=True`, re-raise exceptions from individual registry entry processing instead of logging and skipping
- Add `--strict` CLI flag for CI/build pipelines where a missing path should break the build
- Backward compatible: default is non-strict (existing behavior unchanged)

## Test plan
- [x] New test: `strict=True` raises `TypeError` on malformed entry
- [x] Existing test: malformed entries still skipped in non-strict mode
- [x] All 410 tests pass

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)