### PR TITLE
docs: fix stale diagram module names and add README flow diagram

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,13 +4,40 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
+  docs-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.10"
+
+      - name: Lint Mermaid diagram labels
+        run: python scripts/lint_mermaid.py
+
+      - name: Install Hatch and docs dependencies
+        run: |
+          pip install hatch
+          make install
+
+      - name: Build docs (strict)
+        run: hatch run mkdocs build --strict
+
   deploy:
+    needs: docs-check
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   docs-check:
@@ -39,6 +39,8 @@ jobs:
     needs: docs-check
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -39,16 +39,16 @@ The architecture separates metadata capture (import-time) from document generati
 ```mermaid
 flowchart TD
     subgraph Registration ["Import-Time Registration"]
-        DEC["@openapi(...) decorator"] --> REG["Thread-safe Registry\n_openapi_registry"]
+        DEC["@openapi(...) decorator"] --> REG["Thread-safe Registry<br/>_openapi_registry"]
     end
 
     subgraph Consumers ["On-Demand Consumers"]
-        REG --> GEN["generate_openapi_spec()"]
-        GEN --> JSON["get_openapi_json()\nget_openapi_yaml()"]
-        GEN --> CLI["azure-functions-openapi generate\n→ File / stdout"]
+        REG --> GEN["spec.generate_openapi_spec()"]
+        GEN --> JSON["get_openapi_json()<br/>get_openapi_yaml()"]
+        GEN --> CLI["azure-functions-openapi generate<br/>→ File / stdout"]
     end
 
-    UI["render_swagger_ui()\n→ HTML + Security Headers"] -.->|Browser fetches spec| JSON
+    UI["render_swagger_ui()<br/>→ HTML + Security Headers"] -.->|Browser fetches spec| JSON
 ```
 
 Note: `render_swagger_ui()` does not embed or generate the OpenAPI spec. It returns HTML that instructs the browser to fetch the spec from a configured URL.

--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Spec matches code. Always. Swagger UI out of the box.
 - **Swagger UI** — built-in `/docs` endpoint with security defaults
 - **CLI tooling** — generate specs at build time for CI validation
 
+
+### How it fits together
+
+```mermaid
+flowchart LR
+    DEC["@openapi decorator"] --> REG["_openapi_registry"]
+    REG --> GEN["spec.generate_openapi_spec()"]
+    GEN --> EP["GET /api/openapi.json | .yaml"]
+    UI["render_swagger_ui()<br/>GET /api/docs"] -.->|browser fetches spec| EP
+```
+
 ## FastAPI comparison
 
 | Feature | FastAPI | azure-functions-openapi |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,13 +88,13 @@ The registry is consumed only when a client explicitly requests the spec (`GET /
 
 ```mermaid
 flowchart TD
-    INIT["__init__.py\nPublic API exports"]
-    DEC["decorator.py\n@openapi + registry"]
-    OAI["openapi.py\nSpec compiler"]
-    UTL["utils.py\nSchema extraction + validation"]
-    SUI["swagger_ui.py\nSwagger UI rendering"]
-    CLI["cli.py\nCLI entrypoint"]
-    EXC["exceptions.py\nOpenAPISpecConfigError"]
+    INIT["__init__.py<br/>Public API exports"]
+    DEC["decorator.py<br/>@openapi + registry"]
+    OAI["spec.py / generate_openapi_spec()<br/>Spec compiler"]
+    UTL["utils.py<br/>Schema extraction + validation"]
+    SUI["swagger_ui.py<br/>Swagger UI rendering"]
+    CLI["cli.py<br/>CLI entrypoint"]
+    EXC["exceptions.py<br/>OpenAPISpecConfigError"]
 
     INIT --> DEC
     INIT --> OAI

--- a/scripts/lint_mermaid.py
+++ b/scripts/lint_mermaid.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Lint Mermaid diagrams embedded in Markdown for label-hygiene issues.
+
+Some Mermaid renderers mishandle literal ``\\n`` newline escapes inside node
+labels (e.g. ``NODE["a\\nb"]``), which silently breaks rendering. This linter
+scans Markdown files for ```mermaid``` fenced blocks and flags any literal
+``\\n`` sequence, steering authors toward ``<br/>`` or short labels instead.
+
+Exit code 0 when clean, 1 when any violation is found.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Files/globs to scan, relative to the repository root.
+TARGET_GLOBS = ("README*.md", "DESIGN.md", "docs/**/*.md")
+
+FENCE_START = "```mermaid"
+FENCE_END = "```"
+BAD_TOKEN = "\\n"
+
+
+def _iter_targets(root: Path) -> list[Path]:
+    seen: set[Path] = set()
+    files: list[Path] = []
+    for pattern in TARGET_GLOBS:
+        for path in sorted(root.glob(pattern)):
+            if path.is_file() and path not in seen:
+                seen.add(path)
+                files.append(path)
+    return files
+
+
+def _lint_file(path: Path) -> list[str]:
+    violations: list[str] = []
+    in_block = False
+    for lineno, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = raw.strip()
+        if not in_block:
+            if stripped.startswith(FENCE_START):
+                in_block = True
+            continue
+        if stripped == FENCE_END:
+            in_block = False
+            continue
+        if BAD_TOKEN in raw:
+            violations.append(
+                f"{path}:{lineno}: literal '\\n' in Mermaid label; use '<br/>' or a shorter label"
+            )
+    return violations
+
+
+def main() -> int:
+    root = Path(__file__).resolve().parent.parent
+    all_violations: list[str] = []
+    for path in _iter_targets(root):
+        all_violations.extend(_lint_file(path))
+
+    if all_violations:
+        print("Mermaid label lint failed:")
+        for violation in all_violations:
+            print(f"  {violation}")
+        return 1
+
+    print("Mermaid label lint passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Diagram-state fixes for the OpenAPI package (existence + accuracy + rendering).

- **Stale module names:** the spec-compiler node in `docs/architecture.md` and `DESIGN.md` referenced `openapi.py`, but the canonical module is now `spec.py` (`generate_openapi_spec()`); `openapi.py` is only a deprecation shim. Renamed the nodes to `spec.py / generate_openapi_spec()`.
- **README flow diagram:** added a compact Mermaid flowchart (`@openapi` → `_openapi_registry` → `spec.generate_openapi_spec()` → `/api/openapi.json|yaml` → `render_swagger_ui()`).
- **Mermaid label hygiene:** converted literal `\n` newline escapes in node labels to `<br/>` (some renderers mishandle `\n`).
- **CI guard:** added `scripts/lint_mermaid.py` (dependency-free) and a PR-triggered `docs-check` job in `docs.yml` that runs the mermaid lint plus a strict `mkdocs build`, so future breakage is caught on PRs.

## Verification
- `python scripts/lint_mermaid.py` passes.
- `hatch run mkdocs build --strict` exits 0.
- `make check-all` passes (lint/typecheck/tests/bandit).

Closes #274