### PR TITLE
feat(spec): change default OpenAPI version to 3.1

### DIFF
--- a/src/azure_functions_openapi/cli.py
+++ b/src/azure_functions_openapi/cli.py
@@ -107,8 +107,8 @@ Examples:
     generate_parser.add_argument(
         "--openapi-version",
         choices=["3.0", "3.1"],
-        default="3.0",
-        help="OpenAPI version (default: 3.0)",
+        default="3.1",
+        help="OpenAPI version (default: 3.1)",
     )
     generate_parser.add_argument(
         "--route-prefix",

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -109,7 +109,7 @@ def _convert_schemas_to_3_1(schemas: dict[str, Any]) -> dict[str, Any]:
 def generate_openapi_spec(
     title: str = "API",
     version: str = "1.0.0",
-    openapi_version: str = OPENAPI_VERSION_3_0,
+    openapi_version: str = OPENAPI_VERSION_3_1,
     description: str = DEFAULT_OPENAPI_INFO_DESCRIPTION,
     security_schemes: dict[str, dict[str, Any]] | None = None,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
@@ -403,7 +403,7 @@ def _normalize_spec_output(spec: dict[str, Any]) -> dict[str, Any]:
 def get_openapi_json(
     title: str = "API",
     version: str = "1.0.0",
-    openapi_version: str = OPENAPI_VERSION_3_0,
+    openapi_version: str = OPENAPI_VERSION_3_1,
     description: str = DEFAULT_OPENAPI_INFO_DESCRIPTION,
     security_schemes: dict[str, dict[str, Any]] | None = None,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
@@ -447,7 +447,7 @@ def get_openapi_json(
 def get_openapi_yaml(
     title: str = "API",
     version: str = "1.0.0",
-    openapi_version: str = OPENAPI_VERSION_3_0,
+    openapi_version: str = OPENAPI_VERSION_3_1,
     description: str = DEFAULT_OPENAPI_INFO_DESCRIPTION,
     security_schemes: dict[str, dict[str, Any]] | None = None,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -66,7 +66,7 @@ def test_generate_openapi_spec_structure() -> None:
 
     spec = generate_openapi_spec(title="My API", version="1.2.3", route_prefix="")
 
-    assert spec["openapi"] == "3.0.0"
+    assert spec["openapi"] == "3.1.0"
     assert spec["info"]["title"] == "My API"
     assert spec["info"]["version"] == "1.2.3"
     assert "/sample_func" in spec["paths"]

--- a/tests/test_openapi_3_1.py
+++ b/tests/test_openapi_3_1.py
@@ -156,10 +156,10 @@ class TestConvertSchemasTo31:
 
 
 class TestGenerateOpenapiSpec:
-    def test_default_version_is_3_0(self) -> None:
+    def test_default_version_is_3_1(self) -> None:
         spec = generate_openapi_spec()
 
-        assert spec["openapi"] == "3.0.0"
+        assert spec["openapi"] == "3.1.0"
 
     def test_explicit_3_0_version(self) -> None:
         spec = generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_0)
@@ -192,10 +192,10 @@ class TestGetOpenapiJson:
         assert isinstance(result, str)
         assert '"openapi"' in result
 
-    def test_default_3_0(self) -> None:
+    def test_default_3_1(self) -> None:
         result = get_openapi_json()
 
-        assert '"3.0.0"' in result
+        assert '"3.1.0"' in result
 
     def test_3_1_version(self) -> None:
         result = get_openapi_json(openapi_version=OPENAPI_VERSION_3_1)
@@ -210,10 +210,10 @@ class TestGetOpenapiYaml:
         assert isinstance(result, str)
         assert "openapi:" in result
 
-    def test_default_3_0(self) -> None:
+    def test_default_3_1(self) -> None:
         result = get_openapi_yaml()
 
-        assert "3.0.0" in result
+        assert "3.1.0" in result
 
     def test_3_1_version(self) -> None:
         result = get_openapi_yaml(openapi_version=OPENAPI_VERSION_3_1)

--- a/tests/test_openapi_enhanced.py
+++ b/tests/test_openapi_enhanced.py
@@ -56,7 +56,7 @@ class TestGenerateOpenAPISpecEnhanced:
         with patch.object(OPENAPI_MODULE, "get_openapi_registry", return_value=mock_registry):
             spec = generate_openapi_spec("Test API", "1.0.0", route_prefix="")
 
-            assert spec["openapi"] == "3.0.0"
+            assert spec["openapi"] == "3.1.0"
             assert spec["info"]["title"] == "Test API"
             assert spec["info"]["version"] == "1.0.0"
             assert "/test" in spec["paths"]
@@ -87,7 +87,7 @@ class TestGenerateOpenAPISpecEnhanced:
 
                 spec = generate_openapi_spec("Test API", "1.0.0", route_prefix="")
 
-                assert spec["openapi"] == "3.0.0"
+                assert spec["openapi"] == "3.1.0"
                 assert "/test" in spec["paths"]
                 assert "post" in spec["paths"]["/test"]
 
@@ -134,7 +134,7 @@ class TestGenerateOpenAPISpecEnhanced:
                 original_spec = generate_openapi_spec("Test API", "1.0.0", route_prefix="")
 
                 # Should still generate spec for good functions
-                assert original_spec["openapi"] == "3.0.0"
+                assert original_spec["openapi"] == "3.1.0"
                 assert "/good" in original_spec["paths"]
                 # bad_func might be excluded due to processing error
 
@@ -184,7 +184,7 @@ class TestGetOpenAPIJSONEnhanced:
             mock_generate.assert_called_once_with(
                 "Test API",
                 "1.0.0",
-                "3.0.0",
+                "3.1.0",
                 description="Auto-generated OpenAPI documentation. "
                 "Markdown supported in descriptions (CommonMark).",
                 security_schemes=None,
@@ -213,7 +213,7 @@ class TestGetOpenAPIJSONEnhanced:
             mock_generate.assert_called_once_with(
                 "Test API",
                 "1.0.0",
-                "3.0.0",
+                "3.1.0",
                 description="Custom description",
                 security_schemes=None,
                 route_prefix="/api",
@@ -249,7 +249,7 @@ class TestGetOpenAPIYAMLEnhanced:
             mock_generate.assert_called_once_with(
                 "Test API",
                 "1.0.0",
-                "3.0.0",
+                "3.1.0",
                 description="Auto-generated OpenAPI documentation. "
                 "Markdown supported in descriptions (CommonMark).",
                 security_schemes=None,
@@ -278,7 +278,7 @@ class TestGetOpenAPIYAMLEnhanced:
             mock_generate.assert_called_once_with(
                 "Test API",
                 "1.0.0",
-                "3.0.0",
+                "3.1.0",
                 description="Custom description",
                 security_schemes=None,
                 route_prefix="/api",
@@ -341,7 +341,7 @@ class TestOpenAPISpecComplexScenarios:
 
                 spec = generate_openapi_spec("Complex API", "2.0.0", route_prefix="")
 
-                assert spec["openapi"] == "3.0.0"
+                assert spec["openapi"] == "3.1.0"
                 assert spec["info"]["title"] == "Complex API"
                 assert spec["info"]["version"] == "2.0.0"
 

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -85,7 +85,7 @@ class TestWebhookReceiverSnapshot:
     def test_openapi_3_0_spec(self) -> None:
         """webhook_receiver OpenAPI 3.0 spec matches golden file."""
         _reload_example("examples.webhook_receiver.function_app")
-        spec = generate_openapi_spec("Webhook Receiver API", "1.0.0")
+        spec = generate_openapi_spec("Webhook Receiver API", "1.0.0", openapi_version="3.0.0")
         _assert_snapshot(spec, "webhook_receiver_openapi.json")
 
     def test_paths_are_deterministically_ordered(self) -> None:
@@ -109,7 +109,7 @@ class TestReportJobsSnapshot:
     def test_openapi_3_0_spec(self) -> None:
         """report_jobs OpenAPI 3.0 spec matches golden file."""
         _reload_example("examples.report_jobs.function_app")
-        spec = generate_openapi_spec("Report Jobs API", "1.0.0")
+        spec = generate_openapi_spec("Report Jobs API", "1.0.0", openapi_version="3.0.0")
         _assert_snapshot(spec, "report_jobs_openapi.json")
 
     def test_paths_are_deterministically_ordered(self) -> None:
@@ -133,7 +133,7 @@ class TestNotificationRequestSnapshot:
     def test_openapi_3_0_spec(self) -> None:
         """notification_request OpenAPI 3.0 spec matches golden file."""
         _reload_example("examples.notification_request.function_app")
-        spec = generate_openapi_spec("Notification API", "1.0.0")
+        spec = generate_openapi_spec("Notification API", "1.0.0", openapi_version="3.0.0")
         _assert_snapshot(spec, "notification_request_openapi.json")
 
     def test_paths_are_deterministically_ordered(self) -> None:
@@ -198,7 +198,7 @@ class TestPartnerImportBridgeSnapshot:
     def test_openapi_3_0_spec(self) -> None:
         """partner_import_bridge OpenAPI 3.0 spec matches golden file."""
         _reload_example("examples.partner_import_bridge.function_app")
-        spec = generate_openapi_spec("Partner Import API", "1.0.0")
+        spec = generate_openapi_spec("Partner Import API", "1.0.0", openapi_version="3.0.0")
         _assert_snapshot(spec, "partner_import_bridge_openapi.json")
 
     def test_paths_are_deterministically_ordered(self) -> None:


### PR DESCRIPTION
## Summary

- Default OpenAPI version changed from 3.0.0 to 3.1.0 across all public APIs (`generate_openapi_spec`, `get_openapi_json`, `get_openapi_yaml`) and the CLI `--openapi-version` flag.
- Users can still explicitly request 3.0 output via `openapi_version="3.0.0"` parameter.
- Snapshot tests for 3.0 golden files now pass an explicit version to preserve their intent.

## Motivation

OpenAPI 3.1.0 is the current standard (released Feb 2021, widely supported). New projects should default to the latest spec. This was recommended by Oracle review (approach A) and confirmed by user.

## Changes

| File | Change |
|------|--------|
| `src/azure_functions_openapi/spec.py` | 3 default params → `OPENAPI_VERSION_3_1` |
| `src/azure_functions_openapi/cli.py` | CLI default `"3.1"`, updated help text |
| `tests/test_openapi.py` | Updated default assertion |
| `tests/test_openapi_3_1.py` | Renamed default tests, updated assertions |
| `tests/test_openapi_enhanced.py` | Updated mock assertions for new default |
| `tests/test_snapshots.py` | 3.0 snapshot tests now pass explicit version |

## Testing

- All 408 tests pass
- Coverage: 97.11% (threshold: 95%)