### PR TITLE
docs: require translation sync in the same PR as English changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,11 @@
 - Keep documentation examples, generated schema expectations, and tests synchronized.
 - Prefer focused changes inside the existing extension points.
 
+### Documentation & Translations
+- When a change touches `README.md` or any English documentation, update the translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) **in the same PR** so translations never drift from the English source.
+- This applies to any code change that alters documented behavior, CLI output, or the ecosystem/package table — not just direct edits to prose.
+- If a full translation cannot land in the same PR, add a short "translation pending" note to the affected translated file and open a tracking issue before merging.
+
 ## PR Workflow
 
 **Always issue-first.** Before opening any PR:


### PR DESCRIPTION
## Summary
Adds a **Documentation & Translations** rule to `AGENTS.md` under `## Working Rules`: whenever a change touches `README.md` or English docs (including code changes that alter documented behavior, CLI output, or the ecosystem table), the translated READMEs (`README.ko.md` / `README.ja.md` / `README.zh-CN.md`) must be updated **in the same PR**.

Codifies the practice we just applied when syncing the Ecosystem tables.

Closes #301