### PR TITLE
fix(demo): harden generate_example_swagger and demo-examples target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,6 +243,7 @@ demo-swagger: ensure-hatch
 
 .PHONY: demo-examples
 demo-examples: ensure-hatch
+	@rm -rf demo/.preview/webhook_receiver demo/.preview/notification_request demo/.preview/partner_import_bridge
 	@mkdir -p docs/assets
 	@PLAYWRIGHT_BROWSERS_PATH="$(PLAYWRIGHT_BROWSERS_PATH)" npx -y playwright@$(PLAYWRIGHT_VERSION) install chromium > /dev/null
 	@$(HATCH) run python demo/generate_example_swagger.py \
@@ -256,7 +257,7 @@ demo-examples: ensure-hatch
 	PLAYWRIGHT_BROWSERS_PATH="$(PLAYWRIGHT_BROWSERS_PATH)" npx -y playwright@$(PLAYWRIGHT_VERSION) screenshot \
 		--device="Desktop Chrome" \
 		--full-page \
-		--wait-for-selector ".opblock" \
+		--wait-for-selector ".opblock.is-open" \
 		--wait-for-timeout 2000 \
 		"http://127.0.0.1:$(EXAMPLES_PREVIEW_PORT)/index.html" \
 		"docs/assets/webhook_receiver_swagger_ui.png" > /dev/null; \
@@ -273,7 +274,7 @@ demo-examples: ensure-hatch
 	PLAYWRIGHT_BROWSERS_PATH="$(PLAYWRIGHT_BROWSERS_PATH)" npx -y playwright@$(PLAYWRIGHT_VERSION) screenshot \
 		--device="Desktop Chrome" \
 		--full-page \
-		--wait-for-selector ".opblock" \
+		--wait-for-selector ".opblock.is-open" \
 		--wait-for-timeout 2000 \
 		"http://127.0.0.1:$(EXAMPLES_PREVIEW_PORT)/index.html" \
 		"docs/assets/notification_request_swagger_ui.png" > /dev/null; \
@@ -290,7 +291,7 @@ demo-examples: ensure-hatch
 	PLAYWRIGHT_BROWSERS_PATH="$(PLAYWRIGHT_BROWSERS_PATH)" npx -y playwright@$(PLAYWRIGHT_VERSION) screenshot \
 		--device="Desktop Chrome" \
 		--full-page \
-		--wait-for-selector ".opblock" \
+		--wait-for-selector ".opblock.is-open" \
 		--wait-for-timeout 2000 \
 		"http://127.0.0.1:$(EXAMPLES_PREVIEW_PORT)/index.html" \
 		"docs/assets/partner_import_bridge_swagger_ui.png" > /dev/null; \

--- a/demo/generate_example_swagger.py
+++ b/demo/generate_example_swagger.py
@@ -22,11 +22,11 @@ would conflict with the first import's registrations.
 from __future__ import annotations
 
 import argparse
-from importlib import import_module, reload
+from importlib import import_module
 from pathlib import Path
 import sys
 
-from azure_functions_openapi import get_openapi_json, get_openapi_yaml
+from azure_functions_openapi import get_openapi_json
 import azure_functions_openapi.decorator as decorator_module
 from azure_functions_openapi.swagger_ui import render_swagger_ui
 
@@ -36,7 +36,18 @@ if str(REPO_ROOT) not in sys.path:
 
 
 def _expand_swagger_ui(html: str) -> str:
-    """Patch Swagger UI config to expand all operations on load."""
+    """Patch Swagger UI config to expand all operations on load.
+
+    Raises ValueError if the expected anchor string is not found so that
+    a template change is caught immediately rather than silently producing
+    collapsed screenshots.
+    """
+    anchor = "layout: 'BaseLayout',"
+    if anchor not in html:
+        raise ValueError(
+            f"_expand_swagger_ui: anchor {anchor!r} not found in Swagger UI template. "
+            "The template may have changed — update the anchor string."
+        )
     expanded_layout = (
         "layout: 'BaseLayout',\n"
         "            docExpansion: 'full',\n"
@@ -44,7 +55,7 @@ def _expand_swagger_ui(html: str) -> str:
         "            tryItOutEnabled: false,\n"
         "            supportedSubmitMethods: [],"
     )
-    return html.replace("layout: 'BaseLayout',", expanded_layout)
+    return html.replace(anchor, expanded_layout)
 
 
 def main() -> None:
@@ -77,7 +88,7 @@ def main() -> None:
         decorator_module._openapi_registry.clear()
 
     module_path = f"examples.{args.example}.function_app"
-    module = import_module(module_path)
+    import_module(module_path)
 
     openapi_json = get_openapi_json(title=args.title, version="1.0.0")
     swagger_response = render_swagger_ui(


### PR DESCRIPTION
## Summary
- `_expand_swagger_ui()` now raises `ValueError` when the anchor string is absent — silent no-op from a template change is detected immediately rather than producing collapsed screenshots
- `demo-examples` Makefile target changed from `--wait-for-selector ".opblock"` to `".opblock.is-open"` across all 3 screenshot commands, verifying that `docExpansion: full` actually took effect
- `demo-examples` now `rm -rf`s each preview directory before generation, consistent with `demo-swagger`, preventing stale-file confusion on reruns
- Removed unused `reload` and `get_openapi_yaml` imports; dropped unused `module =` variable binding

Closes #248