### PR TITLE
docs: sync translated READMEs with Pydantic-first Quick Start

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,13 +13,68 @@
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
-> ⚠️ この翻訳は古い可能性があります。最新の内容は [README.md](README.md) を参照してください。
-
 **Azure Functions Python v2 プログラミング モデル**向けの OpenAPI（Swagger）ドキュメント生成と Swagger UI を提供します。
 
 ## Why Use It
 
 Azure Functions の HTTP API をドキュメント化するには、通常、別途 OpenAPI スペックを手作業で管理する必要があります。`azure-functions-openapi` はデコレータ付きハンドラーからスペックを自動生成し、ドキュメントとコードの同期を維持します。
+
+## Before / After
+
+**❌ azure-functions-openapi なし** — スペックを手作業で管理
+
+```python
+# openapi_spec.json — 手で書き、手で更新
+{
+    "paths": {
+        "/api/users": {
+            "post": {
+                "summary": "Create user",
+                "requestBody": { "...": "..." },
+                "responses": { "200": { "...": "..." } }
+            }
+        }
+    }
+}
+
+# function_app.py — 上のスペックとは何の連携もない
+@app.route(route="users", methods=["POST"])
+def create_user(req):
+    ...
+```
+
+スペックはずれ、利用者は推測し、Swagger UI もありません。
+
+**✅ azure-functions-openapi あり** — スペックがハンドラの隣に存在
+
+```python
+from pydantic import BaseModel
+
+
+class CreateUserRequest(BaseModel):
+    name: str
+
+
+class UserResponse(BaseModel):
+    id: str
+    name: str
+
+
+@openapi(
+    summary="Create user",
+    request_model=CreateUserRequest,
+    response_model=UserResponse,
+)
+@app.route(route="users", methods=["POST"])
+def create_user(req):
+    ...
+
+# 自動生成されるエンドポイント:
+# GET /api/openapi.json  — 常にコードと同期
+# GET /api/docs          — Swagger UI を含む
+```
+
+スペックは常にコードと一致します。Swagger UI も標準で提供されます。
 
 ## Scope
 
@@ -57,6 +112,7 @@ azure-functions-openapi
 import json
 
 import azure.functions as func
+from pydantic import BaseModel
 
 from azure_functions_openapi import (
     get_openapi_json,
@@ -65,15 +121,81 @@ from azure_functions_openapi import (
     render_swagger_ui,
 )
 
-
 app = func.FunctionApp()
 
 
-@app.function_name(name="http_trigger")
+# 普通の Pydantic モデルで API を記述します。
+class GreetRequest(BaseModel):
+    name: str
+
+
+class GreetResponse(BaseModel):
+    message: str
+
+
+# @openapi は下の @app.route から route と method を推論します —
+# ここで再度指定する必要はありません。
 @openapi(
     summary="Greet user",
-    route="/api/http_trigger",
-    method="post",
+    tags=["Example"],
+    request_model=GreetRequest,
+    response_model=GreetResponse,
+)
+@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
+def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
+    # @openapi はリクエスト/レスポンスの契約を文書化するだけで、検証はしません。
+    # ランタイム検証は azure-functions-validation を参照してください。
+    data = req.get_json()
+    name = data.get("name", "world")
+    return func.HttpResponse(
+        json.dumps({"message": f"Hello, {name}!"}),
+        mimetype="application/json",
+    )
+```
+
+> **Pydantic v2 は任意です。** `request_model=` / `response_model=` を推奨しますが、依存関係を追加したくなければ生の JSON Schema dict を代わりに渡すこともできます（下記参照）。
+
+<details>
+<summary>スペック + Swagger UI エンドポイントの接続 (openapi.json / openapi.yaml / docs)</summary>
+
+```python
+# 生成されたスペックと Swagger UI を通常の HTTP ルートとして提供します。
+@app.route(route="openapi.json", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+def openapi_json(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(
+        get_openapi_json(
+            title="Sample API",
+            description="OpenAPI document for the Sample API.",
+        ),
+        mimetype="application/json",
+    )
+
+
+@app.route(route="openapi.yaml", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+def openapi_yaml(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(
+        get_openapi_yaml(
+            title="Sample API",
+            description="OpenAPI document for the Sample API.",
+        ),
+        mimetype="application/x-yaml",
+    )
+
+
+@app.route(route="docs", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
+    return render_swagger_ui()
+```
+
+</details>
+
+<details>
+<summary>上級: Pydantic の代わりに生の JSON Schema でスキーマを記述</summary>
+
+```python
+@openapi(
+    summary="Greet user",
+    tags=["Example"],
     request_body={
         "type": "object",
         "properties": {"name": {"type": "string"}},
@@ -92,46 +214,13 @@ app = func.FunctionApp()
             },
         }
     },
-    tags=["Example"],
-    )
+)
 @app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
-    data = req.get_json()
-    name = data.get("name", "world")
-    return func.HttpResponse(
-        json.dumps({"message": f"Hello, {name}!"}),
-        mimetype="application/json",
-    )
-
-@app.function_name(name="openapi_json")
-@app.route(route="openapi.json", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
-def openapi_json(req: func.HttpRequest) -> func.HttpResponse:
-    return func.HttpResponse(
-        get_openapi_json(
-            title="Sample API",
-            description="OpenAPI document for the Sample API.",
-        ),
-        mimetype="application/json",
-    )
-
-
-@app.function_name(name="openapi_yaml")
-@app.route(route="openapi.yaml", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
-def openapi_yaml(req: func.HttpRequest) -> func.HttpResponse:
-    return func.HttpResponse(
-        get_openapi_yaml(
-            title="Sample API",
-            description="OpenAPI document for the Sample API.",
-        ),
-        mimetype="application/x-yaml",
-    )
-
-
-@app.function_name(name="swagger_ui")
-@app.route(route="docs", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
-def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
-    return render_swagger_ui()
+    ...
 ```
+
+</details>
 
 ローカルでは Azure Functions Core Tools で実行できます。
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,13 +13,68 @@
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
-> ⚠️ 이 번역은 오래되었을 수 있습니다. 최신 내용은 [README.md](README.md)를 참고하세요.
-
 **Azure Functions Python v2 프로그래밍 모델**을 위한 OpenAPI(Swagger) 문서화와 Swagger UI를 제공합니다.
 
 ## Why Use It
 
 Azure Functions HTTP API를 문서화하려면 일반적으로 별도의 OpenAPI 스펙을 수동으로 유지해야 합니다. `azure-functions-openapi`는 데코레이터가 적용된 핸들러에서 자동으로 스펙을 생성하여 문서와 코드를 항상 동기화된 상태로 유지합니다.
+
+## Before / After
+
+**❌ azure-functions-openapi 없이** — 스펙을 손으로 관리
+
+```python
+# openapi_spec.json — 직접 작성하고 직접 갱신
+{
+    "paths": {
+        "/api/users": {
+            "post": {
+                "summary": "Create user",
+                "requestBody": { "...": "..." },
+                "responses": { "200": { "...": "..." } }
+            }
+        }
+    }
+}
+
+# function_app.py — 위 스펙과 아무런 연결이 없음
+@app.route(route="users", methods=["POST"])
+def create_user(req):
+    ...
+```
+
+스펙은 어긋나고, 사용자는 추측하며, Swagger UI도 없습니다.
+
+**✅ azure-functions-openapi 사용** — 스펙이 핸들러 옆에 존재
+
+```python
+from pydantic import BaseModel
+
+
+class CreateUserRequest(BaseModel):
+    name: str
+
+
+class UserResponse(BaseModel):
+    id: str
+    name: str
+
+
+@openapi(
+    summary="Create user",
+    request_model=CreateUserRequest,
+    response_model=UserResponse,
+)
+@app.route(route="users", methods=["POST"])
+def create_user(req):
+    ...
+
+# 자동 생성되는 엔드포인트:
+# GET /api/openapi.json  — 항상 코드와 동기화
+# GET /api/docs          — Swagger UI 포함
+```
+
+스펙이 항상 코드와 일치합니다. Swagger UI도 기본 제공됩니다.
 
 ## Scope
 
@@ -57,6 +112,7 @@ azure-functions-openapi
 import json
 
 import azure.functions as func
+from pydantic import BaseModel
 
 from azure_functions_openapi import (
     get_openapi_json,
@@ -65,15 +121,81 @@ from azure_functions_openapi import (
     render_swagger_ui,
 )
 
-
 app = func.FunctionApp()
 
 
-@app.function_name(name="http_trigger")
+# 일반 Pydantic 모델로 API를 기술합니다.
+class GreetRequest(BaseModel):
+    name: str
+
+
+class GreetResponse(BaseModel):
+    message: str
+
+
+# @openapi는 아래 @app.route에서 route와 method를 추론합니다 —
+# 여기서 다시 지정할 필요가 없습니다.
 @openapi(
     summary="Greet user",
-    route="/api/http_trigger",
-    method="post",
+    tags=["Example"],
+    request_model=GreetRequest,
+    response_model=GreetResponse,
+)
+@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
+def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
+    # @openapi는 요청/응답 계약을 문서화할 뿐, 검증하지는 않습니다.
+    # 런타임 검증은 azure-functions-validation을 참고하세요.
+    data = req.get_json()
+    name = data.get("name", "world")
+    return func.HttpResponse(
+        json.dumps({"message": f"Hello, {name}!"}),
+        mimetype="application/json",
+    )
+```
+
+> **Pydantic v2는 선택 사항입니다.** `request_model=` / `response_model=`을 권장하지만, 의존성을 추가하고 싶지 않다면 원시 JSON Schema dict를 대신 전달할 수 있습니다(아래 참고).
+
+<details>
+<summary>스펙 + Swagger UI 엔드포인트 연결 (openapi.json / openapi.yaml / docs)</summary>
+
+```python
+# 생성된 스펙과 Swagger UI를 일반 HTTP 라우트로 제공합니다.
+@app.route(route="openapi.json", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+def openapi_json(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(
+        get_openapi_json(
+            title="Sample API",
+            description="OpenAPI document for the Sample API.",
+        ),
+        mimetype="application/json",
+    )
+
+
+@app.route(route="openapi.yaml", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+def openapi_yaml(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(
+        get_openapi_yaml(
+            title="Sample API",
+            description="OpenAPI document for the Sample API.",
+        ),
+        mimetype="application/x-yaml",
+    )
+
+
+@app.route(route="docs", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
+    return render_swagger_ui()
+```
+
+</details>
+
+<details>
+<summary>고급: Pydantic 대신 원시 JSON Schema로 스키마 기술</summary>
+
+```python
+@openapi(
+    summary="Greet user",
+    tags=["Example"],
     request_body={
         "type": "object",
         "properties": {"name": {"type": "string"}},
@@ -92,46 +214,13 @@ app = func.FunctionApp()
             },
         }
     },
-    tags=["Example"],
-    )
+)
 @app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
-    data = req.get_json()
-    name = data.get("name", "world")
-    return func.HttpResponse(
-        json.dumps({"message": f"Hello, {name}!"}),
-        mimetype="application/json",
-    )
-
-@app.function_name(name="openapi_json")
-@app.route(route="openapi.json", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
-def openapi_json(req: func.HttpRequest) -> func.HttpResponse:
-    return func.HttpResponse(
-        get_openapi_json(
-            title="Sample API",
-            description="OpenAPI document for the Sample API.",
-        ),
-        mimetype="application/json",
-    )
-
-
-@app.function_name(name="openapi_yaml")
-@app.route(route="openapi.yaml", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
-def openapi_yaml(req: func.HttpRequest) -> func.HttpResponse:
-    return func.HttpResponse(
-        get_openapi_yaml(
-            title="Sample API",
-            description="OpenAPI document for the Sample API.",
-        ),
-        mimetype="application/x-yaml",
-    )
-
-
-@app.function_name(name="swagger_ui")
-@app.route(route="docs", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
-def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
-    return render_swagger_ui()
+    ...
 ```
+
+</details>
 
 로컬에서는 Azure Functions Core Tools로 실행할 수 있습니다.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,13 +13,68 @@
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
 
-> ⚠️ 此翻译可能已过时。最新内容请参阅 [README.md](README.md)。
-
 为 **Azure Functions Python v2 编程模型**提供 OpenAPI（Swagger）文档生成和 Swagger UI。
 
 ## Why Use It
 
 记录 Azure Functions HTTP API 通常需要手动维护单独的 OpenAPI 规范。`azure-functions-openapi` 可从带装饰器的处理函数自动生成规范，使文档和代码始终保持同步。
+
+## Before / After
+
+**❌ 不使用 azure-functions-openapi** — 手动维护规范
+
+```python
+# openapi_spec.json — 手写并手动更新
+{
+    "paths": {
+        "/api/users": {
+            "post": {
+                "summary": "Create user",
+                "requestBody": { "...": "..." },
+                "responses": { "200": { "...": "..." } }
+            }
+        }
+    }
+}
+
+# function_app.py — 与上方的规范没有任何关联
+@app.route(route="users", methods=["POST"])
+def create_user(req):
+    ...
+```
+
+规范会偏离，使用者只能猜测，也没有 Swagger UI。
+
+**✅ 使用 azure-functions-openapi** — 规范就在处理器旁边
+
+```python
+from pydantic import BaseModel
+
+
+class CreateUserRequest(BaseModel):
+    name: str
+
+
+class UserResponse(BaseModel):
+    id: str
+    name: str
+
+
+@openapi(
+    summary="Create user",
+    request_model=CreateUserRequest,
+    response_model=UserResponse,
+)
+@app.route(route="users", methods=["POST"])
+def create_user(req):
+    ...
+
+# 自动生成的端点：
+# GET /api/openapi.json  — 始终与代码同步
+# GET /api/docs          — 内置 Swagger UI
+```
+
+规范始终与代码一致，开箱即用的 Swagger UI。
 
 ## Scope
 
@@ -57,6 +112,7 @@ azure-functions-openapi
 import json
 
 import azure.functions as func
+from pydantic import BaseModel
 
 from azure_functions_openapi import (
     get_openapi_json,
@@ -65,15 +121,81 @@ from azure_functions_openapi import (
     render_swagger_ui,
 )
 
-
 app = func.FunctionApp()
 
 
-@app.function_name(name="http_trigger")
+# 使用普通的 Pydantic 模型描述你的 API。
+class GreetRequest(BaseModel):
+    name: str
+
+
+class GreetResponse(BaseModel):
+    message: str
+
+
+# @openapi 会从下方的 @app.route 推断 route 和 method —
+# 无需在此处重复指定。
 @openapi(
     summary="Greet user",
-    route="/api/http_trigger",
-    method="post",
+    tags=["Example"],
+    request_model=GreetRequest,
+    response_model=GreetResponse,
+)
+@app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
+def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
+    # @openapi 仅记录请求/响应契约，并不进行验证。
+    # 运行时验证请参阅 azure-functions-validation。
+    data = req.get_json()
+    name = data.get("name", "world")
+    return func.HttpResponse(
+        json.dumps({"message": f"Hello, {name}!"}),
+        mimetype="application/json",
+    )
+```
+
+> **Pydantic v2 为可选项。** 推荐使用 `request_model=` / `response_model=`，但如果你不想添加依赖，也可以改为传入原始 JSON Schema dict（见下文）。
+
+<details>
+<summary>连接规范 + Swagger UI 端点 (openapi.json / openapi.yaml / docs)</summary>
+
+```python
+# 将生成的规范和 Swagger UI 作为普通 HTTP 路由提供。
+@app.route(route="openapi.json", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+def openapi_json(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(
+        get_openapi_json(
+            title="Sample API",
+            description="OpenAPI document for the Sample API.",
+        ),
+        mimetype="application/json",
+    )
+
+
+@app.route(route="openapi.yaml", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+def openapi_yaml(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(
+        get_openapi_yaml(
+            title="Sample API",
+            description="OpenAPI document for the Sample API.",
+        ),
+        mimetype="application/x-yaml",
+    )
+
+
+@app.route(route="docs", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
+    return render_swagger_ui()
+```
+
+</details>
+
+<details>
+<summary>高级：使用原始 JSON Schema 而非 Pydantic 描述模式</summary>
+
+```python
+@openapi(
+    summary="Greet user",
+    tags=["Example"],
     request_body={
         "type": "object",
         "properties": {"name": {"type": "string"}},
@@ -92,48 +214,15 @@ app = func.FunctionApp()
             },
         }
     },
-    tags=["Example"],
-    )
+)
 @app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
-    data = req.get_json()
-    name = data.get("name", "world")
-    return func.HttpResponse(
-        json.dumps({"message": f"Hello, {name}!"}),
-        mimetype="application/json",
-    )
-
-@app.function_name(name="openapi_json")
-@app.route(route="openapi.json", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
-def openapi_json(req: func.HttpRequest) -> func.HttpResponse:
-    return func.HttpResponse(
-        get_openapi_json(
-            title="Sample API",
-            description="OpenAPI document for the Sample API.",
-        ),
-        mimetype="application/json",
-    )
-
-
-@app.function_name(name="openapi_yaml")
-@app.route(route="openapi.yaml", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
-def openapi_yaml(req: func.HttpRequest) -> func.HttpResponse:
-    return func.HttpResponse(
-        get_openapi_yaml(
-            title="Sample API",
-            description="OpenAPI document for the Sample API.",
-        ),
-        mimetype="application/x-yaml",
-    )
-
-
-@app.function_name(name="swagger_ui")
-@app.route(route="docs", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
-def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
-    return render_swagger_ui()
+    ...
 ```
 
-可使用 Azure Functions Core Tools 在本地运行：
+</details>
+
+在本地可使用 Azure Functions Core Tools 运行。
 
 ```bash
 func start


### PR DESCRIPTION
## Summary
Brings the ko/ja/zh-CN READMEs back into parity with the English Pydantic-first Quick Start (reworked in #290 / #289).

- **Before / After**: adds the localized section that leads with `request_model=` / `response_model=` Pydantic models.
- **Quick Start**: reworked to the clean Pydantic path; `@openapi` infers route/method from `@app.route`, and the `openapi.json` / `openapi.yaml` / `docs` plumbing is folded into a `<details>` block.
- **Advanced**: raw JSON Schema path preserved under an "Advanced" `<details>` section.
- Adds the localized "documents the contract but does **not** validate (validation lives in `azure-functions-validation`)" note to each handler.
- Removes the "this translation may be outdated" banner from all three files.

## Verification
- All Python code blocks in every README parse via `ast.parse` (5 blocks each, matching the English README).

Closes #291