### PR TITLE
feat(decorator): auto-detect route/method from FunctionBuilder

### DIFF
--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -49,8 +49,8 @@ def _extract_binding_hints(func: Any) -> tuple[str | None, str | None]:
     """Extract route and method from a FunctionBuilder's HTTP trigger binding.
 
     Returns ``(route, method)`` where either may be ``None`` if the
-    information is not available.  Only reads the *first* method when
-    ``methods`` is a list.
+    information is not available. Only reads the first method when
+    ``methods`` is a list or tuple.
     """
     if not isinstance(func, FunctionBuilder):
         return None, None

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -45,6 +45,41 @@ def _resolve_metadata_target(func: Any) -> tuple[Any, Callable[..., Any]]:
     return func, cast(Callable[..., Any], func)
 
 
+def _extract_binding_hints(func: Any) -> tuple[str | None, str | None]:
+    """Extract route and method from a FunctionBuilder's HTTP trigger binding.
+
+    Returns ``(route, method)`` where either may be ``None`` if the
+    information is not available.  Only reads the *first* method when
+    ``methods`` is a list.
+    """
+    if not isinstance(func, FunctionBuilder):
+        return None, None
+
+    try:
+        function_obj = func._function
+        bindings = getattr(function_obj, "_bindings", [])
+    except AttributeError:
+        return None, None
+
+    for binding in bindings:
+        if str(getattr(binding, "type", "")).lower() != "httptrigger":
+            continue
+
+        binding_route = getattr(binding, "route", None)
+        methods_attr = getattr(binding, "methods", None)
+
+        binding_method: str | None = None
+        if isinstance(methods_attr, str):
+            binding_method = methods_attr.lower()
+        elif isinstance(methods_attr, (list, tuple)) and methods_attr:
+            val = methods_attr[0]
+            binding_method = str(getattr(val, "value", val)).lower()
+
+        return binding_route, binding_method
+
+    return None, None
+
+
 def openapi(
     # ── basic metadata ───────────────────────────────────────────
     summary: str = "",
@@ -173,8 +208,18 @@ def openapi(
             original_func, metadata_func = _resolve_metadata_target(func)
             target_name = f"{metadata_func.__module__}.{metadata_func.__qualname__}"
 
+            # Auto-detect route/method from FunctionBuilder bindings when
+            # not explicitly provided by the caller.
+            effective_route = route
+            effective_method = method
+            binding_route, binding_method = _extract_binding_hints(func)
+            if effective_route is None and binding_route is not None:
+                effective_route = binding_route
+            if effective_method is None and binding_method is not None:
+                effective_method = binding_method
+
             # Enhanced input validation and sanitization
-            validated_route = _validate_and_sanitize_route(route, metadata_func.__name__)
+            validated_route = _validate_and_sanitize_route(effective_route, metadata_func.__name__)
             sanitized_operation_id = _validate_and_sanitize_operation_id(
                 operation_id, metadata_func.__name__
             )
@@ -244,7 +289,7 @@ def openapi(
                     "operation_id": sanitized_operation_id,
                     # ── routing info ─────────────────────────────────────────
                     "route": validated_route,
-                    "method": method,
+                    "method": effective_method,
                     "parameters": validated_parameters,
                     "security": validated_security,
                     "security_scheme": validated_security_scheme,

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -106,6 +106,40 @@ def test_openapi_accepts_function_builder_when_decorator_is_outermost() -> None:
     assert "/hello" in spec["paths"]
 
 
+def test_openapi_auto_detects_route_and_method_from_function_builder() -> None:
+    """When @openapi omits route/method, they should be extracted from @app.route."""
+    _clear_registry()
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    @openapi(summary="Create user")
+    @app.route(route="users", methods=["POST"])
+    def create_user(req: func.HttpRequest) -> func.HttpResponse:
+        return func.HttpResponse("Created", status_code=201)
+
+    registry = get_openapi_registry()
+    assert registry["create_user"]["route"] == "users"
+    assert registry["create_user"]["method"] == "post"
+
+    spec = generate_openapi_spec(route_prefix="")
+    assert "/users" in spec["paths"]
+    assert "post" in spec["paths"]["/users"]
+
+
+def test_openapi_explicit_route_overrides_binding() -> None:
+    """Explicit route/method in @openapi should take precedence over binding."""
+    _clear_registry()
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    @openapi(summary="Custom", route="/custom-path", method="put")
+    @app.route(route="users", methods=["POST"])
+    def override_func(req: func.HttpRequest) -> func.HttpResponse:
+        return func.HttpResponse("OK", status_code=200)
+
+    registry = get_openapi_registry()
+    assert registry["override_func"]["route"] == "/custom-path"
+    assert registry["override_func"]["method"] == "put"
+
+
 def test_openapi_keeps_function_builder_chain_intact() -> None:
     _clear_registry()
     app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)


### PR DESCRIPTION
## Summary
- When `@openapi()` decorates a `FunctionBuilder` and `route`/`method` are not explicitly provided, extract them from the HTTP trigger binding (`_function._bindings`)
- Explicit values in `@openapi(route=..., method=...)` still take precedence
- Adds `_extract_binding_hints()` helper to read route and first method from bindings
- Aligns README "Before/After" examples with actual behavior

## Before
```python
@openapi(summary="Create user", route="users", method="post")  # must duplicate
@app.route(route="users", methods=["POST"])
def create_user(req): ...
```

## After
```python
@openapi(summary="Create user")  # auto-detected from @app.route
@app.route(route="users", methods=["POST"])
def create_user(req): ...
```

## Test plan
- [x] New test: auto-detects route="users" and method="post" from `@app.route`
- [x] New test: explicit `route`/`method` in `@openapi` overrides binding values
- [x] All 411 tests pass

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)