### PR TITLE
chore(ci): pin external actions to commit SHAs and document policy

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -22,7 +22,7 @@ jobs:
       resource_group: ${{ steps.names.outputs.rg }}
 
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Compute resource names
         id: names
@@ -38,7 +38,7 @@ jobs:
           echo "st=${ST}"   >> "$GITHUB_OUTPUT"
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3.0.0
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -63,7 +63,7 @@ jobs:
                 enableAppInsights=false
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.10"
 
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload e2e report
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: e2e-report/
@@ -105,7 +105,7 @@ jobs:
     if: always()
     steps:
       - name: Azure login (OIDC)
-        uses: azure/login@v3.0.0
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,64 @@ make cov         # Run tests with coverage
 make check-all   # Run the full local gate
 ```
 
+## GitHub Actions Pinning
+
+All external `uses:` references in `.github/workflows/` MUST pin to a
+full 40-character commit SHA with a trailing comment documenting the
+released version or channel. Example:
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+```
+
+This applies to first-party (`actions/*`, `github/*`, `azure/*`) and
+third-party Actions alike.
+
+**Rationale.** Mutable tags (including immutable-looking version tags
+like `@v6.0.1`) can be retroactively moved by an attacker who gains
+write access to the upstream repository. The
+[`tj-actions/changed-files` compromise (CVE-2025-30066, March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066)
+demonstrated this exact failure mode: ~23,000 repositories had their CI
+secrets exfiltrated, and only workflows that pinned to a commit SHA were
+safe. GitHub's own guidance now identifies SHA pinning as
+[the only way to use an Action as an immutable release](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions),
+and OpenSSF Scorecard's
+[`Pinned-Dependencies` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+flags anything weaker as Medium-risk.
+
+Dependabot updates SHA-pinned references on the configured schedule and
+keeps the trailing version comment in sync, so the human-readable
+context never drifts from the pinned commit.
+
+**Approved exceptions.** The following mutable refs are the only ones
+permitted in this repository and are flagged with an inline comment at
+the call site:
+
+- `pypa/gh-action-pypi-publish@release/v1` — PyPA-maintained stable
+  release channel; this pinning style is explicitly recommended upstream.
+- Local composite actions (`uses: ./...`) — versioned with the repo.
+
+When adding a new external Action, resolve the SHA with
+`git ls-remote <repo-url> 'refs/tags/<tag>^{}'`. The trailing `^{}`
+**dereferences** the ref to its target commit; without it, an
+*annotated* tag returns the tag-object SHA instead of the commit SHA,
+and the tag-object SHA is **not** a valid `uses:` target.
+
+```bash
+# Annotated tag — the two forms return *different* SHAs:
+git ls-remote https://github.com/Azure/login 'refs/tags/v3.0.0' 'refs/tags/v3.0.0^{}'
+# 93381592...   refs/tags/v3.0.0       <- tag object, do NOT pin to this
+# 532459ea...   refs/tags/v3.0.0^{}    <- commit, pin to this one
+
+# Lightweight tag — only the non-deref form returns a row, and it is
+# already the commit SHA. Always include the `^{}` form anyway so the
+# same command works for both tag types:
+git ls-remote https://github.com/actions/setup-python 'refs/tags/v6' 'refs/tags/v6^{}'
+```
+
+Single-quote the `refs/...^{}` argument so the `{}` and `^` are not
+interpreted by your shell (notably zsh with `EXTENDED_GLOB`).
+
 ## Example Coverage Policy
 
 Examples are part of the supported API experience and should stay verified.


### PR DESCRIPTION
## Summary
Pins all previously-unpinned action refs in `.github/workflows/e2e-azure.yml` to full commit SHAs with trailing version comments, and adds the canonical `## GitHub Actions Pinning` section to `CONTRIBUTING.md`, standardizing this repo with the sibling repos in the Azure Functions Python DX Toolkit.

## Changes
- Add `## GitHub Actions Pinning` section to `CONTRIBUTING.md` (58 lines)
- Pin 5 action ref occurrences in `.github/workflows/e2e-azure.yml`:
  - `actions/checkout@v7` → `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7`
  - `azure/login@v3.0.0` → `532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0` (2 locations)
  - `actions/setup-python@v6` → `ece7cb06caefa5fff74198d8649806c4678c61a1 # v6`
  - `actions/upload-artifact@v7.0.1` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1`

## Rationale
See the new CONTRIBUTING.md section for full context:

- **`tj-actions/changed-files` (CVE-2025-30066, March 2025)** — ~23,000 repositories had CI secrets exfiltrated because they pinned to a mutable tag; only SHA-pinned workflows were safe.
- **GitHub's own guidance** — SHA pinning is the only supported way to use an Action as an immutable release.
- **OpenSSF Scorecard** — `Pinned-Dependencies` check flags anything weaker as Medium-risk.

## Test Plan
- [x] CONTRIBUTING.md renders correctly on GitHub
- [x] All SHAs verified via `git ls-remote 'refs/tags/<tag>' 'refs/tags/<tag>^{}'`
- [x] `azure/login@v3.0.0` is an annotated tag; the `^{}`-dereferenced SHA (`532459ea...`) is pinned, not the tag-object SHA
- [x] Existing SHA-pinned refs unchanged
- [x] Dependabot config unchanged (updates trailing version comments in place)

## Follow-up (out of scope)
Some pre-existing `uses:` refs in this repo have outdated trailing comments (e.g., a SHA whose current tag is `v7` but the comment still reads `# v6`). Those are pre-existing drift from earlier Dependabot updates and can be reconciled in a separate PR — this change is scoped to the specific refs called out in issue #260.

Closes #260
