### PR TITLE
feat(bridge): read the shared endpoint namespace for OpenAPI generation

### DIFF
--- a/src/azure_functions_openapi/_endpoint_contract.py
+++ b/src/azure_functions_openapi/_endpoint_contract.py
@@ -1,0 +1,48 @@
+"""Read-side contract for the shared ``endpoint`` namespace metadata.
+
+Producer packages (``azure-functions-validation``, ``azure-functions-langgraph``,
+...) write a self-contained, OpenAPI-ready payload onto handlers under the
+``_azure_functions_metadata`` convention attribute, namespace ``"endpoint"``.
+Unlike the ``validation`` namespace (which carries user-defined Pydantic model
+*classes*), the ``endpoint`` payload is entirely JSON Schema, so this consumer
+needs **no** import of the producing package and no access to the user's models.
+
+This module mirrors the *shape the bridge reads* as a ``TypedDict`` so the
+consumed contract is explicit and type-checked. The producer's canonical schema
+lives in ``azure-functions-validation`` (``schemas/endpoint.schema.json``); the
+two packages release independently, so this read-side mirror keeps the
+consumer's expectations pinned even as producers evolve.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+# Convention attribute name shared across every Azure Functions toolkit package.
+HANDLER_METADATA_ATTR = "_azure_functions_metadata"
+
+# Namespace owned by the shared endpoint contract.
+ENDPOINT_NAMESPACE = "endpoint"
+
+# Payload ``version`` values this consumer understands.
+SUPPORTED_ENDPOINT_VERSIONS: frozenset[int] = frozenset({1})
+
+
+class _EndpointMetadataRequired(TypedDict):
+    """Keys present on every endpoint payload."""
+
+    version: int
+
+
+class EndpointMetadata(_EndpointMetadataRequired, total=False):
+    """The ``endpoint`` namespace payload read from ``HANDLER_METADATA_ATTR``.
+
+    All schema fields are self-contained JSON Schema dicts (no model classes).
+    Pydantic ``$defs`` are kept unresolved by the producer (refs point at
+    ``#/$defs/{Model}``); this consumer is the sole ``$ref``-collision authority.
+    """
+
+    request_body: dict[str, Any] | None
+    request_body_required: bool
+    parameters: list[dict[str, Any]]
+    responses: dict[str, dict[str, Any]] | None

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -257,6 +257,10 @@ def _discovered_operation_from_endpoint(
             if not isinstance(detail, dict):
                 continue
             try:
+                # Reject booleans explicitly: ``bool`` is a subclass of ``int``,
+                # so ``int(True)``/``int(False)`` would silently become 1/0.
+                if isinstance(status, bool):
+                    raise TypeError
                 status_code = int(status)
             except (TypeError, ValueError):
                 logger.warning(
@@ -276,7 +280,11 @@ def _discovered_operation_from_endpoint(
         "route": path,
         "method": method,
         "request_body": request_body,
-        "request_body_required": bool(endpoint.get("request_body_required", True)),
+        "request_body_required": (
+            endpoint["request_body_required"]
+            if isinstance(endpoint.get("request_body_required"), bool)
+            else True
+        ),
         "parameters": parameters,
         "response": response,
     }

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -7,6 +7,10 @@ from typing import Any, get_origin
 
 from pydantic import BaseModel
 
+from azure_functions_openapi._endpoint_contract import (
+    ENDPOINT_NAMESPACE,
+    SUPPORTED_ENDPOINT_VERSIONS,
+)
 from azure_functions_openapi._validation_contract import (
     HANDLER_METADATA_ATTR,
     SUPPORTED_VALIDATION_VERSIONS,
@@ -125,6 +129,13 @@ def _models_conflict(existing: dict[str, Any], discovered: dict[str, Any]) -> bo
     except OpenAPISpecConfigError:
         return True
 
+    existing_response = existing.get("response") or {}
+    discovered_response = discovered.get("response") or {}
+    if isinstance(existing_response, dict) and isinstance(discovered_response, dict):
+        for status, detail in discovered_response.items():
+            if status in existing_response and existing_response[status] != detail:
+                return True
+
     return False
 
 
@@ -134,9 +145,20 @@ def _merge_into_existing(existing: dict[str, Any], discovered: dict[str, Any]) -
 
     if not existing.get("request_body") and discovered.get("request_body"):
         existing["request_body"] = discovered["request_body"]
+        if "request_body_required" in discovered:
+            existing["request_body_required"] = discovered["request_body_required"]
 
     if not existing.get("response_model") and discovered.get("response_model"):
         existing["response_model"] = discovered["response_model"]
+
+    discovered_response = discovered.get("response")
+    if isinstance(discovered_response, dict) and discovered_response:
+        existing_response = existing.get("response")
+        if not isinstance(existing_response, dict):
+            existing_response = {}
+        for status, detail in discovered_response.items():
+            existing_response.setdefault(status, detail)
+        existing["response"] = existing_response
 
     existing_params = existing.get("parameters", [])
     discovered_params = discovered.get("parameters", [])
@@ -209,6 +231,57 @@ def _discovered_operation(
     }
 
 
+def _discovered_operation_from_endpoint(
+    function_name: str, endpoint: dict[str, Any], path: str, method: str
+) -> dict[str, Any]:
+    """Build a discovered-operation dict from the self-contained ``endpoint`` payload.
+
+    Unlike :func:`_discovered_operation`, every schema field here is already a
+    JSON Schema dict authored by the producer, so no Pydantic model access is
+    needed. The producer's ``responses`` map is ``{"<status>": {"schema": ...}}``;
+    we wrap each entry into a full OpenAPI response object so the spec generator
+    can embed it verbatim.
+    """
+    raw_request_body = endpoint.get("request_body")
+    request_body = raw_request_body if isinstance(raw_request_body, dict) else None
+
+    raw_parameters = endpoint.get("parameters")
+    parameters = [p for p in raw_parameters if isinstance(p, dict)] if isinstance(
+        raw_parameters, list
+    ) else []
+
+    response: dict[int, dict[str, Any]] = {}
+    raw_responses = endpoint.get("responses")
+    if isinstance(raw_responses, dict):
+        for status, detail in raw_responses.items():
+            if not isinstance(detail, dict):
+                continue
+            try:
+                status_code = int(status)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Skipping endpoint response with non-integer status %r on %r",
+                    status,
+                    function_name,
+                )
+                continue
+            schema = detail.get("schema")
+            response[status_code] = {
+                "description": detail.get("description", ""),
+                "content": {"application/json": {"schema": schema}},
+            }
+
+    return {
+        "function_name": function_name,
+        "route": path,
+        "method": method,
+        "request_body": request_body,
+        "request_body_required": bool(endpoint.get("request_body_required", True)),
+        "parameters": parameters,
+        "response": response,
+    }
+
+
 # Maximum decorator depth to walk when chasing ``__wrapped__``.
 _MAX_WRAPPED_DEPTH = 16
 
@@ -267,6 +340,53 @@ def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
     return None
 
 
+def _read_endpoint_hints(handler: Any) -> dict[str, Any] | None:
+    """Read shared ``endpoint`` namespace metadata from a handler.
+
+    Mirrors :func:`_read_validation_hints` but targets the self-contained
+    ``endpoint`` namespace (pure JSON Schema, no model classes). Walks the
+    ``__wrapped__`` chain (outer -> inner) for the first handler carrying
+    ``_azure_functions_metadata["endpoint"]``.
+
+    Version policy (``version`` is a required key on the endpoint payload):
+    * Present and supported -> accepted.
+    * Missing, malformed, or unsupported -> ``logger.warning()`` + continue walking.
+
+    Returns a *deep copy* so callers cannot mutate the handler attribute.
+    """
+    current: Any = handler
+    for _ in range(_MAX_WRAPPED_DEPTH):
+        toolkit_meta = getattr(current, HANDLER_METADATA_ATTR, None)
+        if isinstance(toolkit_meta, dict):
+            hints = toolkit_meta.get(ENDPOINT_NAMESPACE)
+            if isinstance(hints, dict):
+                raw_version = hints.get("version")
+                if (
+                    type(raw_version) is not int
+                    or raw_version not in SUPPORTED_ENDPOINT_VERSIONS
+                ):
+                    logger.warning(
+                        "Skipping endpoint metadata on %r: unsupported version %r "
+                        "(supported: %s)",
+                        current,
+                        raw_version,
+                        ", ".join(str(v) for v in sorted(SUPPORTED_ENDPOINT_VERSIONS)),
+                    )
+                    wrapped = getattr(current, "__wrapped__", None)
+                    if wrapped is None or wrapped is current:
+                        break
+                    current = wrapped
+                    continue
+                return copy.deepcopy(hints)
+
+        wrapped = getattr(current, "__wrapped__", None)
+        if wrapped is None or wrapped is current:
+            break
+        current = wrapped
+
+    return None
+
+
 def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -> None:
     """Scan function builders for validation metadata and register OpenAPI operations.
 
@@ -291,8 +411,9 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
         handler = getattr(function_obj, "_func", None)
         if handler is None:
             continue
-        metadata = _read_validation_hints(handler)
-        if metadata is None:
+        endpoint_hints = _read_endpoint_hints(handler)
+        metadata = None if endpoint_hints is not None else _read_validation_hints(handler)
+        if endpoint_hints is None and metadata is None:
             continue
 
         canonical_id = canonical_function_id(handler)
@@ -308,7 +429,14 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
         methods = _extract_methods(binding)
 
         for method in methods:
-            discovered = _discovered_operation(function_name, metadata, path, method)
+            if endpoint_hints is not None:
+                discovered = _discovered_operation_from_endpoint(
+                    function_name, endpoint_hints, path, method
+                )
+            elif metadata is not None:
+                discovered = _discovered_operation(function_name, metadata, path, method)
+            else:  # pragma: no cover - guarded above (endpoint or metadata is set)
+                continue
             endpoint_key = f"{method}::{path}"
 
             with registry.lock:
@@ -348,13 +476,23 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
                     )
                     continue
 
-            register_openapi_metadata(
-                path=path,
-                method=method,
-                request_body=discovered.get("request_body"),
-                response_model=discovered.get("response_model")
-                if _is_base_model_type(discovered.get("response_model"))
-                else None,
-                parameters=discovered.get("parameters") or None,
-            )
+            if endpoint_hints is not None:
+                register_openapi_metadata(
+                    path=path,
+                    method=method,
+                    request_body=discovered.get("request_body"),
+                    request_body_required=discovered.get("request_body_required", True),
+                    response=discovered.get("response") or None,
+                    parameters=discovered.get("parameters") or None,
+                )
+            else:
+                register_openapi_metadata(
+                    path=path,
+                    method=method,
+                    request_body=discovered.get("request_body"),
+                    response_model=discovered.get("response_model")
+                    if _is_base_model_type(discovered.get("response_model"))
+                    else None,
+                    parameters=discovered.get("parameters") or None,
+                )
             logger.debug("Registered validation metadata for endpoint '%s'", endpoint_key)

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_openapi.bridge import (
+    _HANDLER_METADATA_ATTR,
+    _discovered_operation_from_endpoint,
+    _models_conflict,
+    _read_endpoint_hints,
+    scan_validation_metadata,
+)
+from azure_functions_openapi.decorator import (
+    clear_openapi_registry,
+    get_openapi_registry,
+    register_openapi_metadata,
+)
+from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+# A representative flat endpoint payload (all JSON Schema, no model classes).
+FLAT_ENDPOINT: dict[str, Any] = {
+    "version": 1,
+    "request_body": {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    },
+    "request_body_required": True,
+    "parameters": [
+        {"name": "limit", "in": "query", "required": False, "schema": {"type": "integer"}},
+    ],
+    "responses": {
+        "200": {"schema": {"type": "object", "properties": {"id": {"type": "integer"}}}},
+    },
+}
+
+
+class MockBinding:
+    def __init__(self, route: str, methods: list[str] | None, type: str = "httpTrigger") -> None:
+        self.route = route
+        self.methods = methods
+        self.type = type
+
+
+class MockFunction:
+    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
+        self._name = name
+        self._func = func
+        self._bindings = bindings
+
+
+class MockBuilder:
+    def __init__(self, function: MockFunction) -> None:
+        self._function = function
+
+
+class MockApp:
+    def __init__(self, builders: list[MockBuilder]) -> None:
+        self._function_builders = builders
+
+
+def _make_handler(namespaces: dict[str, Any]) -> Any:
+    def handler(req: Any) -> Any:
+        return req
+
+    setattr(handler, _HANDLER_METADATA_ATTR, namespaces)
+    return handler
+
+
+def _make_app(
+    namespaces: dict[str, Any],
+    *,
+    name: str = "create_user",
+    route: str = "users",
+    methods: list[str] | None = None,
+) -> MockApp:
+    handler = _make_handler(namespaces)
+    binding = MockBinding(route=route, methods=methods or ["POST"])
+    fn = MockFunction(name=name, func=handler, bindings=[binding])
+    return MockApp([MockBuilder(fn)])
+
+
+# ---------------------------------------------------------------------------
+# _read_endpoint_hints
+# ---------------------------------------------------------------------------
+
+
+def test_read_endpoint_hints_accepts_version_1() -> None:
+    handler = _make_handler({"endpoint": FLAT_ENDPOINT})
+    result = _read_endpoint_hints(handler)
+    assert result is not None
+    assert result["request_body"]["properties"]["name"]["type"] == "string"
+
+
+def test_read_endpoint_hints_missing_version_rejected() -> None:
+    # ``version`` is a required key for the endpoint contract (unlike validation).
+    handler = _make_handler({"endpoint": {"request_body": {"type": "object"}}})
+    assert _read_endpoint_hints(handler) is None
+
+
+def test_read_endpoint_hints_unsupported_version_rejected(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    handler = _make_handler({"endpoint": {"version": 999}})
+    with caplog.at_level("WARNING", logger="azure_functions_openapi.bridge"):
+        assert _read_endpoint_hints(handler) is None
+    assert any("unsupported version" in m for m in caplog.messages)
+
+
+def test_read_endpoint_hints_boolean_version_rejected() -> None:
+    handler = _make_handler({"endpoint": {"version": True}})
+    assert _read_endpoint_hints(handler) is None
+
+
+def test_read_endpoint_hints_walks_wrapped_chain() -> None:
+    inner: Any = lambda req: req  # noqa: E731
+    setattr(inner, _HANDLER_METADATA_ATTR, {"endpoint": FLAT_ENDPOINT})
+    outer: Any = lambda req: inner(req)  # noqa: E731
+    outer.__wrapped__ = inner
+
+    result = _read_endpoint_hints(outer)
+    assert result is not None
+    assert result["version"] == 1
+
+
+def test_read_endpoint_hints_invalid_outer_valid_inner() -> None:
+    inner: Any = lambda req: req  # noqa: E731
+    setattr(inner, _HANDLER_METADATA_ATTR, {"endpoint": FLAT_ENDPOINT})
+    outer: Any = lambda req: inner(req)  # noqa: E731
+    setattr(outer, _HANDLER_METADATA_ATTR, {"endpoint": {"version": 999}})
+    outer.__wrapped__ = inner
+
+    result = _read_endpoint_hints(outer)
+    assert result is not None
+    assert result["version"] == 1
+
+
+def test_read_endpoint_hints_self_referencing_stops() -> None:
+    handler: Any = lambda req: req  # noqa: E731
+    setattr(handler, _HANDLER_METADATA_ATTR, {"endpoint": {"version": 999}})
+    handler.__wrapped__ = handler
+    assert _read_endpoint_hints(handler) is None
+
+
+def test_read_endpoint_hints_returns_deep_copy() -> None:
+    handler = _make_handler({"endpoint": FLAT_ENDPOINT})
+    result = _read_endpoint_hints(handler)
+    assert result is not None
+    result["request_body"]["properties"]["name"]["type"] = "mutated"
+
+    stored = getattr(handler, _HANDLER_METADATA_ATTR)["endpoint"]
+    assert stored["request_body"]["properties"]["name"]["type"] == "string"
+
+
+def test_read_endpoint_hints_absent_namespace() -> None:
+    handler = _make_handler({"validation": {"body": None}})
+    assert _read_endpoint_hints(handler) is None
+
+
+# ---------------------------------------------------------------------------
+# _discovered_operation_from_endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_discovered_operation_from_endpoint_shape() -> None:
+    discovered = _discovered_operation_from_endpoint(
+        "create_user", FLAT_ENDPOINT, "/api/users", "post"
+    )
+    assert discovered["request_body"]["type"] == "object"
+    assert discovered["request_body_required"] is True
+    assert discovered["parameters"][0]["name"] == "limit"
+    assert discovered["response"][200]["content"]["application/json"]["schema"] == {
+        "type": "object",
+        "properties": {"id": {"type": "integer"}},
+    }
+    assert discovered["response"][200]["description"] == ""
+
+
+def test_discovered_operation_from_endpoint_defaults_and_filters() -> None:
+    payload: dict[str, Any] = {
+        "version": 1,
+        "request_body": "not-a-dict",
+        "parameters": ["bad", {"name": "ok", "in": "query"}],
+        "responses": {
+            "not-an-int": {"schema": {"type": "string"}},
+            "201": "not-a-dict",
+            "204": {"schema": {"type": "null"}},
+        },
+    }
+    discovered = _discovered_operation_from_endpoint("fn", payload, "/api/x", "post")
+    assert discovered["request_body"] is None
+    assert discovered["request_body_required"] is True  # defaulted
+    assert discovered["parameters"] == [{"name": "ok", "in": "query"}]
+    assert set(discovered["response"].keys()) == {204}
+
+
+def test_discovered_operation_from_endpoint_non_dict_responses() -> None:
+    payload: dict[str, Any] = {"version": 1, "responses": "nope"}
+    discovered = _discovered_operation_from_endpoint("fn", payload, "/api/x", "get")
+    assert discovered["response"] == {}
+
+
+# ---------------------------------------------------------------------------
+# scan_validation_metadata — endpoint namespace happy path
+# ---------------------------------------------------------------------------
+
+
+def test_scan_registers_from_endpoint_namespace() -> None:
+    app = _make_app({"endpoint": FLAT_ENDPOINT})
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["request_body"]["properties"]["name"]["type"] == "string"
+    assert entry["request_body_required"] is True
+    assert entry["response"][200]["content"]["application/json"]["schema"]["properties"] == {
+        "id": {"type": "integer"}
+    }
+    assert entry["parameters"][0]["name"] == "limit"
+
+
+def test_scan_endpoint_request_body_not_required() -> None:
+    payload = dict(FLAT_ENDPOINT)
+    payload["request_body_required"] = False
+    app = _make_app({"endpoint": payload})
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["request_body_required"] is False
+
+
+# ---------------------------------------------------------------------------
+# Version-skew: endpoint preferred, validation fallback
+# ---------------------------------------------------------------------------
+
+
+class _Body(BaseModel):
+    name: str
+
+
+class _Resp(BaseModel):
+    id: int
+
+
+def test_scan_prefers_endpoint_over_validation_when_both_present() -> None:
+    app = _make_app(
+        {
+            "endpoint": FLAT_ENDPOINT,
+            "validation": {"body": _Body, "response_model": _Resp},
+        }
+    )
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    # Endpoint path does NOT set response_model (it uses the raw ``response`` slot).
+    assert entry["response_model"] is None
+    assert entry["response"][200]["content"]["application/json"]["schema"]["properties"] == {
+        "id": {"type": "integer"}
+    }
+
+
+def test_scan_falls_back_to_validation_when_only_validation_present() -> None:
+    app = _make_app({"validation": {"body": _Body, "response_model": _Resp}})
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["response_model"] is _Resp
+
+
+def test_scan_falls_back_to_validation_when_endpoint_version_unsupported() -> None:
+    app = _make_app(
+        {
+            "endpoint": {"version": 999, "request_body": {"type": "object"}},
+            "validation": {"body": _Body, "response_model": _Resp},
+        }
+    )
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["response_model"] is _Resp
+
+
+# ---------------------------------------------------------------------------
+# Merge into existing @openapi entry
+# ---------------------------------------------------------------------------
+
+
+def test_scan_endpoint_merges_into_existing_openapi_entry() -> None:
+    register_openapi_metadata(path="/api/users", method="post", summary="explicit")
+    app = _make_app({"endpoint": FLAT_ENDPOINT})
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["summary"] == "explicit"  # explicit metadata preserved
+    assert entry["request_body"]["properties"]["name"]["type"] == "string"
+    assert entry["request_body_required"] is True
+    assert 200 in entry["response"]
+
+
+def test_scan_endpoint_conflicting_response_raises() -> None:
+    register_openapi_metadata(
+        path="/api/users",
+        method="post",
+        response={200: {"content": {"application/json": {"schema": {"type": "string"}}}}},
+    )
+    app = _make_app({"endpoint": FLAT_ENDPOINT})
+    with pytest.raises(OpenAPISpecConfigError):
+        scan_validation_metadata(app)
+
+
+# ---------------------------------------------------------------------------
+# _models_conflict — response dict
+# ---------------------------------------------------------------------------
+
+
+def test_models_conflict_response_dict_same_status_differs() -> None:
+    assert (
+        _models_conflict(
+            {"response": {200: {"a": 1}}},
+            {"response": {200: {"a": 2}}},
+        )
+        is True
+    )
+
+
+def test_models_conflict_response_dict_disjoint_status_ok() -> None:
+    assert (
+        _models_conflict(
+            {"response": {200: {"a": 1}}},
+            {"response": {404: {"a": 1}}},
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Nested-model known limitation (verbatim embed of $defs refs)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_endpoint_embeds_nested_defs_verbatim() -> None:
+    """Path A (MVP): nested-model ``$defs``/``#/$defs/`` refs are embedded
+    verbatim rather than hoisted into ``components.schemas``. This documents the
+    known limitation tracked by the follow-up hoisting issue.
+    """
+    nested_payload: dict[str, Any] = {
+        "version": 1,
+        "request_body": {
+            "type": "object",
+            "properties": {"child": {"$ref": "#/$defs/Child"}},
+            "$defs": {"Child": {"type": "object", "properties": {"x": {"type": "integer"}}}},
+        },
+        "request_body_required": True,
+    }
+    app = _make_app({"endpoint": nested_payload})
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    # The producer's $defs are preserved inline, unresolved (not hoisted).
+    assert entry["request_body"]["$defs"]["Child"]["properties"]["x"]["type"] == "integer"
+    assert entry["request_body"]["properties"]["child"]["$ref"] == "#/$defs/Child"

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -214,6 +214,28 @@ def test_discovered_operation_from_endpoint_non_dict_responses() -> None:
     assert discovered["response"] == {}
 
 
+def test_discovered_operation_rejects_boolean_status_keys() -> None:
+    # ``bool`` is an ``int`` subclass; ``True``/``False`` must not coerce to 1/0.
+    payload: dict[str, Any] = {
+        "version": 1,
+        "responses": {
+            True: {"schema": {"type": "string"}},
+            False: {"schema": {"type": "null"}},
+            "200": {"schema": {"type": "object"}},
+        },
+    }
+    discovered = _discovered_operation_from_endpoint("fn", payload, "/api/x", "post")
+    assert set(discovered["response"].keys()) == {200}
+
+
+def test_discovered_operation_request_body_required_rejects_non_bool() -> None:
+    # Non-boolean truthy values (e.g. the string "false") must not be honored;
+    # only real booleans are accepted, otherwise default to True.
+    payload: dict[str, Any] = {"version": 1, "request_body_required": "false"}
+    discovered = _discovered_operation_from_endpoint("fn", payload, "/api/x", "post")
+    assert discovered["request_body_required"] is True
+
+
 # ---------------------------------------------------------------------------
 # scan_validation_metadata — endpoint namespace happy path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements #311 (part of #270 endpoint-metadata convergence). Teaches the OpenAPI scanner to read the self-contained `endpoint` metadata namespace — pure JSON Schema authored by producer packages (e.g. `azure-functions-validation`) — and register operations directly, **preferring it over the legacy `validation` namespace** when both are present.

Design follows the Oracle-approved **Path A / MVP**: producer schemas are embedded **verbatim** with no `$defs` hoisting (a follow-up issue will add hoisting into `components.schemas`).

## Changes
- **`_endpoint_contract.py`** (new): read-side contract mirror — `HANDLER_METADATA_ATTR`, `ENDPOINT_NAMESPACE`, `SUPPORTED_ENDPOINT_VERSIONS={1}`, and an `EndpointMetadata` TypedDict. No import of any producer package required.
- **`_read_endpoint_hints`**: walks the `__wrapped__` chain (depth 16), reads the `endpoint` namespace. Unlike `validation`, `version` is **required** — missing/malformed/unsupported → warn + continue walking. Returns a deep copy.
- **`_discovered_operation_from_endpoint`**: converts the producer `responses` map `{"<status>": {"schema": ...}}` into int-keyed full OpenAPI response objects for `spec.py`; filters non-int statuses / non-dict details; threads `request_body_required`.
- **Routing** in `scan_validation_metadata`: endpoint hints preferred; validation used as fallback. Endpoint path registers via `register_openapi_metadata(response=, request_body_required=)`.
- **Merge**: `_models_conflict` flags same-status response divergence; `_merge_into_existing` fills responses via `setdefault` (existing `@openapi` wins) and copies `request_body_required` alongside `request_body`.

## Version-skew behavior
| Handler has | Result |
|---|---|
| `endpoint` (v1) + `validation` | endpoint wins; `response_model` stays `None` |
| `validation` only | validation fallback (unchanged behavior) |
| `endpoint` unsupported version + `validation` | warn + fallback to validation |

## Testing
- New `tests/test_bridge_endpoint.py` — 22 tests (version gate, wrapped-chain, deep-copy safety, discovered-op shape/filters, happy path, 3 version-skew cases, merge-into-existing, response conflict, nested-`$defs` verbatim limitation).
- Full suite **311 tests pass**, coverage **96.20%** (gate 95%).
- `make check-all` clean: lint, mypy strict, bandit security, build.

## Review
Oracle design review (Path A) approved; implementation review **93/100**, no must-fix items.

Refs #311 #270