### PR TITLE
fix(docs): correct broken Demo image paths in all README variants

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -148,13 +148,13 @@ func start
 
 生成された OpenAPI ファイルは、同じサンプル実行から静的プレビューとして取得されています。そのため、この README には代表的な関数が実際に生成したドキュメントが表示されます。
 
-![OpenAPI spec preview](docs/assets/webhook_receiver_openapi_spec_preview.png)
+![OpenAPI spec preview](docs/assets/hello_openapi_spec_preview.png)
 
 ### Swagger UI Result
 
 以下の Web プレビューも同じ代表サンプルから生成されており、そのフローで作られた Swagger UI ページを自動的にレンダリングして取得したものです。
 
-![OpenAPI Swagger UI preview](docs/assets/webhook_receiver_swagger_ui_preview.png)
+![OpenAPI Swagger UI preview](docs/assets/hello_openapi_swagger_ui_preview.png)
 
 ## Documentation
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -148,13 +148,13 @@ func start
 
 생성된 OpenAPI 파일은 같은 예제 실행 결과에서 정적 미리보기로 캡처되었습니다. 따라서 이 README에는 대표 함수가 실제로 생성한 문서가 그대로 표시됩니다.
 
-![OpenAPI spec preview](docs/assets/webhook_receiver_openapi_spec_preview.png)
+![OpenAPI spec preview](docs/assets/hello_openapi_spec_preview.png)
 
 ### Swagger UI Result
 
 아래 웹 미리보기 역시 같은 대표 예제에서 생성되었으며, 해당 예제 흐름이 만든 Swagger UI 페이지를 자동으로 렌더링해 캡처한 결과입니다.
 
-![OpenAPI Swagger UI preview](docs/assets/webhook_receiver_swagger_ui_preview.png)
+![OpenAPI Swagger UI preview](docs/assets/hello_openapi_swagger_ui_preview.png)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -289,13 +289,13 @@ The representative `webhook_receiver` example shows the full outcome of adopting
 
 The generated OpenAPI file is captured as a static preview from the same example run, so the README shows the actual document produced by the representative function.
 
-![OpenAPI spec preview](docs/assets/webhook_receiver_openapi_spec_preview.png)
+![OpenAPI spec preview](docs/assets/hello_openapi_spec_preview.png)
 
 ### Swagger UI Result
 
 The web preview below is generated from the same representative example and captured automatically from the rendered Swagger UI page produced by that example flow.
 
-![OpenAPI Swagger UI preview](docs/assets/webhook_receiver_swagger_ui_preview.png)
+![OpenAPI Swagger UI preview](docs/assets/hello_openapi_swagger_ui_preview.png)
 
 ## When to use
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -148,13 +148,13 @@ func start
 
 生成的 OpenAPI 文件来自同一次示例运行，并被捕获为静态预览。因此，此 README 展示的就是代表性函数实际生成的文档。
 
-![OpenAPI spec preview](docs/assets/webhook_receiver_openapi_spec_preview.png)
+![OpenAPI spec preview](docs/assets/hello_openapi_spec_preview.png)
 
 ### Swagger UI Result
 
 下面的网页预览也来自同一个代表性示例，并由该示例流程生成的 Swagger UI 页面自动渲染和截图得到。
 
-![OpenAPI Swagger UI preview](docs/assets/webhook_receiver_swagger_ui_preview.png)
+![OpenAPI Swagger UI preview](docs/assets/hello_openapi_swagger_ui_preview.png)
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md` all referenced `webhook_receiver_openapi_spec_preview.png` and `webhook_receiver_swagger_ui_preview.png` in the **Demo** section, but neither file exists in `docs/assets/`
- The Makefile (`SPEC_PREVIEW_PNG`) and `make demo-swagger` generate these under `hello_openapi_spec_preview.png` / `hello_openapi_swagger_ui_preview.png`
- Updated all four README files to reference the correct, existing filenames — no files were renamed or moved

## Verification

```bash
ls docs/assets/hello_openapi_spec_preview.png docs/assets/hello_openapi_swagger_ui_preview.png
# both exist ✅
```

Closes #244