### PR TITLE
fix(registry): unify callable identity, self-locking mutators, deprecate discrete params

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,6 +57,13 @@ from azure_functions_openapi.decorator import get_openapi_registry
 print(get_openapi_registry().keys())
 ```
 
+Registry keys are keyed by the decorated function's short name. When two
+handlers share the same short name, the earlier (displaced) entry is preserved
+under its fully-qualified id (`module.qualname`) in addition to the short-name
+key, so no registration is silently lost. If you rely on these keys for
+debugging, expect both a short-name key and a fully-qualified key when name
+collisions occur.
+
 ### Fixes
 
 - add `@openapi` to every operation you want documented

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 
 from azure_functions_openapi.decorator import register_openapi_metadata
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
-from azure_functions_openapi.registry import registry
+from azure_functions_openapi.registry import canonical_function_id, registry
 from azure_functions_openapi.routes import DEFAULT_ROUTE_PREFIX, normalize_route_prefix
 from azure_functions_openapi.utils import type_to_schema
 
@@ -294,6 +294,8 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
         if metadata is None:
             continue
 
+        canonical_id = canonical_function_id(handler)
+
         binding = _extract_http_binding(function_obj)
         if binding is None:
             logger.debug(
@@ -309,21 +311,38 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
             endpoint_key = f"{method}::{path}"
 
             with registry.lock:
-                explicit_by_name = registry.get(function_name)
-                explicit_by_endpoint = registry.get(endpoint_key)
+                # Resolve the target entry by, in order of trust:
+                #   1. canonical callable identity (collision-free),
+                #   2. the OpenAPI endpoint key (method::path),
+                #   3. the short function name (backward-compatible fallback).
+                target = registry.find_by_function_id(canonical_id)
+                match_kind = "canonical @openapi id"
 
-                if explicit_by_name is not None:
-                    _merge_into_existing(explicit_by_name, discovered)
-                    logger.debug(
-                        "Merged validation metadata into explicit @openapi entry '%s'",
-                        function_name,
-                    )
-                    continue
+                if target is None:
+                    target = registry.get(endpoint_key)
+                    match_kind = "OpenAPI endpoint"
 
-                if explicit_by_endpoint is not None:
-                    _merge_into_existing(explicit_by_endpoint, discovered)
+                if target is None:
+                    # Short-name fallback: refuse to merge when the name is
+                    # ambiguous (shared across modules) to avoid silently
+                    # attaching metadata to the wrong handler.
+                    if registry.count_by_function_name(function_name) > 1:
+                        logger.warning(
+                            "Refusing to merge validation metadata by ambiguous "
+                            "short name '%s': multiple @openapi entries share this "
+                            "name across modules. Registering a standalone endpoint "
+                            "instead.",
+                            function_name,
+                        )
+                    else:
+                        target = registry.get(function_name)
+                        match_kind = "short-name fallback"
+
+                if target is not None:
+                    _merge_into_existing(target, discovered)
                     logger.debug(
-                        "Merged validation metadata into explicit OpenAPI endpoint '%s'",
+                        "Merged validation metadata via %s into endpoint '%s'",
+                        match_kind,
                         endpoint_key,
                     )
                     continue

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -264,26 +264,6 @@ def openapi(
             resolved_response_model = response_model
             resolved_response = response
 
-            _deprecated_used = [
-                name
-                for name, value in (
-                    ("request_model", request_model),
-                    ("request_body", request_body),
-                    ("response_model", response_model),
-                    ("response", response),
-                )
-                if value is not None
-            ]
-            if _deprecated_used:
-                warnings.warn(
-                    f"The discrete @openapi parameter(s) {_deprecated_used} are "
-                    "deprecated in favor of the unified 'requests='/'responses=' "
-                    "parameters and will be removed in a future release. "
-                    "See https://github.com/yeongseon/azure-functions-openapi-python/issues/285.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-
             if requests is not None:
                 if request_model is not None or request_body is not None:
                     raise ValueError(
@@ -311,6 +291,30 @@ def openapi(
                     raise ValueError(
                         "'responses' must be either a Pydantic BaseModel subclass or a dictionary."
                     )
+
+            # Emit the deprecation warning only after mixed-style validation
+            # has passed, so callers hitting a ValueError above are not also
+            # warned about a config they were told is invalid.
+            _deprecated_used = [
+                name
+                for name, value in (
+                    ("request_model", request_model),
+                    ("request_body", request_body),
+                    ("response_model", response_model),
+                    ("response", response),
+                )
+                if value is not None
+            ]
+            if _deprecated_used:
+                warnings.warn(
+                    "The discrete @openapi parameter(s) "
+                    f"{', '.join(_deprecated_used)} are "
+                    "deprecated in favor of the unified 'requests='/'responses=' "
+                    "parameters and will be removed in a future release. "
+                    "See https://github.com/yeongseon/azure-functions-openapi-python/issues/285.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
 
             # Validate request/response models
             _validate_models(

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Callable, TypeVar, cast
+import warnings
 
 from azure.functions.decorators.function_app import FunctionBuilder
 from pydantic import BaseModel
 
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError, SDKIncompatibleError
-from azure_functions_openapi.registry import OpenAPIRegistry, registry
+from azure_functions_openapi.registry import OpenAPIRegistry, canonical_function_id, registry
 from azure_functions_openapi.utils import sanitize_operation_id, validate_route_path
 
 # Define a generic type variable for functions
@@ -205,16 +206,15 @@ def openapi(
         (equivalent to `response_model`) or a manual responses dict keyed by
         status code (equivalent to `response`).
 
-    .. note::
-       **Deprecation plan (pre-1.0).** This decorator currently exposes two
-       parallel parameter styles: the discrete pairs
-       (``request_model``/``request_body`` and ``response_model``/``response``)
-       and the unified parameters (``requests`` and ``responses``). Before the
-       1.0 contract freeze, only **one** documented style will ship. The
-       unified ``requests``/``responses`` parameters are the intended survivors;
-       the discrete parameters are planned for deprecation (with a release of
-       overlap and a ``DeprecationWarning``) and eventual removal. New code
-       should prefer ``requests``/``responses``. Tracking: issue #272.
+    .. deprecated::
+       This decorator currently exposes two parallel parameter styles: the
+       discrete pairs (``request_model``/``request_body`` and
+       ``response_model``/``response``) and the unified parameters
+       (``requests`` and ``responses``). The unified ``requests``/``responses``
+       parameters are the intended survivors; passing any of the discrete
+       parameters now emits a :class:`DeprecationWarning`. They will be removed
+       in a future release after a deprecation window. New code should prefer
+       ``requests``/``responses``. Tracking: issue #285.
 
     Returns
     -------
@@ -264,6 +264,26 @@ def openapi(
             resolved_response_model = response_model
             resolved_response = response
 
+            _deprecated_used = [
+                name
+                for name, value in (
+                    ("request_model", request_model),
+                    ("request_body", request_body),
+                    ("response_model", response_model),
+                    ("response", response),
+                )
+                if value is not None
+            ]
+            if _deprecated_used:
+                warnings.warn(
+                    f"The discrete @openapi parameter(s) {_deprecated_used} are "
+                    "deprecated in favor of the unified 'requests='/'responses=' "
+                    "parameters and will be removed in a future release. "
+                    "See https://github.com/yeongseon/azure-functions-openapi-python/issues/285.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+
             if requests is not None:
                 if request_model is not None or request_body is not None:
                     raise ValueError(
@@ -299,7 +319,7 @@ def openapi(
                 metadata_func.__name__,
             )
 
-            function_id = f"{metadata_func.__module__}.{metadata_func.__qualname__}"
+            function_id = canonical_function_id(metadata_func)
 
             with _registry_lock:
                 registry_key = metadata_func.__name__

--- a/src/azure_functions_openapi/registry.py
+++ b/src/azure_functions_openapi/registry.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from contextlib import AbstractContextManager
 import copy
+import inspect
 import threading
 from typing import Any
 
@@ -55,19 +56,33 @@ class OpenAPIRegistry:
         return self._entries
 
     def get(self, key: str) -> dict[str, Any] | None:
-        """Return the live entry stored under *key*, or ``None`` if absent."""
-        return self._entries.get(key)
+        """Return the live entry stored under *key*, or ``None`` if absent.
+
+        The returned dict is the *live* entry (not a copy). Callers that need a
+        consistent read-modify-write view must hold :attr:`lock` across the
+        whole ``get`` → mutate sequence; use :meth:`snapshot` when a detached
+        copy is acceptable.
+        """
+        with self._lock:
+            return self._entries.get(key)
 
     def set(self, key: str, value: dict[str, Any]) -> None:
-        """Store *value* under *key*. Caller must hold :attr:`lock`."""
-        self._entries[key] = value
+        """Store *value* under *key*.
+
+        Acquires :attr:`lock` internally. Because the lock is re-entrant, this
+        stays safe when the caller already holds it for a larger transaction.
+        """
+        with self._lock:
+            self._entries[key] = value
 
     def setdefault(self, key: str, value: dict[str, Any]) -> dict[str, Any]:
         """Insert *value* under *key* if absent; return the stored entry.
 
-        Caller must hold :attr:`lock`.
+        Acquires :attr:`lock` internally (re-entrant, so nesting inside an
+        outer ``with registry.lock:`` transaction is safe).
         """
-        return self._entries.setdefault(key, value)
+        with self._lock:
+            return self._entries.setdefault(key, value)
 
     def snapshot(self) -> dict[str, dict[str, Any]]:
         """Return a deep copy of all entries, taken under :attr:`lock`."""
@@ -79,7 +94,52 @@ class OpenAPIRegistry:
         with self._lock:
             self._entries.clear()
 
+    def find_by_function_id(self, function_id: str) -> dict[str, Any] | None:
+        """Return the entry whose ``_function_id`` equals *function_id*.
+
+        This is the collision-free lookup path: ``@openapi`` records a
+        canonical ``_function_id`` (see :func:`canonical_function_id`) for every
+        entry, so a handler can be resolved by identity regardless of how its
+        short name collides with other modules. Returns ``None`` if no entry
+        matches. Caller should hold :attr:`lock` when the result is used for a
+        read-modify-write transaction.
+        """
+        with self._lock:
+            for entry in self._entries.values():
+                if entry.get("_function_id") == function_id:
+                    return entry
+        return None
+
+    def count_by_function_name(self, function_name: str) -> int:
+        """Return how many entries carry ``function_name`` as their name.
+
+        Used to detect ambiguous short-name fallbacks (two handlers sharing a
+        short name across modules) so callers can refuse to merge silently.
+        """
+        with self._lock:
+            return sum(
+                1
+                for entry in self._entries.values()
+                if entry.get("function_name") == function_name
+            )
+
 
 # Process-wide singleton. The ``@openapi`` decorator records metadata at import
 # time — before any application object exists — so a shared instance is required.
 registry = OpenAPIRegistry()
+
+
+def canonical_function_id(handler: Any) -> str:
+    """Compute a stable, collision-free identity for a handler callable.
+
+    Unwraps decorator layers (``functools.wraps`` sets ``__wrapped__``) so that
+    an inner handler and any wrappers resolve to the same identity, then keys by
+    fully-qualified name: ``f"{module}.{qualname}"``. Both the ``@openapi``
+    decorator (when recording ``_function_id``) and the SDK bridge (when looking
+    an entry back up) use this helper, so they always agree on identity even
+    when two handlers share a short ``__name__`` across different modules.
+    """
+    target = inspect.unwrap(handler) if callable(handler) else handler
+    module = getattr(target, "__module__", "") or ""
+    qualname = getattr(target, "__qualname__", None) or getattr(target, "__name__", "") or ""
+    return f"{module}.{qualname}"

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -74,3 +74,41 @@ def test_discrete_and_unified_produce_identical_metadata() -> None:
     u = reg["unified"]
     assert d["request_model"] is u["request_model"] is ReqModel
     assert d["response_model"] is u["response_model"] is RespModel
+
+
+def test_no_deprecation_warning_when_mixed_style_raises() -> None:
+    # A caller mixing unified and discrete parameters gets a ValueError; the
+    # deprecation warning must not also fire in that case.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        with pytest.raises(ValueError, match="Cannot provide both"):
+
+            @openapi(
+                route="items",
+                method="post",
+                requests=ReqModel,
+                request_model=ReqModel,
+            )
+            def handler(req: Any) -> Any:
+                return req
+
+
+def test_deprecation_warning_lists_names_comma_separated() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+
+        @openapi(
+            route="items",
+            method="post",
+            request_model=ReqModel,
+            response_model=RespModel,
+        )
+        def handler(req: Any) -> Any:
+            return req
+
+    messages = [str(w.message) for w in caught if issubclass(w.category, DeprecationWarning)]
+    assert messages, "expected a DeprecationWarning"
+    message = messages[0]
+    assert "request_model, response_model" in message
+    # Must not be rendered as a Python list repr.
+    assert "['" not in message

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,0 +1,76 @@
+"""Tests for the discrete-parameter deprecation (issue #285)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+import warnings
+
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_openapi.decorator import (
+    clear_openapi_registry,
+    get_openapi_registry,
+    openapi,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+class ReqModel(BaseModel):
+    name: str
+
+
+class RespModel(BaseModel):
+    id: int
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"request_model": ReqModel},
+        {"request_body": {"type": "object"}},
+        {"response_model": RespModel},
+        {"response": {200: {"description": "ok"}}},
+    ],
+)
+def test_discrete_parameters_emit_deprecation_warning(kwargs: dict[str, Any]) -> None:
+    with pytest.warns(DeprecationWarning, match="unified"):
+
+        @openapi(route="items", method="post", **kwargs)
+        def handler(req: Any) -> Any:
+            return req
+
+
+def test_unified_parameters_do_not_warn() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+
+        @openapi(route="items", method="post", requests=ReqModel, responses=RespModel)
+        def handler(req: Any) -> Any:
+            return req
+
+
+def test_discrete_and_unified_produce_identical_metadata() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        @openapi(route="a", method="post", request_model=ReqModel, response_model=RespModel)
+        def discrete(req: Any) -> Any:
+            return req
+
+    @openapi(route="b", method="post", requests=ReqModel, responses=RespModel)
+    def unified(req: Any) -> Any:
+        return req
+
+    reg = get_openapi_registry()
+    d = reg["discrete"]
+    u = reg["unified"]
+    assert d["request_model"] is u["request_model"] is ReqModel
+    assert d["response_model"] is u["response_model"] is RespModel

--- a/tests/test_registry_identity.py
+++ b/tests/test_registry_identity.py
@@ -1,0 +1,196 @@
+"""Tests for registry identity/locking hardening (issues #279, #284)."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from functools import wraps
+import threading
+from typing import Any
+
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_openapi.bridge import scan_validation_metadata
+from azure_functions_openapi.decorator import (
+    clear_openapi_registry,
+    get_openapi_registry,
+    openapi,
+)
+from azure_functions_openapi.registry import (
+    OpenAPIRegistry,
+    canonical_function_id,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+# ── Mock Azure Functions SDK objects (mirrors tests/test_bridge.py) ──────────
+@dataclass
+class MockBinding:
+    route: str
+    methods: list[str] | None
+    type: str = "httpTrigger"
+
+
+@dataclass
+class MockFunction:
+    _name: str
+    _func: Any
+    _bindings: list[Any]
+
+
+@dataclass
+class MockBuilder:
+    _function: MockFunction
+
+
+@dataclass
+class MockApp:
+    _function_builders: list[MockBuilder]
+
+
+def _make_app(name: str, route: str, handler: Any, method: str = "post") -> MockApp:
+    binding = MockBinding(route=route, methods=[method.upper()])
+    fn = MockFunction(_name=name, _func=handler, _bindings=[binding])
+    return MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+
+def _set_validation(handler: Any, metadata: dict[str, Any]) -> None:
+    setattr(handler, "_azure_functions_metadata", {"validation": metadata})
+
+
+class Body(BaseModel):
+    name: str
+
+
+# Two @openapi handlers that share the short name ``create_user`` but live in
+# different scopes → different qualname → the classic cross-module collision.
+def _make_handler_a() -> Any:
+    @openapi(summary="A", route="users", method="post")
+    def create_user(req: Any) -> Any:
+        return req
+
+    return create_user
+
+
+def _make_handler_b() -> Any:
+    @openapi(summary="B", route="accounts", method="post")
+    def create_user(req: Any) -> Any:
+        return req
+
+    return create_user
+
+
+# ── #284: registry mutators are self-locking ────────────────────────────────
+def test_registry_set_and_setdefault_without_external_lock() -> None:
+    reg = OpenAPIRegistry()
+    reg.set("k", {"function_name": "k"})
+    assert reg.get("k") == {"function_name": "k"}
+    # setdefault returns existing without overwriting
+    assert reg.setdefault("k", {"function_name": "other"})["function_name"] == "k"
+    assert reg.setdefault("new", {"function_name": "new"})["function_name"] == "new"
+
+
+def test_registry_concurrent_registration_is_safe() -> None:
+    reg = OpenAPIRegistry()
+
+    def worker(i: int) -> None:
+        for j in range(50):
+            reg.set(f"{i}-{j}", {"function_name": f"{i}-{j}"})
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(reg.snapshot()) == 8 * 50
+
+
+# ── #279: canonical identity helper ─────────────────────────────────────────
+def test_canonical_function_id_uses_module_and_qualname() -> None:
+    def handler(req: Any) -> Any:
+        return req
+
+    cid = canonical_function_id(handler)
+    assert cid.endswith(".test_canonical_function_id_uses_module_and_qualname.<locals>.handler")
+    assert handler.__module__ in cid
+
+
+def test_canonical_function_id_unwraps_functools_wraps() -> None:
+    def inner(req: Any) -> Any:
+        return req
+
+    @wraps(inner)
+    def outer(req: Any) -> Any:
+        return inner(req)
+
+    assert canonical_function_id(outer) == canonical_function_id(inner)
+
+
+# ── #279: bridge merges into the correct entry despite short-name collision ──
+@pytest.mark.parametrize("register_a_first", [True, False])
+def test_bridge_merges_into_correct_handler_on_name_collision(register_a_first: bool) -> None:
+    if register_a_first:
+        handler_a = _make_handler_a()
+        handler_b = _make_handler_b()
+    else:
+        handler_b = _make_handler_b()
+        handler_a = _make_handler_a()
+
+    # Attach validation metadata only to handler A and scan it.
+    _set_validation(handler_a, {"body": Body})
+    app = _make_app(name="create_user", route="users", handler=handler_a)
+    scan_validation_metadata(app)
+
+    reg = get_openapi_registry()
+    a_id = canonical_function_id(handler_a)
+    b_id = canonical_function_id(handler_b)
+    entry_a = next(e for e in reg.values() if e.get("_function_id") == a_id)
+    entry_b = next(e for e in reg.values() if e.get("_function_id") == b_id)
+
+    # Metadata merged into A (its route), never into B.
+    assert entry_a.get("request_body") is not None
+    assert entry_a["summary"] == "A"
+    assert entry_b.get("request_body") is None
+    assert entry_b["summary"] == "B"
+
+
+def test_bridge_double_scan_does_not_duplicate(caplog: pytest.LogCaptureFixture) -> None:
+    handler_a = _make_handler_a()
+    _set_validation(handler_a, {"body": Body})
+    app = _make_app(name="create_user", route="users", handler=handler_a)
+
+    scan_validation_metadata(app)
+    count_after_first = len(get_openapi_registry())
+    scan_validation_metadata(app)
+    count_after_second = len(get_openapi_registry())
+
+    assert count_after_first == count_after_second
+
+
+def test_bridge_refuses_ambiguous_short_name_fallback(caplog: pytest.LogCaptureFixture) -> None:
+    # Two @openapi entries share the short name; scan a third, unregistered
+    # handler whose canonical id matches neither and whose route matches no
+    # endpoint. The short-name fallback must refuse to merge and warn.
+    _make_handler_a()
+    _make_handler_b()
+
+    def create_user(req: Any) -> Any:  # not @openapi-registered
+        return req
+
+    _set_validation(create_user, {"body": Body})
+    app = _make_app(name="create_user", route="unrelated", handler=create_user)
+
+    with caplog.at_level("WARNING"):
+        scan_validation_metadata(app)
+
+    assert any("ambiguous" in rec.message.lower() for rec in caplog.records)
+    # A standalone endpoint was registered instead of a wrong merge.
+    assert "post::/api/unrelated" in get_openapi_registry()


### PR DESCRIPTION
## Summary
Resolves three related registry/decorator issues in one changeset (they share `registry.py`, `bridge.py`, and `decorator.py`).

- **#279 — callable identity unification**: New `canonical_function_id()` (`module.qualname` resolved through `inspect.unwrap`) gives the decorator and bridge a single source of truth for function identity. Added `OpenAPIRegistry.find_by_function_id()` and `count_by_function_name()`. Bridge lookup order is now: (1) `find_by_function_id(canonical_id)`, (2) endpoint key `method::path`, (3) short-name fallback **only when unambiguous** — otherwise it logs a warning and registers standalone. The `method::path` endpoint key is preserved.
- **#284 — self-locking mutators**: `OpenAPIRegistry.set()`, `setdefault()`, and `get()` now acquire the internal `RLock` themselves. The lock is re-entrant, so these remain safe inside existing outer transactions.
- **#285 — deprecate discrete params**: `@openapi` emits a `DeprecationWarning` when any of `request_model` / `request_body` / `response_model` / `response` is supplied, steering callers toward the unified `requests=` / `responses=` API. The programmatic `register_openapi_metadata` path is intentionally left unchanged. No 1.0 framing.

## Tests
- New `tests/test_registry_identity.py` (self-locking, 8×50 concurrency, `canonical_function_id` module/qualname + `functools.wraps` unwrap, order-independent collision merge, double-scan no-dup, ambiguous fallback warns).
- New `tests/test_deprecation.py` (discrete params warn, unified params don't, identical metadata output).
- Full suite: **503 passed, 5 skipped**, coverage **96.17%** (≥95% gate). `make lint` + `make typecheck` clean.

## Notes
- Registry key / `_function_id` behavior is observable via `get_openapi_registry()`, but `spec.py` emits from `meta["function_name"]`/`meta["route"]`, so generated specs are unaffected.
- One PR intentionally covers three issues due to the overlapping files.

Closes #279
Closes #284
Closes #285