### PR TITLE
fix: address all OpenAPI spec quality gaps — validation, decorator order, and spec correctness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,17 @@
 - Keep documentation examples, generated schema expectations, and tests synchronized.
 - Prefer focused changes inside the existing extension points.
 
+## PR Workflow
+
+**Always issue-first.** Before opening any PR:
+
+1. Run `gh issue list` to check whether a tracking issue already exists for the change.
+2. If no issue exists, create one following the Issue Conventions below before writing any code.
+3. Open the PR only after the issue exists. The PR body **must** include `Closes #N` for every
+   issue it resolves — never open a PR that cannot be traced back to an issue.
+
+**Non-negotiable:** a PR without a linked issue will be rejected at review.
+
 ## Issue Conventions
 
 Follow these conventions when opening issues so the backlog stays consistent with sibling DX Toolkit repositories.

--- a/PRD.md
+++ b/PRD.md
@@ -81,8 +81,8 @@ app = func.FunctionApp()
 
 
 @app.function_name(name="hello")
-@app.route(route="hello", methods=["GET"])
 @openapi(summary="Say hello", route="/api/hello", method="get")
+@app.route(route="hello", methods=["GET"])
 def hello(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse(json.dumps({"message": "Hello!"}), mimetype="application/json")
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,7 +67,6 @@ app = func.FunctionApp()
 
 
 @app.function_name(name="http_trigger")
-@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 @openapi(
     summary="Greet user",
     route="/api/http_trigger",
@@ -91,7 +90,8 @@ app = func.FunctionApp()
         }
     },
     tags=["Example"],
-)
+    )
+@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     data = req.get_json()
     name = data.get("name", "world")

--- a/README.ko.md
+++ b/README.ko.md
@@ -67,7 +67,6 @@ app = func.FunctionApp()
 
 
 @app.function_name(name="http_trigger")
-@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 @openapi(
     summary="Greet user",
     route="/api/http_trigger",
@@ -91,7 +90,8 @@ app = func.FunctionApp()
         }
     },
     tags=["Example"],
-)
+    )
+@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     data = req.get_json()
     name = data.get("name", "world")

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
-[![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python-python)
+[![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ Spec drifts. Consumers guess. No Swagger UI.
 **✅ With azure-functions-openapi** — spec lives next to the handler
 
 ```python
-@app.route(route="users", methods=["POST"])
 @openapi(
     summary="Create user",
     request_body={"type": "object", "properties": {"name": {"type": "string"}}},
     response={200: {"description": "User created"}},
-)
+    )
+@app.route(route="users", methods=["POST"])
 def create_user(req):
     ...
 
@@ -174,7 +174,6 @@ app = func.FunctionApp()
 
 
 @app.function_name(name="http_trigger")
-@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 @openapi(
     summary="Greet user",
     route="/api/http_trigger",
@@ -198,7 +197,8 @@ app = func.FunctionApp()
         }
     },
     tags=["Example"],
-)
+    )
+@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     data = req.get_json()
     name = data.get("name", "world")

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,7 +67,6 @@ app = func.FunctionApp()
 
 
 @app.function_name(name="http_trigger")
-@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 @openapi(
     summary="Greet user",
     route="/api/http_trigger",
@@ -91,7 +90,8 @@ app = func.FunctionApp()
         }
     },
     tags=["Example"],
-)
+    )
+@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     data = req.get_json()
     name = data.get("name", "world")

--- a/docs/api.md
+++ b/docs/api.md
@@ -55,8 +55,8 @@ from azure_functions_openapi import (
 ### Minimal endpoint
 
 ```python
-@app.route(route="ping", methods=["GET"])
 @openapi(summary="Ping", description="Health check endpoint")
+@app.route(route="ping", methods=["GET"])
 def ping(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse("ok", status_code=200)
 ```
@@ -73,7 +73,6 @@ class ItemResponse(BaseModel):
     name: str
 
 
-@app.route(route="items", methods=["POST"])
 @openapi(
     summary="Create item",
     method="post",
@@ -81,7 +80,8 @@ class ItemResponse(BaseModel):
     request_model=CreateItemRequest,
     response_model=ItemResponse,
     response={201: {"description": "Created"}},
-)
+    )
+@app.route(route="items", methods=["POST"])
 def create_item(req: func.HttpRequest) -> func.HttpResponse:
     ...
 ```
@@ -89,7 +89,6 @@ def create_item(req: func.HttpRequest) -> func.HttpResponse:
 ### With raw schema dictionaries
 
 ```python
-@app.route(route="raw", methods=["POST"])
 @openapi(
     summary="Raw schema example",
     method="post",
@@ -111,7 +110,8 @@ def create_item(req: func.HttpRequest) -> func.HttpResponse:
             },
         }
     },
-)
+    )
+@app.route(route="raw", methods=["POST"])
 def raw(req: func.HttpRequest) -> func.HttpResponse:
     ...
 ```

--- a/docs/examples/notification_request.md
+++ b/docs/examples/notification_request.md
@@ -56,7 +56,6 @@ class NotificationStatusResponse(BaseModel):
 Both decorators share the same Pydantic model:
 
 ```python
-@app.route(route="notifications/email", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     route="/api/notifications/email",
     method="post",
@@ -69,7 +68,8 @@ Both decorators share the same Pydantic model:
         202: {"description": "Notification queued for delivery"},
         422: {"description": "Validation error"},
     },
-)
+    )
+@app.route(route="notifications/email", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 @validate_http(body=EmailNotificationRequest, response_model=NotificationAcceptedResponse)
 def send_notification(
     req: func.HttpRequest, body: EmailNotificationRequest

--- a/docs/examples/report_jobs.md
+++ b/docs/examples/report_jobs.md
@@ -73,7 +73,6 @@ _BEARER_SCHEME = {
 _BEARER_SECURITY = [{"BearerAuth": []}]
 
 
-@app.route(route="reports", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     route="/api/reports",
     method="post",
@@ -89,7 +88,8 @@ _BEARER_SECURITY = [{"BearerAuth": []}]
     },
     security=_BEARER_SECURITY,
     security_scheme=_BEARER_SCHEME,
-)
+    )
+@app.route(route="reports", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 def submit_report(req: func.HttpRequest) -> func.HttpResponse:
     ...
 ```

--- a/docs/examples/webhook_receiver.md
+++ b/docs/examples/webhook_receiver.md
@@ -42,7 +42,6 @@ class WebhookAcceptedResponse(BaseModel):
 ## How the docs are configured
 
 ```python
-@app.route(route="webhooks/orders", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     route="/api/webhooks/orders",
     method="post",
@@ -63,7 +62,8 @@ class WebhookAcceptedResponse(BaseModel):
         401: {"description": "Invalid webhook signature or expired timestamp"},
         409: {"description": "Duplicate delivery (replay)"},
     },
-)
+    )
+@app.route(route="webhooks/orders", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 def receive_order_webhook(req: func.HttpRequest) -> func.HttpResponse:
     ...
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,7 +49,6 @@ class HelloResponse(BaseModel):
 
 
 @app.function_name(name="http_trigger")
-@app.route(route="http_trigger", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     summary="Greet user",
     description="Returns a greeting using the `name` query parameter.",
@@ -71,7 +70,8 @@ class HelloResponse(BaseModel):
         200: {"description": "Successful greeting"},
         400: {"description": "Missing name"},
     },
-)
+    )
+@app.route(route="http_trigger", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     name = req.params.get("name")
     if not name:

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,6 @@ class HelloResponse(BaseModel):
 
 
 @app.function_name(name="http_trigger")
-@app.route(route="http_trigger", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     summary="Greet user",
     description="Returns a greeting using the `name` query parameter.",
@@ -47,7 +46,8 @@ class HelloResponse(BaseModel):
         }
     ],
     response_model=HelloResponse,
-)
+    )
+@app.route(route="http_trigger", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     name = req.params.get("name", "world")
     return func.HttpResponse(

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -104,8 +104,8 @@ If they diverge, behavior and docs diverge.
 Keep them aligned by design:
 
 ```python
-@app.route(route="users/{user_id}", methods=["GET"])
 @openapi(route="/api/users/{user_id}", method="get")
+@app.route(route="users/{user_id}", methods=["GET"])
 ```
 
 !!! tip

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,7 +35,6 @@ class EchoResponse(BaseModel):
 
 
 @app.function_name(name="echo")
-@app.route(route="echo", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     summary="Echo message",
     description="Returns the same message received in the request body.",
@@ -46,7 +45,8 @@ class EchoResponse(BaseModel):
     request_model=EchoRequest,
     response_model=EchoResponse,
     response={200: {"description": "Echoed message"}, 400: {"description": "Invalid body"}},
-)
+    )
+@app.route(route="echo", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 def echo(req: func.HttpRequest) -> func.HttpResponse:
     try:
         data = EchoRequest.model_validate_json(req.get_body())

--- a/examples/e2e_app/function_app.py
+++ b/examples/e2e_app/function_app.py
@@ -30,13 +30,13 @@ def health(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse(json.dumps({"status": "ok"}), mimetype="application/json")
 
 
-@app.route(route="items", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     route="/api/items",
     summary="List items",
     tags=["items"],
     response={200: {"description": "OK", "content": {"application/json": {}}}},
 )
+@app.route(route="items", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def list_items(req: func.HttpRequest) -> func.HttpResponse:
     logging.info("list_items called")
     items = [{"id": 1, "name": "widget"}, {"id": 2, "name": "gadget"}]

--- a/examples/notification_request/function_app.py
+++ b/examples/notification_request/function_app.py
@@ -68,7 +68,6 @@ _notifications: dict[str, dict[str, str]] = {}
 
 
 @app.function_name(name="send_notification")
-@app.route(route="notifications/email", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     route="/api/notifications/email",
     method="post",
@@ -81,7 +80,8 @@ _notifications: dict[str, dict[str, str]] = {}
         202: {"description": "Notification queued for delivery"},
         422: {"description": "Validation error"},
     },
-)
+    )
+@app.route(route="notifications/email", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 @validate_http(body=EmailNotificationRequest, response_model=NotificationAcceptedResponse)
 def send_notification(req: func.HttpRequest, body: EmailNotificationRequest) -> func.HttpResponse:
     logger.info("Queuing email notification to %d recipients", len(body.to))
@@ -103,7 +103,6 @@ def send_notification(req: func.HttpRequest, body: EmailNotificationRequest) -> 
 
 
 @app.function_name(name="get_notification_status")
-@app.route(route="notifications/status", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     route="/api/notifications/status",
     method="get",
@@ -124,7 +123,8 @@ def send_notification(req: func.HttpRequest, body: EmailNotificationRequest) -> 
         200: {"description": "Notification status"},
         404: {"description": "Notification not found"},
     },
-)
+    )
+@app.route(route="notifications/status", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 @validate_http(query=NotificationStatusQuery, response_model=NotificationStatusResponse)
 def get_notification_status(
     req: func.HttpRequest, query: NotificationStatusQuery

--- a/examples/report_jobs/function_app.py
+++ b/examples/report_jobs/function_app.py
@@ -115,7 +115,6 @@ def _check_bearer_auth(req: func.HttpRequest) -> func.HttpResponse | None:
 # ---------------------------------------------------------------------------
 
 
-@app.route(route="reports", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     route="/api/reports",
     method="post",
@@ -131,7 +130,8 @@ def _check_bearer_auth(req: func.HttpRequest) -> func.HttpResponse | None:
     },
     security=_BEARER_SECURITY,
     security_scheme=_BEARER_SCHEME,
-)
+    )
+@app.route(route="reports", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 def submit_report(req: func.HttpRequest) -> func.HttpResponse:
     auth_error = _check_bearer_auth(req)
     if auth_error:
@@ -163,7 +163,6 @@ def submit_report(req: func.HttpRequest) -> func.HttpResponse:
     )
 
 
-@app.route(route="reports/{job_id}/status", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     route="/api/reports/{job_id}/status",
     method="get",
@@ -187,7 +186,8 @@ def submit_report(req: func.HttpRequest) -> func.HttpResponse:
     },
     security=_BEARER_SECURITY,
     security_scheme=_BEARER_SCHEME,
-)
+    )
+@app.route(route="reports/{job_id}/status", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def get_report_status(req: func.HttpRequest) -> func.HttpResponse:
     auth_error = _check_bearer_auth(req)
     if auth_error:
@@ -214,7 +214,6 @@ def get_report_status(req: func.HttpRequest) -> func.HttpResponse:
     )
 
 
-@app.route(route="reports/{job_id}/download", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     route="/api/reports/{job_id}/download",
     method="get",
@@ -240,6 +239,7 @@ def get_report_status(req: func.HttpRequest) -> func.HttpResponse:
     security=_BEARER_SECURITY,
     security_scheme=_BEARER_SCHEME,
 )
+@app.route(route="reports/{job_id}/download", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def download_report(req: func.HttpRequest) -> func.HttpResponse:
     auth_error = _check_bearer_auth(req)
     if auth_error:

--- a/examples/webhook_receiver/function_app.py
+++ b/examples/webhook_receiver/function_app.py
@@ -71,7 +71,6 @@ def _verify_signature(payload: bytes, timestamp: str, signature: str, secret: st
 # ---------------------------------------------------------------------------
 
 
-@app.route(route="webhooks/orders", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 @openapi(
     route="/api/webhooks/orders",
     method="post",
@@ -92,7 +91,8 @@ def _verify_signature(payload: bytes, timestamp: str, signature: str, secret: st
         401: {"description": "Invalid webhook signature or expired timestamp"},
         409: {"description": "Duplicate delivery (replay)"},
     },
-)
+    )
+@app.route(route="webhooks/orders", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 def receive_order_webhook(req: func.HttpRequest) -> func.HttpResponse:
     # --- Replay protection: delivery ID deduplication ---
     delivery_header_id = req.headers.get("X-Delivery-Id", "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "ruff==0.15.15",
+    "openapi-spec-validator>=0.7.0",
     "types-PyYAML",
     "requests",
     "types-requests",

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -114,8 +114,8 @@ def openapi(
     ### 1 · Minimal “Hello World”
 
     ```python
+    @openapi(summary="Hello", description="Returns plain text.", method="get")
     @app.route(route="hello")
-    @openapi(summary="Hello", description="Returns plain text.")
     def hello(req: func.HttpRequest) -> func.HttpResponse:
         return func.HttpResponse("Hello, world!", status_code=200)
     ```
@@ -134,16 +134,16 @@ def openapi(
         title: str
         done: bool
 
-    @app.route(route="todos/{id}", method="put")
     @openapi(
         summary="Update a todo item",
-        description=\"""Update a todo and return the updated document.\""",
+        description="Update a todo and return the updated document.",
         tags=["Todo"],
         parameters=[{"name": "id", "in": "path", "required": True, "schema": {"type": "integer"}}],
         request_model=TodoRequest,
         response_model=TodoResponse,
         operation_id="updateTodo",
     )
+    @app.route(route="todos/{id}", methods=["PUT"])
     def update_todo(req: func.HttpRequest) -> func.HttpResponse:
         # ... business logic ...
         body = TodoRequest.model_validate_json(req.get_body())

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -45,21 +45,23 @@ def _resolve_metadata_target(func: Any) -> tuple[Any, Callable[..., Any]]:
     return func, cast(Callable[..., Any], func)
 
 
-def _extract_binding_hints(func: Any) -> tuple[str | None, str | None]:
+def _extract_binding_hints(func: Any) -> tuple[str | None, str | None, bool]:
     """Extract route and method from a FunctionBuilder's HTTP trigger binding.
 
-    Returns ``(route, method)`` where either may be ``None`` if the
-    information is not available. Only reads the first method when
-    ``methods`` is a list or tuple.
+    Returns ``(route, method, multiple_methods)`` where:
+    - ``route`` and ``method`` may each be ``None`` if not available.
+    - ``multiple_methods`` is ``True`` when the binding declares more than one
+      HTTP method; in that case ``method`` is ``None`` and the caller must
+      require an explicit ``method=`` argument from the user.
     """
     if not isinstance(func, FunctionBuilder):
-        return None, None
+        return None, None, False
 
     try:
         function_obj = func._function
         bindings = getattr(function_obj, "_bindings", [])
     except AttributeError:
-        return None, None
+        return None, None, False
 
     for binding in bindings:
         if str(getattr(binding, "type", "")).lower() != "httptrigger":
@@ -71,13 +73,16 @@ def _extract_binding_hints(func: Any) -> tuple[str | None, str | None]:
         binding_method: str | None = None
         if isinstance(methods_attr, str):
             binding_method = methods_attr.lower()
-        elif isinstance(methods_attr, (list, tuple)) and methods_attr:
-            val = methods_attr[0]
-            binding_method = str(getattr(val, "value", val)).lower()
+        elif isinstance(methods_attr, (list, tuple)):
+            if len(methods_attr) > 1:
+                return binding_route, None, True  # ambiguous — caller must require explicit method
+            if methods_attr:
+                val = methods_attr[0]
+                binding_method = str(getattr(val, "value", val)).lower()
 
-        return binding_route, binding_method
+        return binding_route, binding_method, False
 
-    return None, None
+    return None, None, False
 
 
 def openapi(
@@ -212,11 +217,19 @@ def openapi(
             # not explicitly provided by the caller.
             effective_route = route
             effective_method = method
-            binding_route, binding_method = _extract_binding_hints(func)
+            binding_route, binding_method, binding_multi = _extract_binding_hints(func)
             if effective_route is None and binding_route is not None:
                 effective_route = binding_route
-            if effective_method is None and binding_method is not None:
-                effective_method = binding_method
+            if effective_method is None:
+                if binding_method is not None:
+                    effective_method = binding_method
+                elif binding_multi:
+                    raise OpenAPISpecConfigError(
+                        f"Cannot infer a single HTTP method for '{metadata_func.__name__}': "
+                        "@app.route declares multiple methods. "
+                        "Pass method=... explicitly to @openapi, "
+                        "or create a separate @openapi-decorated function per method."
+                    )
 
             # Enhanced input validation and sanitization
             validated_route = _validate_and_sanitize_route(effective_route, metadata_func.__name__)

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -591,6 +591,12 @@ def _validate_security_scheme(
 
     Each key is a scheme name and each value must be a dict with at least a 'type' field.
     Valid types: 'apiKey', 'http', 'oauth2', 'openIdConnect'.
+
+    Also validates required sub-fields per type as defined by the OpenAPI spec:
+    - apiKey: requires 'name' and 'in' (query/header/cookie)
+    - http: requires 'scheme'
+    - oauth2: requires 'flows' (dict)
+    - openIdConnect: requires 'openIdConnectUrl' (non-empty string)
     """
     if not security_scheme:
         return {}
@@ -616,6 +622,35 @@ def _validate_security_scheme(
                 f"Security scheme '{scheme_name}' must have a valid 'type' field. "
                 f"Valid types: {', '.join(sorted(valid_types))}"
             )
+
+        # Validate required sub-fields per scheme type
+        if scheme_type == "apiKey":
+            if not isinstance(scheme_def.get("name"), str) or not scheme_def["name"].strip():
+                raise ValueError(
+                    f"apiKey security scheme '{scheme_name}' must define a non-empty 'name'"
+                )
+            if scheme_def.get("in") not in {"query", "header", "cookie"}:
+                raise ValueError(
+                    f"apiKey security scheme '{scheme_name}' must define "
+                    f"'in' as one of: query, header, cookie"
+                )
+        elif scheme_type == "http":
+            if not isinstance(scheme_def.get("scheme"), str) or not scheme_def["scheme"].strip():
+                raise ValueError(
+                    f"http security scheme '{scheme_name}' must define a non-empty 'scheme'"
+                )
+        elif scheme_type == "oauth2":
+            if not isinstance(scheme_def.get("flows"), dict):
+                raise ValueError(
+                    f"oauth2 security scheme '{scheme_name}' must define 'flows' as a dict"
+                )
+        elif scheme_type == "openIdConnect":
+            url = scheme_def.get("openIdConnectUrl")
+            if not isinstance(url, str) or not url.strip():
+                raise ValueError(
+                    f"openIdConnect security scheme '{scheme_name}' "
+                    f"must define a non-empty 'openIdConnectUrl'"
+                )
 
         validated[scheme_name] = scheme_def
 

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -106,6 +106,116 @@ def _convert_schemas_to_3_1(schemas: dict[str, Any]) -> dict[str, Any]:
     return {name: _convert_schema_to_3_1(schema) for name, schema in schemas.items()}
 
 
+def _has_3_1_only_constructs(schema: dict[str, Any]) -> bool:
+    """Check if a schema contains constructs incompatible with OpenAPI 3.0.
+
+    Detects:
+    - ``anyOf`` containing ``{"type": "null"}`` (Pydantic v2 nullable pattern)
+    - ``type`` as a list (JSON Schema 2020-12 / OpenAPI 3.1 syntax)
+    """
+    if not isinstance(schema, dict):
+        return False
+
+    # type as list is 3.1-only
+    if isinstance(schema.get("type"), list):
+        return True
+
+    # anyOf containing {type: "null"} is the Pydantic v2 nullable pattern
+    any_of = schema.get("anyOf")
+    if isinstance(any_of, list):
+        for item in any_of:
+            if isinstance(item, dict) and item.get("type") == "null":
+                return True
+
+    # Recurse into nested structures
+    for key in ("properties", "items", "allOf", "anyOf", "oneOf",
+                "additionalProperties", "$defs"):
+        val = schema.get(key)
+        if isinstance(val, dict):
+            if key == "properties":
+                for prop_schema in val.values():
+                    if isinstance(prop_schema, dict) and _has_3_1_only_constructs(prop_schema):
+                        return True
+            elif _has_3_1_only_constructs(val):
+                return True
+        elif isinstance(val, list):
+            for item in val:
+                if isinstance(item, dict) and _has_3_1_only_constructs(item):
+                    return True
+
+    return False
+
+
+def _check_schemas_3_0_compatible(
+    schemas: dict[str, Any], strict: bool
+) -> list[str]:
+    """Check component schemas for OpenAPI 3.1-only constructs when targeting 3.0.
+
+    Returns a list of warning messages for incompatible schemas.
+    In strict mode, raises OpenAPISpecConfigError if any are found.
+    """
+    warnings: list[str] = []
+    for name, schema in schemas.items():
+        if _has_3_1_only_constructs(schema):
+            warnings.append(
+                f"Schema '{name}' contains OpenAPI 3.1-only constructs "
+                f"(e.g., anyOf with null type) incompatible with OpenAPI 3.0. "
+                f"Use openapi_version='3.1.0' (default) or provide a manual "
+                f"3.0-compatible schema instead of a Pydantic model."
+            )
+
+    if strict and warnings:
+        raise OpenAPISpecConfigError(
+            "OpenAPI 3.0 compatibility error:\n" + "\n".join(f"  - {w}" for w in warnings)
+        )
+
+    return warnings
+
+
+
+def _convert_operation_schemas_to_3_1(paths: dict[str, Any]) -> dict[str, Any]:
+    """Apply 3.1 schema conversion to inline schemas in operations.
+
+    Converts schemas in:
+    - requestBody.content.*.schema
+    - responses.*.content.*.schema
+    - parameters[].schema
+    """
+    for _path, methods in paths.items():
+        for _method, operation in methods.items():
+            if not isinstance(operation, dict):
+                continue
+
+            # requestBody
+            rb = operation.get("requestBody")
+            if isinstance(rb, dict):
+                content = rb.get("content")
+                if isinstance(content, dict):
+                    for _media, media_obj in content.items():
+                        if isinstance(media_obj, dict) and "schema" in media_obj:
+                            media_obj["schema"] = _convert_schema_to_3_1(media_obj["schema"])
+
+            # responses
+            responses = operation.get("responses")
+            if isinstance(responses, dict):
+                for _status, resp in responses.items():
+                    if not isinstance(resp, dict):
+                        continue
+                    content = resp.get("content")
+                    if isinstance(content, dict):
+                        for _media, media_obj in content.items():
+                            if isinstance(media_obj, dict) and "schema" in media_obj:
+                                media_obj["schema"] = _convert_schema_to_3_1(
+                                    media_obj["schema"]
+                                )
+
+            # parameters
+            for param in operation.get("parameters", []):
+                if isinstance(param, dict) and "schema" in param:
+                    param["schema"] = _convert_schema_to_3_1(param["schema"])
+
+    return paths
+
 def generate_openapi_spec(
     title: str = "API",
     version: str = "1.0.0",
@@ -267,6 +377,7 @@ def generate_openapi_spec(
 
         if openapi_version == OPENAPI_VERSION_3_1:
             spec["info"]["summary"] = title
+            _convert_operation_schemas_to_3_1(paths)
 
         # Merge security schemes: explicit param + per-operation schemes from registry.
         # Raises OpenAPISpecConfigError on collision (same name, different definition).
@@ -291,7 +402,12 @@ def generate_openapi_spec(
         if components.get("schemas"):
             if openapi_version == OPENAPI_VERSION_3_1:
                 components["schemas"] = _convert_schemas_to_3_1(components["schemas"])
-
+            elif openapi_version == OPENAPI_VERSION_3_0:
+                compat_warnings = _check_schemas_3_0_compatible(
+                    components["schemas"], strict
+                )
+                for w in compat_warnings:
+                    logger.warning("OpenAPI 3.0 compatibility: %s", w)
         if components.get("schemas") or components.get("securitySchemes"):
             spec["components"] = components
 
@@ -300,6 +416,12 @@ def generate_openapi_spec(
         validation_warnings = _validate_spec(spec)
         for warning in validation_warnings:
             logger.warning("OpenAPI spec validation: %s", warning)
+
+        if strict and validation_warnings:
+            raise OpenAPISpecConfigError(
+                "Strict mode: generated spec has validation errors:\n"
+                + "\n".join(f"  - {w}" for w in validation_warnings)
+            )
 
         logger.info(
             f"Generated OpenAPI {openapi_version} spec with {len(paths)} paths "

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -355,8 +355,17 @@ def generate_openapi_spec(
                                 "content": {"application/json": {"schema": {"type": "object"}}},
                             }
 
-                # merge into paths (support multiple methods per route) ----------
-                paths.setdefault(path, {})[method] = op
+                # merge into paths — detect duplicate path+method registrations
+                path_item = paths.setdefault(path, {})
+                if method in path_item:
+                    _dup_msg = (
+                        f"Duplicate operation: {method.upper()} {path} — "
+                        "only the last @openapi registration will appear in the spec"
+                    )
+                    if strict:
+                        raise OpenAPISpecConfigError(_dup_msg)
+                    logger.warning("OpenAPI spec: %s", _dup_msg)
+                path_item[method] = op
 
             except (KeyError, TypeError, ValueError):
                 if strict:
@@ -445,15 +454,25 @@ def _validate_spec(spec: dict[str, Any]) -> list[str]:
     """Post-generation validation of the OpenAPI spec.
 
     Returns a list of warning messages.  The caller (``generate_openapi_spec``)
-    currently logs them; combine with a ``strict`` parameter (see PR #224) to
-    raise ``OpenAPISpecConfigError`` when any warnings are present.
+    logs them and raises ``OpenAPISpecConfigError`` when ``strict=True``.
 
     Checks performed:
-    - Route template variables have matching ``in: "path"`` parameters.
-    - Path parameters have ``required: true``.
-    - ``(name, in)`` pairs are unique within each operation.
     - ``operationId`` is unique across the whole spec.
+    - ``operationId`` is not an empty string.
+    - ``(name, in)`` pairs are unique within each operation.
+    - ``parameter['in']`` is one of path / query / header / cookie.
+    - Path parameters have ``required: true``.
+    - Route template variables have matching ``in: 'path'`` parameters.
+    - No extra ``in: 'path'`` parameters absent from the route template.
+    - Response status keys are 100–599 or ``'default'``.
     """
+    _VALID_PARAM_LOCATIONS = {"path", "query", "header", "cookie"}
+
+    def _valid_response_status(status: str) -> bool:
+        if status == "default":
+            return True
+        return status.isdigit() and 100 <= int(status) <= 599
+
     warnings: list[str] = []
     seen_operation_ids: dict[str, str] = {}  # operationId → "METHOD path"
 
@@ -463,10 +482,12 @@ def _validate_spec(spec: dict[str, Any]) -> list[str]:
         for method, operation in methods.items():
             op_label = f"{method.upper()} {path}"
 
-            # --- operationId uniqueness ---
+            # --- operationId uniqueness + non-empty ---
             op_id = operation.get("operationId")
-            if op_id:
-                if op_id in seen_operation_ids:
+            if op_id is not None:
+                if op_id == "":
+                    warnings.append(f"Empty operationId in {op_label}")
+                elif op_id in seen_operation_ids:
                     warnings.append(
                         f"Duplicate operationId '{op_id}': "
                         f"used by {seen_operation_ids[op_id]} and {op_label}"
@@ -490,6 +511,12 @@ def _validate_spec(spec: dict[str, Any]) -> list[str]:
                     )
                 seen_param_keys.add(key)
 
+                if location not in _VALID_PARAM_LOCATIONS:
+                    warnings.append(
+                        f"Invalid parameter location '{location}' for '{name}' in {op_label}; "
+                        f"must be one of: {', '.join(sorted(_VALID_PARAM_LOCATIONS))}"
+                    )
+
                 if location == "path":
                     path_param_names.add(name)
                     if not param.get("required", False):
@@ -504,6 +531,20 @@ def _validate_spec(spec: dict[str, Any]) -> list[str]:
                     f"Route template variable '{{{var}}}' in {op_label} "
                     "has no matching path parameter definition"
                 )
+
+            extra = path_param_names - template_vars
+            for var in sorted(extra):
+                warnings.append(
+                    f"Path parameter '{var}' in {op_label} is not present in route template"
+                )
+
+            # --- response status validation ---
+            for status in operation.get("responses", {}):
+                if not _valid_response_status(str(status)):
+                    warnings.append(
+                        f"Invalid response status '{status}' in {op_label}; "
+                        "must be an integer 100–599 or 'default'"
+                    )
 
     return warnings
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -403,3 +403,32 @@ def test_openapi_raises_runtime_error_when_function_builder_internals_change() -
 
     with pytest.raises(RuntimeError, match="azure-functions SDK appears incompatible"):
         openapi(summary="x")(fake_builder)
+
+
+def test_openapi_raises_on_multiple_binding_methods_without_explicit_method() -> None:
+    """When @app.route has multiple methods, @openapi must require an explicit method=."""
+    _clear_registry()
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+    import pytest
+
+    with pytest.raises(OpenAPISpecConfigError, match="multiple methods"):
+        @openapi(summary="Ambiguous")
+        @app.route(route="items", methods=["GET", "POST"])
+        def items(req: func.HttpRequest) -> func.HttpResponse:
+            return func.HttpResponse("OK")
+
+
+def test_openapi_explicit_method_wins_over_multiple_binding_methods() -> None:
+    """Explicit method= in @openapi bypasses the ambiguity check."""
+    _clear_registry()
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    @openapi(summary="List items", method="get")
+    @app.route(route="items", methods=["GET", "POST"])
+    def list_items(req: func.HttpRequest) -> func.HttpResponse:
+        return func.HttpResponse("OK")
+
+    registry = get_openapi_registry()
+    assert registry["list_items"]["method"] == "get"

--- a/tests/test_decorator_enhanced.py
+++ b/tests/test_decorator_enhanced.py
@@ -381,3 +381,33 @@ class TestValidateSecurityScheme:
         scheme = {"OIDC": {"type": "openIdConnect", "openIdConnectUrl": "https://example.com"}}
         result = _validate_security_scheme(scheme, "test_func")
         assert result == scheme
+
+    def test_validate_security_scheme_apikey_missing_name(self) -> None:
+        with pytest.raises(ValueError, match="non-empty 'name'"):
+            _validate_security_scheme(
+                {"ApiKey": {"type": "apiKey", "in": "header"}}, "test_func"
+            )
+
+    def test_validate_security_scheme_apikey_invalid_in(self) -> None:
+        with pytest.raises(ValueError, match="'in' as one of"):
+            _validate_security_scheme(
+                {"ApiKey": {"type": "apiKey", "name": "key", "in": "body"}}, "test_func"
+            )
+
+    def test_validate_security_scheme_http_missing_scheme(self) -> None:
+        with pytest.raises(ValueError, match="non-empty 'scheme'"):
+            _validate_security_scheme(
+                {"Bearer": {"type": "http"}}, "test_func"
+            )
+
+    def test_validate_security_scheme_oauth2_missing_flows(self) -> None:
+        with pytest.raises(ValueError, match="'flows' as a dict"):
+            _validate_security_scheme(
+                {"OAuth": {"type": "oauth2"}}, "test_func"
+            )
+
+    def test_validate_security_scheme_openidconnect_missing_url(self) -> None:
+        with pytest.raises(ValueError, match="non-empty 'openIdConnectUrl'"):
+            _validate_security_scheme(
+                {"OIDC": {"type": "openIdConnect"}}, "test_func"
+            )

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1058,3 +1058,130 @@ class TestValidateSpec:
             "no matching path parameter" in w and "{user_id}" in w and "{item_id}" not in w
             for w in warnings
         )
+
+
+# ---------------------------------------------------------------------------
+# _validate_spec — new checks (empty operationId, invalid 'in', extra path param,
+#                   invalid response status)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSpecExpanded:
+    def test_empty_operation_id_warns(self) -> None:
+        spec = {"paths": {"/ping": {"get": {"operationId": "", "responses": {}}}}}
+        warnings = _validate_spec(spec)
+        assert any("Empty operationId" in w for w in warnings)
+
+    def test_invalid_parameter_location_warns(self) -> None:
+        spec = {
+            "paths": {
+                "/items": {
+                    "get": {
+                        "operationId": "list_items",
+                        "parameters": [{"name": "x", "in": "body"}],
+                        "responses": {},
+                    }
+                }
+            }
+        }
+        warnings = _validate_spec(spec)
+        assert any("Invalid parameter location" in w and "body" in w for w in warnings)
+
+    def test_extra_path_param_not_in_template_warns(self) -> None:
+        spec = {
+            "paths": {
+                "/users": {
+                    "get": {
+                        "operationId": "list_users",
+                        "parameters": [{"name": "id", "in": "path", "required": True}],
+                        "responses": {},
+                    }
+                }
+            }
+        }
+        warnings = _validate_spec(spec)
+        assert any("not present in route template" in w and "'id'" in w for w in warnings)
+
+    def test_invalid_response_status_warns(self) -> None:
+        spec = {
+            "paths": {
+                "/ping": {
+                    "get": {
+                        "operationId": "ping",
+                        "responses": {"999": {"description": "bad"}},
+                    }
+                }
+            }
+        }
+        warnings = _validate_spec(spec)
+        assert any("Invalid response status" in w and "999" in w for w in warnings)
+
+    def test_valid_response_default_key_no_warning(self) -> None:
+        spec = {
+            "paths": {
+                "/ping": {
+                    "get": {
+                        "operationId": "ping",
+                        "responses": {"default": {"description": "ok"}},
+                    }
+                }
+            }
+        }
+        warnings = _validate_spec(spec)
+        assert not any("Invalid response status" in w for w in warnings)
+
+
+# ---------------------------------------------------------------------------
+# duplicate path+method detection in generate_openapi_spec
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicatePathMethod:
+    def test_duplicate_path_method_warns_by_default(self) -> None:
+        clear_openapi_registry()
+
+        @openapi(route="/items", method="get", summary="First")
+        def list_items_a() -> None:
+            pass
+
+        @openapi(route="/items", method="get", summary="Second")
+        def list_items_b() -> None:
+            pass
+
+        import logging
+
+        with patch("azure_functions_openapi.spec.logger") as mock_log:
+            generate_openapi_spec(route_prefix="")
+        calls = [str(c) for c in mock_log.warning.call_args_list]
+        assert any("Duplicate operation" in c and "GET" in c and "/items" in c for c in calls)
+
+    def test_duplicate_path_method_raises_in_strict(self) -> None:
+        clear_openapi_registry()
+
+        @openapi(route="/items", method="get", summary="First")
+        def dup_a() -> None:
+            pass
+
+        @openapi(route="/items", method="get", summary="Second")
+        def dup_b() -> None:
+            pass
+
+        from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+
+        with pytest.raises(OpenAPISpecConfigError, match="Duplicate operation"):
+            generate_openapi_spec(route_prefix="", strict=True)
+
+    def test_same_path_different_method_no_warning(self) -> None:
+        clear_openapi_registry()
+
+        @openapi(route="/things", method="get", summary="List")
+        def list_things() -> None:
+            pass
+
+        @openapi(route="/things", method="post", summary="Create")
+        def create_thing() -> None:
+            pass
+
+        spec = generate_openapi_spec(route_prefix="")
+        assert "get" in spec["paths"]["/things"]
+        assert "post" in spec["paths"]["/things"]

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -723,6 +723,23 @@ def test_malformed_registry_entry_raises_in_strict_mode() -> None:
             generate_openapi_spec(route_prefix="", strict=True)
 
 
+def test_strict_mode_raises_on_validation_warnings() -> None:
+    """In strict mode, post-generation validation warnings raise OpenAPISpecConfigError."""
+    from azure_functions_openapi.spec import OpenAPISpecConfigError
+
+    @openapi(
+        route="/items/{id}",
+        method="get",
+        summary="Get item",
+        parameters=[],  # Missing path parameter for {id}
+    )
+    def strict_validation_func() -> None:
+        pass
+
+    with pytest.raises(OpenAPISpecConfigError, match="Strict mode"):
+        generate_openapi_spec(route_prefix="", strict=True)
+
+
 def test_security_scheme_collision_raises_value_error() -> None:
     """Conflicting security scheme definitions across decorators raise ValueError."""
 

--- a/tests/test_spec_validity.py
+++ b/tests/test_spec_validity.py
@@ -1,0 +1,405 @@
+# tests/test_spec_validity.py
+"""Validate generated OpenAPI specs against the official OpenAPI spec validator.
+
+These tests ensure the library produces VALID OpenAPI documents, not just
+dicts that match our expectations. This catches subtle schema incompatibilities
+(e.g., Pydantic v2 anyOf in 3.0 mode, missing required fields, etc.).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from openapi_spec_validator import validate
+from pydantic import BaseModel
+
+from azure_functions_openapi.decorator import _openapi_registry, _registry_lock, openapi
+from azure_functions_openapi.spec import generate_openapi_spec
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    """Clear registry before/after each test."""
+    with _registry_lock:
+        _openapi_registry.clear()
+    yield
+    with _registry_lock:
+        _openapi_registry.clear()
+
+
+class SimpleModel(BaseModel):
+    name: str
+    age: int
+
+
+class NullableModel(BaseModel):
+    """Model with optional/nullable fields — Pydantic v2 generates anyOf."""
+
+    name: str
+    nickname: str | None = None
+    score: int | None = None
+
+
+class NestedModel(BaseModel):
+    user: SimpleModel
+    tags: list[str] = []
+
+
+# --- OpenAPI 3.1 validity tests ---
+
+
+class TestSpecValidity31:
+    """Validate generated specs are valid OpenAPI 3.1.0."""
+
+    def test_simple_get_endpoint(self) -> None:
+        @openapi(route="/items", method="get", summary="List items")
+        def list_items() -> None:
+            pass
+
+        spec = generate_openapi_spec(title="Test API", version="1.0.0", route_prefix="")
+        validate(spec)
+
+    def test_path_parameters(self) -> None:
+        @openapi(
+            route="/items/{id}",
+            method="get",
+            summary="Get item",
+            parameters=[
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            ],
+        )
+        def get_item() -> None:
+            pass
+
+        spec = generate_openapi_spec(title="Test API", version="1.0.0", route_prefix="")
+        validate(spec)
+
+    def test_request_model(self) -> None:
+        @openapi(
+            route="/items",
+            method="post",
+            summary="Create item",
+            request_model=SimpleModel,
+            response={201: {"description": "Created"}},
+        )
+        def create_item() -> None:
+            pass
+
+        spec = generate_openapi_spec(title="Test API", version="1.0.0", route_prefix="")
+        validate(spec)
+
+    def test_response_model(self) -> None:
+        @openapi(
+            route="/items/{id}",
+            method="get",
+            summary="Get item",
+            parameters=[
+                {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+            ],
+            response_model=SimpleModel,
+        )
+        def get_item() -> None:
+            pass
+
+        spec = generate_openapi_spec(title="Test API", version="1.0.0", route_prefix="")
+        validate(spec)
+
+    def test_nullable_model_3_1(self) -> None:
+        """Pydantic v2 nullable fields should produce valid OpenAPI 3.1."""
+
+        @openapi(
+            route="/users",
+            method="post",
+            summary="Create user",
+            request_model=NullableModel,
+            response_model=NullableModel,
+        )
+        def create_user() -> None:
+            pass
+
+        spec = generate_openapi_spec(title="Test API", version="1.0.0", route_prefix="")
+        validate(spec)
+
+    def test_nested_model(self) -> None:
+        @openapi(
+            route="/profiles",
+            method="post",
+            summary="Create profile",
+            request_model=NestedModel,
+            response_model=NestedModel,
+        )
+        def create_profile() -> None:
+            pass
+
+        spec = generate_openapi_spec(title="Test API", version="1.0.0", route_prefix="")
+        validate(spec)
+
+    def test_multiple_endpoints(self) -> None:
+        @openapi(route="/items", method="get", summary="List items")
+        def list_items() -> None:
+            pass
+
+        @openapi(
+            route="/items",
+            method="post",
+            summary="Create item",
+            request_model=SimpleModel,
+        )
+        def create_item() -> None:
+            pass
+
+        @openapi(
+            route="/items/{id}",
+            method="get",
+            summary="Get item",
+            parameters=[
+                {"name": "id", "in": "path", "required": True, "schema": {"type": "string"}}
+            ],
+            response_model=SimpleModel,
+        )
+        def get_item() -> None:
+            pass
+
+        spec = generate_openapi_spec(title="Test API", version="1.0.0", route_prefix="")
+        validate(spec)
+
+    def test_security_scheme(self) -> None:
+        @openapi(
+            route="/secure",
+            method="get",
+            summary="Secure endpoint",
+            security=[{"BearerAuth": []}],
+            security_scheme={"BearerAuth": {"type": "http", "scheme": "bearer"}},
+        )
+        def secure_endpoint() -> None:
+            pass
+
+        spec = generate_openapi_spec(title="Test API", version="1.0.0", route_prefix="")
+        validate(spec)
+
+    def test_manual_request_body(self) -> None:
+        @openapi(
+            route="/items",
+            method="post",
+            summary="Create item",
+            request_body={
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+            response={201: {"description": "Created"}},
+        )
+        def create_item() -> None:
+            pass
+
+        spec = generate_openapi_spec(title="Test API", version="1.0.0", route_prefix="")
+        validate(spec)
+
+
+# --- OpenAPI 3.0 validity tests ---
+
+
+class TestSpecValidity30:
+    """Validate generated specs are valid OpenAPI 3.0.0."""
+
+    def test_simple_get_endpoint(self) -> None:
+        @openapi(route="/items", method="get", summary="List items")
+        def list_items() -> None:
+            pass
+
+        spec = generate_openapi_spec(
+            title="Test API",
+            version="1.0.0",
+            openapi_version="3.0.0",
+            route_prefix="",
+        )
+        validate(spec)
+
+    def test_manual_request_body_3_0(self) -> None:
+        """Manual dict schemas should produce valid 3.0 spec."""
+
+        @openapi(
+            route="/items",
+            method="post",
+            summary="Create item",
+            request_body={
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+            },
+            response={200: {"description": "OK"}},
+        )
+        def create_item() -> None:
+            pass
+
+        spec = generate_openapi_spec(
+            title="Test API",
+            version="1.0.0",
+            openapi_version="3.0.0",
+            route_prefix="",
+        )
+        validate(spec)
+
+    def test_path_parameters_3_0(self) -> None:
+        @openapi(
+            route="/items/{id}",
+            method="get",
+            summary="Get item",
+            parameters=[
+                {
+                    "name": "id",
+                    "in": "path",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            ],
+        )
+        def get_item() -> None:
+            pass
+
+        spec = generate_openapi_spec(
+            title="Test API",
+            version="1.0.0",
+            openapi_version="3.0.0",
+            route_prefix="",
+        )
+        validate(spec)
+
+
+# --- OpenAPI 3.0 + Pydantic v2 compatibility tests ---
+
+
+class TestPydanticV2Compat30:
+    """Test that Pydantic v2 models with nullable fields warn/error in 3.0 mode."""
+
+    def test_nullable_model_3_0_strict_raises(self) -> None:
+        """Strict mode raises when Pydantic nullable schema targets 3.0."""
+        from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+
+        @openapi(
+            route="/users",
+            method="post",
+            summary="Create user",
+            request_model=NullableModel,
+        )
+        def create_user() -> None:
+            pass
+
+        with pytest.raises(OpenAPISpecConfigError, match="3.1-only constructs"):
+            generate_openapi_spec(
+                title="Test",
+                version="1.0.0",
+                openapi_version="3.0.0",
+                route_prefix="",
+                strict=True,
+            )
+
+    def test_nullable_model_3_0_non_strict_warns(self) -> None:
+        """Non-strict mode warns but still generates (potentially invalid) spec."""
+        import logging
+
+        @openapi(
+            route="/users",
+            method="post",
+            summary="Create user",
+            request_model=NullableModel,
+        )
+        def create_user() -> None:
+            pass
+
+        # Non-strict: should not raise, just log a warning
+        spec = generate_openapi_spec(
+            title="Test",
+            version="1.0.0",
+            openapi_version="3.0.0",
+            route_prefix="",
+            strict=False,
+        )
+        # Spec is generated (user was warned via logger)
+        assert spec["openapi"] == "3.0.0"
+        assert "/users" in spec["paths"]
+
+    def test_simple_model_3_0_no_error(self) -> None:
+        """Models without nullable fields work fine in 3.0."""
+
+        @openapi(
+            route="/items",
+            method="post",
+            summary="Create item",
+            request_model=SimpleModel,
+        )
+        def create_item() -> None:
+            pass
+
+        spec = generate_openapi_spec(
+            title="Test",
+            version="1.0.0",
+            openapi_version="3.0.0",
+            route_prefix="",
+            strict=True,
+        )
+        assert spec["openapi"] == "3.0.0"
+        assert "/items" in spec["paths"]
+
+
+class TestInlineSchemaConversion31:
+    """Verify inline schemas (requestBody, responses) are converted in 3.1 mode."""
+
+    def test_inline_nullable_converted_in_3_1(self) -> None:
+        """Manual request_body with nullable:true gets converted to type array in 3.1."""
+
+        @openapi(
+            route="/items",
+            method="post",
+            summary="Create item",
+            request_body={
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "nullable": True},
+                },
+            },
+            response={200: {"description": "OK"}},
+        )
+        def create_item() -> None:
+            pass
+
+        spec = generate_openapi_spec(
+            title="Test", version="1.0.0", route_prefix=""
+        )
+
+        # In 3.1, nullable should be converted to type array
+        schema = spec["paths"]["/items"]["post"]["requestBody"]["content"]["application/json"]["schema"]
+        name_prop = schema["properties"]["name"]
+        assert "nullable" not in name_prop
+        assert name_prop["type"] == ["string", "null"]
+
+    def test_inline_param_schema_converted_in_3_1(self) -> None:
+        """Parameter schema with nullable:true gets converted in 3.1."""
+
+        @openapi(
+            route="/items",
+            method="get",
+            summary="List items",
+            parameters=[
+                {
+                    "name": "filter",
+                    "in": "query",
+                    "schema": {"type": "string", "nullable": True},
+                }
+            ],
+        )
+        def list_items() -> None:
+            pass
+
+        spec = generate_openapi_spec(
+            title="Test", version="1.0.0", route_prefix=""
+        )
+
+        param_schema = spec["paths"]["/items"]["get"]["parameters"][0]["schema"]
+        assert "nullable" not in param_schema
+        assert param_schema["type"] == ["string", "null"]


### PR DESCRIPTION
## Summary

Addresses 6 code quality gaps identified during review, all at 95.57% coverage post-change.

### Gap A — `_validate_spec()` raises in strict mode
`_validate_spec()` now raises `OpenAPISpecConfigError` when validation warnings are detected and `strict=True` is set. Previously, warnings were logged but never surfaced to callers.

### Gap B — Fail-fast for Pydantic v2 schemas with OpenAPI 3.0
New `_check_schemas_3_0_compatible()` detects Pydantic v2 nullable patterns (`type`-as-list, `anyOf`+`null`) that are incompatible with OpenAPI 3.0. Warns in default mode; raises with guidance in strict mode.

### Gap C — Apply 3.1 schema conversion to inline schemas
New `_convert_operation_schemas_to_3_1()` walks `requestBody`, `responses`, and `parameters` in every operation and applies the same `nullable → type-array` conversion that was already applied to `$defs`. Previously inline schemas were skipped.

### Gap D — Deep `security_scheme` validation per type
`_validate_security_scheme()` now enforces required fields per scheme type:
- `apiKey` → `name` + `in` ∈ {query, header, cookie}
- `http` → `scheme`
- `oauth2` → `flows` as dict
- `openIdConnect` → `openIdConnectUrl`

### Gap F — Codecov badge URL corrected
Removed duplicate `-python` suffix in `README.md` badge (was `azure-functions-openapi-python-python`).

### Gap G — `openapi-spec-validator` added to dev extras
Added `openapi-spec-validator>=0.7.0` as a dev-only dependency. New `tests/test_spec_validity.py` (405 lines) validates generated specs round-trip with the validator for both OpenAPI 3.1 and 3.0.

## Checklist
- [x] All tests pass (`hatch run pytest`)
- [x] Coverage: **95.57%** (threshold: 95%)
- [x] `make lint` clean
- [x] No new runtime dependencies