### PR TITLE
fix(spec): add path parameter and operationId validation

### DIFF
--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any
 
 import yaml
@@ -307,14 +308,15 @@ def generate_openapi_spec(
         raise RuntimeError("Failed to generate OpenAPI specification") from e
 
 
-_PATH_PARAM_RE = __import__("re").compile(r"\{([^}]+)\}")
+_PATH_PARAM_RE = re.compile(r"\{([^}]+)\}")
 
 
 def _validate_spec(spec: dict[str, Any]) -> list[str]:
     """Post-generation validation of the OpenAPI spec.
 
-    Returns a list of warning messages. Does **not** raise; callers decide
-    whether to log or raise based on policy (e.g. strict mode).
+    Returns a list of warning messages.  The caller (``generate_openapi_spec``)
+    currently logs them; combine with a ``strict`` parameter (see PR #224) to
+    raise ``OpenAPISpecConfigError`` when any warnings are present.
 
     Checks performed:
     - Route template variables have matching ``in: "path"`` parameters.

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -290,6 +290,10 @@ def generate_openapi_spec(
 
         spec = _normalize_spec_output(spec)
 
+        validation_warnings = _validate_spec(spec)
+        for warning in validation_warnings:
+            logger.warning("OpenAPI spec validation: %s", warning)
+
         logger.info(
             f"Generated OpenAPI {openapi_version} spec with {len(paths)} paths "
             f"for {len(registry)} functions"
@@ -301,6 +305,75 @@ def generate_openapi_spec(
     except Exception as e:
         logger.error(f"Failed to generate OpenAPI specification: {str(e)}")
         raise RuntimeError("Failed to generate OpenAPI specification") from e
+
+
+_PATH_PARAM_RE = __import__("re").compile(r"\{([^}]+)\}")
+
+
+def _validate_spec(spec: dict[str, Any]) -> list[str]:
+    """Post-generation validation of the OpenAPI spec.
+
+    Returns a list of warning messages. Does **not** raise; callers decide
+    whether to log or raise based on policy (e.g. strict mode).
+
+    Checks performed:
+    - Route template variables have matching ``in: "path"`` parameters.
+    - Path parameters have ``required: true``.
+    - ``(name, in)`` pairs are unique within each operation.
+    - ``operationId`` is unique across the whole spec.
+    """
+    warnings: list[str] = []
+    seen_operation_ids: dict[str, str] = {}  # operationId → "METHOD path"
+
+    for path, methods in spec.get("paths", {}).items():
+        template_vars = set(_PATH_PARAM_RE.findall(path))
+
+        for method, operation in methods.items():
+            op_label = f"{method.upper()} {path}"
+
+            # --- operationId uniqueness ---
+            op_id = operation.get("operationId")
+            if op_id:
+                if op_id in seen_operation_ids:
+                    warnings.append(
+                        f"Duplicate operationId '{op_id}': "
+                        f"used by {seen_operation_ids[op_id]} and {op_label}"
+                    )
+                else:
+                    seen_operation_ids[op_id] = op_label
+
+            # --- parameter validation ---
+            params = operation.get("parameters", [])
+            path_param_names: set[str] = set()
+            seen_param_keys: set[tuple[str, str]] = set()
+
+            for param in params:
+                name = param.get("name", "")
+                location = param.get("in", "")
+                key = (name, location)
+
+                if key in seen_param_keys:
+                    warnings.append(
+                        f"Duplicate parameter ({location}:{name}) in {op_label}"
+                    )
+                seen_param_keys.add(key)
+
+                if location == "path":
+                    path_param_names.add(name)
+                    if not param.get("required", False):
+                        warnings.append(
+                            f"Path parameter '{name}' in {op_label} must be required"
+                        )
+
+            # --- template var ↔ path parameter matching ---
+            missing = template_vars - path_param_names
+            for var in sorted(missing):
+                warnings.append(
+                    f"Route template variable '{{{var}}}' in {op_label} "
+                    "has no matching path parameter definition"
+                )
+
+    return warnings
 
 
 def _normalize_spec_output(spec: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -16,6 +16,7 @@ from azure_functions_openapi.decorator import (
 from azure_functions_openapi.spec import (
     DEFAULT_OPENAPI_INFO_DESCRIPTION,
     _ensure_default_response,
+    _validate_spec,
     generate_openapi_spec,
     get_openapi_json,
     get_openapi_yaml,
@@ -904,3 +905,110 @@ def test_get_openapi_json_default_route_prefix_matches_runtime_url() -> None:
     spec = json.loads(get_openapi_json())
 
     assert "/api/users" in spec["paths"]
+
+
+class TestValidateSpec:
+    """Tests for _validate_spec post-generation validation."""
+
+    def test_missing_path_parameter_definition(self) -> None:
+        spec = {
+            "paths": {
+                "/items/{id}": {
+                    "get": {
+                        "operationId": "get_item",
+                        "parameters": [],
+                    }
+                }
+            }
+        }
+        warnings = _validate_spec(spec)
+        assert any("{id}" in w and "no matching path parameter" in w for w in warnings)
+
+    def test_path_param_not_required(self) -> None:
+        spec = {
+            "paths": {
+                "/items/{id}": {
+                    "get": {
+                        "operationId": "get_item",
+                        "parameters": [
+                            {"name": "id", "in": "path", "required": False},
+                        ],
+                    }
+                }
+            }
+        }
+        warnings = _validate_spec(spec)
+        assert any("must be required" in w for w in warnings)
+
+    def test_duplicate_operation_id(self) -> None:
+        spec = {
+            "paths": {
+                "/a": {"get": {"operationId": "dup_op"}},
+                "/b": {"get": {"operationId": "dup_op"}},
+            }
+        }
+        warnings = _validate_spec(spec)
+        assert any("Duplicate operationId" in w and "dup_op" in w for w in warnings)
+
+    def test_duplicate_parameter_name_in(self) -> None:
+        spec = {
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "list_items",
+                        "parameters": [
+                            {"name": "q", "in": "query"},
+                            {"name": "q", "in": "query"},
+                        ],
+                    }
+                }
+            }
+        }
+        warnings = _validate_spec(spec)
+        assert any("Duplicate parameter" in w and "q" in w for w in warnings)
+
+    def test_valid_spec_no_warnings(self) -> None:
+        spec = {
+            "paths": {
+                "/items/{id}": {
+                    "get": {
+                        "operationId": "get_item",
+                        "parameters": [
+                            {"name": "id", "in": "path", "required": True},
+                        ],
+                    }
+                },
+                "/items": {
+                    "get": {
+                        "operationId": "list_items",
+                        "parameters": [
+                            {"name": "q", "in": "query"},
+                        ],
+                    }
+                },
+            }
+        }
+        warnings = _validate_spec(spec)
+        assert warnings == []
+
+    def test_multiple_template_vars(self) -> None:
+        spec = {
+            "paths": {
+                "/users/{user_id}/items/{item_id}": {
+                    "get": {
+                        "operationId": "get_user_item",
+                        "parameters": [
+                            {"name": "user_id", "in": "path", "required": True},
+                            # item_id missing
+                        ],
+                    }
+                }
+            }
+        }
+        warnings = _validate_spec(spec)
+        assert any("{item_id}" in w and "no matching path parameter" in w for w in warnings)
+        # user_id is provided — no "no matching" warning for it
+        assert not any(
+            "no matching path parameter" in w and "{user_id}" in w and "{item_id}" not in w
+            for w in warnings
+        )


### PR DESCRIPTION
## Summary
- Add `_validate_spec()` post-generation validation that checks:
  - Route template variables (`{id}`) have matching `in: "path"` parameter definitions
  - Path parameters have `required: true` (per OpenAPI spec requirement)
  - `(name, in)` pairs are unique within each operation
  - `operationId` is unique across all operations
- Warnings are logged via `logger.warning()` but do not fail generation (non-breaking)
- Can be combined with `--strict` (from #219) for fail-fast behavior in CI

## Test plan
- [x] 6 new tests: missing path param, path param not required, duplicate operationId, duplicate parameter, valid spec, multiple template vars
- [x] All 415 tests pass

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)