### PR TITLE
docs: add pepy download badge and llms.txt for discoverability

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,7 @@
 # Azure Functions OpenAPI
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-openapi/month)](https://pepy.tech/project/azure-functions-openapi)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
 [![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml)

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,7 @@
 # Azure Functions OpenAPI
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-openapi/month)](https://pepy.tech/project/azure-functions-openapi)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
 [![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > Part of the **Azure Functions Python DX Toolkit** — dogfood-tested by [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python).
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-openapi/month)](https://pepy.tech/project/azure-functions-openapi)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
 [![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,7 @@
 # Azure Functions OpenAPI
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-openapi.svg)](https://pypi.org/project/azure-functions-openapi/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-openapi/month)](https://pepy.tech/project/azure-functions-openapi)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-openapi/)
 [![CI](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/publish-pypi.yml)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,25 @@
+# Azure Functions OpenAPI
+
+> OpenAPI (Swagger) documentation and Swagger UI for the Azure Functions Python v2 programming model.
+
+Part of the **Azure Functions Python DX Toolkit**. Decorate HTTP-triggered functions to auto-generate an OpenAPI 3 specification and serve Swagger UI, bringing a FastAPI-like developer experience to Azure Functions. Install from PyPI with `pip install azure-functions-openapi`.
+
+## Getting Started
+- [Installation](https://yeongseon.github.io/azure-functions-openapi-python/installation/): Install the package and prerequisites.
+- [Quickstart](https://yeongseon.github.io/azure-functions-openapi-python/getting-started/): Minimal end-to-end example.
+- [Configuration](https://yeongseon.github.io/azure-functions-openapi-python/configuration/): Customize spec metadata, servers, and routes.
+
+## User Guide
+- [Usage](https://yeongseon.github.io/azure-functions-openapi-python/usage/): Decorator reference, request/response models.
+- [CLI](https://yeongseon.github.io/azure-functions-openapi-python/cli/): Generate specs from the command line.
+- [Route Prefix](https://yeongseon.github.io/azure-functions-openapi-python/route-prefix/): Handle custom route prefixes.
+- [Architecture](https://yeongseon.github.io/azure-functions-openapi-python/architecture/): How spec generation and the handler bridge work.
+
+## Reference
+- [API Reference](https://yeongseon.github.io/azure-functions-openapi-python/api/): Public API surface.
+- [FAQ](https://yeongseon.github.io/azure-functions-openapi-python/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.github.io/azure-functions-openapi-python/troubleshooting/): Common issues and fixes.
+
+## Optional
+- [Deploy to Azure](https://yeongseon.github.io/azure-functions-openapi-python/deployment/): Deployment guide.
+- [Changelog](https://yeongseon.github.io/azure-functions-openapi-python/changelog/): Release history.


### PR DESCRIPTION
## Summary

Discoverability improvements (no code changes):

- **pepy monthly-downloads badge** added to `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md` (right after the PyPI badge).
- **`docs/llms.txt`** added — an llmstxt.org-style summary served at the gh-pages site root (`/llms.txt`) with curated links to installation, quickstart, usage, CLI, architecture, and reference docs.

## Verification
- `mkdocs build --strict` passes; `llms.txt` present at site root.

Closes #282
