### PR TITLE
ci: run skipif-guarded validation example tests on one matrix cell

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -52,6 +52,14 @@ jobs:
           fi
           .venv/bin/hatch run python -c "import azure.functions, importlib.metadata as m; print('azure-functions installed:', m.version('azure-functions'))"
 
+      - name: Install azure-functions-validation (run bridge/validation example tests on one cell)
+        # These example tests are skipif-guarded on the optional azure-functions-validation
+        # import. Install it on a single matrix cell so they actually execute in CI (see #275).
+        if: matrix.python-version == '3.12' && matrix.azure-functions-version == 'latest'
+        run: |
+          .venv/bin/hatch run pip install --upgrade 'azure-functions-validation>=0.7.0'
+          .venv/bin/hatch run python -c "import azure_functions_validation, importlib.metadata as m; print('azure-functions-validation installed:', m.version('azure-functions-validation'))"
+
       - name: Run full quality checks
         run: make check-all
 


### PR DESCRIPTION
## Summary
`tests/test_partner_import_bridge_example.py`, `tests/test_with_validation_example.py`, and the validation snapshot cases are `pytest.mark.skipif`-guarded on the optional `azure-functions-validation` import. Because that dependency was never installed in CI, these bridge/validation paths were **silently skipped on every matrix cell** and contributed nothing.

- Install `azure-functions-validation>=0.7.0` on the Python 3.12 / latest cell so the guarded tests actually execute in CI.
- Kept to a single cell to bound risk/runtime; other cells continue to skip and remain ≥95% coverage.

## Verification
- Locally, with `azure-functions-validation` installed, the 33 previously-skipped tests pass and full-suite coverage rises 95.78% → **96.02%**.
- `make check-all` passes; `ci-test.yml` validated as well-formed YAML.

Closes #275