### PR TITLE
docs: merge redundant Features list into What it does

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Spec matches code. Always. Swagger UI out of the box.
 - **Auto-generated spec** — `/openapi.json` and `/openapi.yaml` endpoints from decorated handlers
 - **Swagger UI** — built-in `/docs` endpoint with security defaults
 - **CLI tooling** — generate specs at build time for CI validation
+- **Schema support** — query, path, header, body, and response schemas
 
 
 ### How it fits together
@@ -131,14 +132,6 @@ This package does not own:
 - Runtime exposure or graph deployment — use [`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph-python)
 - Request/response validation or serialization — use [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python)
 - Project scaffolding — use [`azure-functions-scaffold`](https://github.com/yeongseon/azure-functions-scaffold-python)
-
-## Features
-
-- `@openapi` decorator for operation metadata
-- `/openapi.json`, `/openapi.yaml`, and `/docs` endpoints
-- Query, path, header, body, and response schema support
-- Swagger UI helper with security defaults
-- CLI tooling for spec generation (JSON and YAML output)
 
 ## CLI Quick Start
 


### PR DESCRIPTION
## Summary
- Fold the unique "schema support" bullet into `## What it does` and remove the redundant `## Features` section (no information lost).

Closes #294