### PR TITLE
feat(spec): hoist inline $defs from endpoint schemas into components.schemas

### DIFF
--- a/demo/generate_example_swagger.py
+++ b/demo/generate_example_swagger.py
@@ -15,7 +15,7 @@ registers all @openapi decorators via side-effect), then writes:
 Run once per example — in a separate subprocess per example so the
 process-global OpenAPI registry never leaks between runs. Do NOT call
 reload() because some examples (e.g. partner_import_bridge) call
-scan_validation_metadata(app) at module level — a second execution
+scan_endpoint_metadata(app) at module level — a second execution
 would conflict with the first import's registrations.
 """
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,7 +18,7 @@ from azure_functions_openapi import (
     openapi,
     register_openapi_metadata,
     render_swagger_ui,
-    scan_validation_metadata,
+    scan_endpoint_metadata,
 )
 ```
 
@@ -29,7 +29,7 @@ from azure_functions_openapi import (
 | `openapi` | decorator | Attach operation metadata to function handlers |
 | `register_openapi_metadata` | function | Register metadata for dynamically-created endpoints |
 | `clear_openapi_registry` | function | Remove all entries from the registry |
-| `scan_validation_metadata` | function | Auto-discover validation metadata from `@validate_http` handlers |
+| `scan_endpoint_metadata` | function | Auto-discover validation metadata from `@validate_http` handlers |
 | `generate_openapi_spec` | function | Build OpenAPI dictionary from decorator registry |
 | `get_openapi_json` | function | Build OpenAPI and serialize to JSON string |
 | `get_openapi_yaml` | function | Build OpenAPI and serialize to YAML string |
@@ -44,7 +44,7 @@ from azure_functions_openapi import (
 
 ```text
 @openapi metadata ---------> internal registry --> generate_openapi_spec --> JSON/YAML endpoint
-                                                    @validate_http metadata --> scan_validation_metadata(app) --^       `--> render_swagger_ui (docs)
+                                                    @validate_http metadata --> scan_endpoint_metadata(app) --^       `--> render_swagger_ui (docs)
 ```
 
 !!! note
@@ -161,22 +161,22 @@ The sections below are generated directly from source docstrings.
 
 ## Bridge: Auto-discover validation metadata
 
-### `scan_validation_metadata`
+### `scan_endpoint_metadata`
 
-::: azure_functions_openapi.scan_validation_metadata
+::: azure_functions_openapi.scan_endpoint_metadata
 
 Scans a `FunctionApp` for HTTP-triggered functions decorated with `@validate_http`
 and auto-registers their Pydantic models in the OpenAPI registry.
 
 ```python
-from azure_functions_openapi import scan_validation_metadata
+from azure_functions_openapi import scan_endpoint_metadata
 
 # Call after all routes are registered
-scan_validation_metadata(app)
+scan_endpoint_metadata(app)
 ```
 
 !!! info "No extra dependencies required"
-    `scan_validation_metadata()` reads the convention-based metadata attribute
+    `scan_endpoint_metadata()` reads the convention-based metadata attribute
     written by `@validate_http`.  No import from `azure-functions-validation` is needed —
     just install both packages in your project.
 

--- a/docs/examples/partner_import_bridge.md
+++ b/docs/examples/partner_import_bridge.md
@@ -2,7 +2,7 @@
 
 This is the bridge example showing how to generate OpenAPI docs from
 `@validate_http` decorators without using `@openapi` on every handler.
-It uses `scan_validation_metadata(app)`, `register_openapi_metadata()`,
+It uses `scan_endpoint_metadata(app)`, `register_openapi_metadata()`,
 and the `OpenAPIOperationMetadata` dataclass.
 
 Source: `examples/partner_import_bridge/function_app.py`
@@ -19,7 +19,7 @@ Source: `examples/partner_import_bridge/function_app.py`
 
 ## Features demonstrated
 
-- `scan_validation_metadata(app)` — auto-register OpenAPI metadata from `@validate_http`
+- `scan_endpoint_metadata(app)` — auto-register OpenAPI metadata from `@validate_http`
 - `register_openapi_metadata()` — programmatic registration for endpoints
 - `request_model` parameter on `register_openapi_metadata()` — proper Pydantic schema conversion
 - `OpenAPIOperationMetadata` dataclass — structured alternative to keyword arguments
@@ -68,9 +68,9 @@ class ImportBatchResponse(BaseModel):
 ### Step 1: Scan for validation metadata
 
 ```python
-from azure_functions_openapi import scan_validation_metadata
+from azure_functions_openapi import scan_endpoint_metadata
 
-scan_validation_metadata(app)
+scan_endpoint_metadata(app)
 ```
 
 ### Step 2: Register metadata programmatically
@@ -240,7 +240,7 @@ Expected behavior:
 ## Production takeaways
 
 - Use `request_model` instead of raw `model_json_schema()` for proper schema references
-- `scan_validation_metadata(app)` picks up `@validate_http` metadata automatically when available
+- `scan_endpoint_metadata(app)` picks up `@validate_http` metadata automatically when available
 - Use `OpenAPIOperationMetadata` for centralized, structured metadata management
 - `request_body_required=False` is useful for endpoints that accept optional request bodies
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ pip install azure-functions-openapi[docs]
 ```
 
 If you also use `azure-functions-validation` for request/response validation,
-install it alongside — `scan_validation_metadata()` will auto-discover
+install it alongside — `scan_endpoint_metadata()` will auto-discover
 validation metadata without any extra configuration:
 
 ```bash

--- a/docs/route-prefix.md
+++ b/docs/route-prefix.md
@@ -25,7 +25,7 @@ To match this default, `azure-functions-openapi` uses `"/api"` as the default
 `route_prefix` in:
 
 - `generate_openapi_spec(..., route_prefix="/api")`
-- `scan_validation_metadata(app, route_prefix="/api")`
+- `scan_endpoint_metadata(app, route_prefix="/api")`
 - The CLI flag `azure-functions-openapi generate --route-prefix /api`
 
 ## Authoring routes with `@openapi`
@@ -56,7 +56,7 @@ azure-functions-openapi generate --app function_app --route-prefix ""
 
 ```python
 spec = generate_openapi_spec(route_prefix="")
-scan_validation_metadata(app, route_prefix="")
+scan_endpoint_metadata(app, route_prefix="")
 ```
 
 ### Custom prefix
@@ -69,7 +69,7 @@ azure-functions-openapi generate --app function_app --route-prefix /v1
 
 ```python
 spec = generate_openapi_spec(route_prefix="/v1")
-scan_validation_metadata(app, route_prefix="/v1")
+scan_endpoint_metadata(app, route_prefix="/v1")
 ```
 
 The prefix is normalized: leading slash is added if missing, trailing slashes
@@ -84,8 +84,8 @@ FunctionApp that mixes them produces a single, consistent `paths` map:
 | ------------------------------------ | ------------------------------------ |
 | `@openapi(route=...)` decorator      | `generate_openapi_spec(route_prefix=)` at spec-build time |
 | `register_openapi_metadata(path=...)`| `generate_openapi_spec(route_prefix=)` at spec-build time |
-| Validation bridge auto-discovery     | `scan_validation_metadata(route_prefix=)` at scan time and `generate_openapi_spec(route_prefix=)` at spec-build time |
+| Validation bridge auto-discovery     | `scan_endpoint_metadata(route_prefix=)` at scan time and `generate_openapi_spec(route_prefix=)` at spec-build time |
 
 To keep the bridge-discovered registry entries and the final spec aligned,
-pass the **same** `route_prefix` to both `scan_validation_metadata()` and
+pass the **same** `route_prefix` to both `scan_endpoint_metadata()` and
 `generate_openapi_spec()` (or the CLI `--route-prefix`).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -335,13 +335,13 @@ See [Notification Request Example](examples/notification_request.md) for a compl
 ### Automatic bridge (zero-duplication)
 
 If you want OpenAPI specs generated automatically from `@validate_http` decorators
-without repeating models in `@openapi`, use `scan_validation_metadata()`:
+without repeating models in `@openapi`, use `scan_endpoint_metadata()`:
 
 ```python
-from azure_functions_openapi import scan_validation_metadata
+from azure_functions_openapi import scan_endpoint_metadata
 
 # After all routes are registered:
-scan_validation_metadata(app)
+scan_endpoint_metadata(app)
 ```
 
 This scans the app's registered HTTP functions for `@validate_http` metadata
@@ -349,7 +349,7 @@ and auto-registers them in the OpenAPI registry. Explicit `@openapi` decorators
 always take precedence.
 
 !!! info "No extra dependencies required"
-    `scan_validation_metadata()` reads the convention-based metadata attribute
+    `scan_endpoint_metadata()` reads the convention-based metadata attribute
     written by `@validate_http` — no extra install step needed beyond having both
     packages in your project.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,4 +7,4 @@
 | Representative | `examples/webhook_receiver` | Webhook intake with HMAC-SHA256 signature verification. Shows `@openapi()` basics: `summary`, `description`, `tags`, `request_model`, `response_model`, `response`. |
 | Complex | `examples/report_jobs` | Async report generation with Bearer auth. Shows `security`, `security_scheme`, `OPENAPI_VERSION_3_1`, `generate_openapi_spec()`, `render_swagger_ui(custom_csp=..., enable_client_logging=True)`. |
 | Integration | `examples/notification_request` | Email notification with `@openapi` + `@validate_http` stacked. Shows `requests=`, `responses=` unified params and shared Pydantic models. |
-| Bridge | `examples/partner_import_bridge` | Partner data import with `scan_validation_metadata(app)`, `register_openapi_metadata()`, `OpenAPIOperationMetadata`, and `request_body_required`. |
+| Bridge | `examples/partner_import_bridge` | Partner data import with `scan_endpoint_metadata(app)`, `register_openapi_metadata()`, `OpenAPIOperationMetadata`, and `request_body_required`. |

--- a/examples/partner_import_bridge/function_app.py
+++ b/examples/partner_import_bridge/function_app.py
@@ -3,7 +3,7 @@
 Demonstrates:
 - register_openapi_metadata() for dynamically registered routes
 - OpenAPIOperationMetadata dataclass
-- scan_validation_metadata(app) bridge integration
+- scan_endpoint_metadata(app) bridge integration
 - request_body_required parameter
 - Practical pattern: partner data import with batch processing
 """
@@ -24,7 +24,7 @@ from azure_functions_openapi import (
     OpenAPIOperationMetadata,
     get_openapi_json,
     register_openapi_metadata,
-    scan_validation_metadata,
+    scan_endpoint_metadata,
 )
 from azure_functions_openapi.swagger_ui import render_swagger_ui
 
@@ -152,11 +152,11 @@ def purge_partners(req: func.HttpRequest) -> func.HttpResponse:
 # ---------------------------------------------------------------------------
 # Bridge: auto-register OpenAPI metadata from @validate_http decorators
 # When azure-functions-validation exposes handler metadata,
-# scan_validation_metadata(app) picks it up automatically. For versions
+# scan_endpoint_metadata(app) picks it up automatically. For versions
 # that do not yet export metadata, register manually below.
 # ---------------------------------------------------------------------------
 
-scan_validation_metadata(app)
+scan_endpoint_metadata(app)
 
 
 # ---------------------------------------------------------------------------

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -119,15 +119,15 @@ def clear_openapi_registry() -> None: ...
 
 **Use when**: Testing or rebuilding the registry from scratch.
 
-### scan_validation_metadata
+### scan_endpoint_metadata
 
 ```python
-def scan_validation_metadata(app: Any) -> None: ...
+def scan_endpoint_metadata(app: Any) -> None: ...
 ```
 
 **Purpose**: Scan a FunctionApp's registered HTTP functions for `@validate_http` metadata and auto-register them in the OpenAPI registry.
 
-**No extra dependencies**: `scan_validation_metadata()` reads the convention-based `_azure_functions_metadata` attribute — no import from `azure-functions-validation` is needed.
+**No extra dependencies**: `scan_endpoint_metadata()` reads the convention-based `_azure_functions_metadata` attribute — no import from `azure-functions-validation` is needed.
 
 **Behavior**:
 - Iterates `app._function_builders` to find HTTP-triggered functions
@@ -141,10 +141,10 @@ def scan_validation_metadata(app: Any) -> None: ...
 
 **Example**:
 ```python
-from azure_functions_openapi import scan_validation_metadata
+from azure_functions_openapi import scan_endpoint_metadata
 
 # Call after all routes are registered
-scan_validation_metadata(app)
+scan_endpoint_metadata(app)
 ```
 ### generate_openapi_spec
 

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ Renders Swagger UI with enterprise security headers (CSP, HSTS).
 - `OpenAPIOperationMetadata` — Type for operation metadata
 - `OpenAPISpecConfigError` — Exception for configuration errors
 - `OPENAPI_VERSION_3_0`, `OPENAPI_VERSION_3_1` — Version constants
-- `scan_validation_metadata(app)` — Auto-discover @validate_http metadata and register in OpenAPI registry
+- `scan_endpoint_metadata(app)` — Auto-discover @validate_http metadata and register in OpenAPI registry
 
 ## Quick Start
 

--- a/src/azure_functions_openapi/__init__.py
+++ b/src/azure_functions_openapi/__init__.py
@@ -17,6 +17,7 @@ from azure_functions_openapi.swagger_ui import render_swagger_ui
 from azure_functions_openapi.types import OpenAPIOperationMetadata
 
 __version__ = "0.19.1"
+scan_endpoint_metadata = _bridge.scan_endpoint_metadata
 scan_validation_metadata = _bridge.scan_validation_metadata
 
 __all__ = [
@@ -33,5 +34,6 @@ __all__ = [
     "openapi",
     "register_openapi_metadata",
     "render_swagger_ui",
+    "scan_endpoint_metadata",
     "scan_validation_metadata",
 ]

--- a/src/azure_functions_openapi/_endpoint_contract.py
+++ b/src/azure_functions_openapi/_endpoint_contract.py
@@ -1,0 +1,48 @@
+"""Read-side contract for the shared ``endpoint`` namespace metadata.
+
+Producer packages (``azure-functions-validation``, ``azure-functions-langgraph``,
+...) write a self-contained, OpenAPI-ready payload onto handlers under the
+``_azure_functions_metadata`` convention attribute, namespace ``"endpoint"``.
+Unlike the ``validation`` namespace (which carries user-defined Pydantic model
+*classes*), the ``endpoint`` payload is entirely JSON Schema, so this consumer
+needs **no** import of the producing package and no access to the user's models.
+
+This module mirrors the *shape the bridge reads* as a ``TypedDict`` so the
+consumed contract is explicit and type-checked. The producer's canonical schema
+lives in ``azure-functions-validation`` (``schemas/endpoint.schema.json``); the
+two packages release independently, so this read-side mirror keeps the
+consumer's expectations pinned even as producers evolve.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+# Convention attribute name shared across every Azure Functions toolkit package.
+HANDLER_METADATA_ATTR = "_azure_functions_metadata"
+
+# Namespace owned by the shared endpoint contract.
+ENDPOINT_NAMESPACE = "endpoint"
+
+# Payload ``version`` values this consumer understands.
+SUPPORTED_ENDPOINT_VERSIONS: frozenset[int] = frozenset({1})
+
+
+class _EndpointMetadataRequired(TypedDict):
+    """Keys present on every endpoint payload."""
+
+    version: int
+
+
+class EndpointMetadata(_EndpointMetadataRequired, total=False):
+    """The ``endpoint`` namespace payload read from ``HANDLER_METADATA_ATTR``.
+
+    All schema fields are self-contained JSON Schema dicts (no model classes).
+    Pydantic ``$defs`` are kept unresolved by the producer (refs point at
+    ``#/$defs/{Model}``); this consumer is the sole ``$ref``-collision authority.
+    """
+
+    request_body: dict[str, Any] | None
+    request_body_required: bool
+    parameters: list[dict[str, Any]]
+    responses: dict[str, dict[str, Any]] | None

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -7,6 +7,10 @@ from typing import Any, get_origin
 
 from pydantic import BaseModel
 
+from azure_functions_openapi._endpoint_contract import (
+    ENDPOINT_NAMESPACE,
+    SUPPORTED_ENDPOINT_VERSIONS,
+)
 from azure_functions_openapi._validation_contract import (
     HANDLER_METADATA_ATTR,
     SUPPORTED_VALIDATION_VERSIONS,
@@ -125,6 +129,13 @@ def _models_conflict(existing: dict[str, Any], discovered: dict[str, Any]) -> bo
     except OpenAPISpecConfigError:
         return True
 
+    existing_response = existing.get("response") or {}
+    discovered_response = discovered.get("response") or {}
+    if isinstance(existing_response, dict) and isinstance(discovered_response, dict):
+        for status, detail in discovered_response.items():
+            if status in existing_response and existing_response[status] != detail:
+                return True
+
     return False
 
 
@@ -134,9 +145,20 @@ def _merge_into_existing(existing: dict[str, Any], discovered: dict[str, Any]) -
 
     if not existing.get("request_body") and discovered.get("request_body"):
         existing["request_body"] = discovered["request_body"]
+        if "request_body_required" in discovered:
+            existing["request_body_required"] = discovered["request_body_required"]
 
     if not existing.get("response_model") and discovered.get("response_model"):
         existing["response_model"] = discovered["response_model"]
+
+    discovered_response = discovered.get("response")
+    if isinstance(discovered_response, dict) and discovered_response:
+        existing_response = existing.get("response")
+        if not isinstance(existing_response, dict):
+            existing_response = {}
+        for status, detail in discovered_response.items():
+            existing_response.setdefault(status, detail)
+        existing["response"] = existing_response
 
     existing_params = existing.get("parameters", [])
     discovered_params = discovered.get("parameters", [])
@@ -209,6 +231,57 @@ def _discovered_operation(
     }
 
 
+def _discovered_operation_from_endpoint(
+    function_name: str, endpoint: dict[str, Any], path: str, method: str
+) -> dict[str, Any]:
+    """Build a discovered-operation dict from the self-contained ``endpoint`` payload.
+
+    Unlike :func:`_discovered_operation`, every schema field here is already a
+    JSON Schema dict authored by the producer, so no Pydantic model access is
+    needed. The producer's ``responses`` map is ``{"<status>": {"schema": ...}}``;
+    we wrap each entry into a full OpenAPI response object so the spec generator
+    can embed it verbatim.
+    """
+    raw_request_body = endpoint.get("request_body")
+    request_body = raw_request_body if isinstance(raw_request_body, dict) else None
+
+    raw_parameters = endpoint.get("parameters")
+    parameters = [p for p in raw_parameters if isinstance(p, dict)] if isinstance(
+        raw_parameters, list
+    ) else []
+
+    response: dict[int, dict[str, Any]] = {}
+    raw_responses = endpoint.get("responses")
+    if isinstance(raw_responses, dict):
+        for status, detail in raw_responses.items():
+            if not isinstance(detail, dict):
+                continue
+            try:
+                status_code = int(status)
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Skipping endpoint response with non-integer status %r on %r",
+                    status,
+                    function_name,
+                )
+                continue
+            schema = detail.get("schema")
+            response[status_code] = {
+                "description": detail.get("description", ""),
+                "content": {"application/json": {"schema": schema}},
+            }
+
+    return {
+        "function_name": function_name,
+        "route": path,
+        "method": method,
+        "request_body": request_body,
+        "request_body_required": bool(endpoint.get("request_body_required", True)),
+        "parameters": parameters,
+        "response": response,
+    }
+
+
 # Maximum decorator depth to walk when chasing ``__wrapped__``.
 _MAX_WRAPPED_DEPTH = 16
 
@@ -267,6 +340,53 @@ def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
     return None
 
 
+def _read_endpoint_hints(handler: Any) -> dict[str, Any] | None:
+    """Read shared ``endpoint`` namespace metadata from a handler.
+
+    Mirrors :func:`_read_validation_hints` but targets the self-contained
+    ``endpoint`` namespace (pure JSON Schema, no model classes). Walks the
+    ``__wrapped__`` chain (outer -> inner) for the first handler carrying
+    ``_azure_functions_metadata["endpoint"]``.
+
+    Version policy (``version`` is a required key on the endpoint payload):
+    * Present and supported -> accepted.
+    * Missing, malformed, or unsupported -> ``logger.warning()`` + continue walking.
+
+    Returns a *deep copy* so callers cannot mutate the handler attribute.
+    """
+    current: Any = handler
+    for _ in range(_MAX_WRAPPED_DEPTH):
+        toolkit_meta = getattr(current, HANDLER_METADATA_ATTR, None)
+        if isinstance(toolkit_meta, dict):
+            hints = toolkit_meta.get(ENDPOINT_NAMESPACE)
+            if isinstance(hints, dict):
+                raw_version = hints.get("version")
+                if (
+                    type(raw_version) is not int
+                    or raw_version not in SUPPORTED_ENDPOINT_VERSIONS
+                ):
+                    logger.warning(
+                        "Skipping endpoint metadata on %r: unsupported version %r "
+                        "(supported: %s)",
+                        current,
+                        raw_version,
+                        ", ".join(str(v) for v in sorted(SUPPORTED_ENDPOINT_VERSIONS)),
+                    )
+                    wrapped = getattr(current, "__wrapped__", None)
+                    if wrapped is None or wrapped is current:
+                        break
+                    current = wrapped
+                    continue
+                return copy.deepcopy(hints)
+
+        wrapped = getattr(current, "__wrapped__", None)
+        if wrapped is None or wrapped is current:
+            break
+        current = wrapped
+
+    return None
+
+
 def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -> None:
     """Scan function builders for validation metadata and register OpenAPI operations.
 
@@ -291,8 +411,9 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
         handler = getattr(function_obj, "_func", None)
         if handler is None:
             continue
-        metadata = _read_validation_hints(handler)
-        if metadata is None:
+        endpoint_hints = _read_endpoint_hints(handler)
+        metadata = None if endpoint_hints is not None else _read_validation_hints(handler)
+        if endpoint_hints is None and metadata is None:
             continue
 
         canonical_id = canonical_function_id(handler)
@@ -308,7 +429,14 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
         methods = _extract_methods(binding)
 
         for method in methods:
-            discovered = _discovered_operation(function_name, metadata, path, method)
+            if endpoint_hints is not None:
+                discovered = _discovered_operation_from_endpoint(
+                    function_name, endpoint_hints, path, method
+                )
+            elif metadata is not None:
+                discovered = _discovered_operation(function_name, metadata, path, method)
+            else:  # pragma: no cover - guarded above (endpoint or metadata is set)
+                continue
             endpoint_key = f"{method}::{path}"
 
             with registry.lock:
@@ -348,13 +476,23 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
                     )
                     continue
 
-            register_openapi_metadata(
-                path=path,
-                method=method,
-                request_body=discovered.get("request_body"),
-                response_model=discovered.get("response_model")
-                if _is_base_model_type(discovered.get("response_model"))
-                else None,
-                parameters=discovered.get("parameters") or None,
-            )
+            if endpoint_hints is not None:
+                register_openapi_metadata(
+                    path=path,
+                    method=method,
+                    request_body=discovered.get("request_body"),
+                    request_body_required=discovered.get("request_body_required", True),
+                    response=discovered.get("response") or None,
+                    parameters=discovered.get("parameters") or None,
+                )
+            else:
+                register_openapi_metadata(
+                    path=path,
+                    method=method,
+                    request_body=discovered.get("request_body"),
+                    response_model=discovered.get("response_model")
+                    if _is_base_model_type(discovered.get("response_model"))
+                    else None,
+                    parameters=discovered.get("parameters") or None,
+                )
             logger.debug("Registered validation metadata for endpoint '%s'", endpoint_key)

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 import copy
 import logging
 from typing import Any, get_origin
+import warnings
 
 from pydantic import BaseModel
 
@@ -246,9 +247,11 @@ def _discovered_operation_from_endpoint(
     request_body = raw_request_body if isinstance(raw_request_body, dict) else None
 
     raw_parameters = endpoint.get("parameters")
-    parameters = [p for p in raw_parameters if isinstance(p, dict)] if isinstance(
-        raw_parameters, list
-    ) else []
+    parameters = (
+        [p for p in raw_parameters if isinstance(p, dict)]
+        if isinstance(raw_parameters, list)
+        else []
+    )
 
     response: dict[int, dict[str, Any]] = {}
     raw_responses = endpoint.get("responses")
@@ -314,8 +317,7 @@ def _read_validation_hints(handler: Any) -> dict[str, Any] | None:
                 # --- version gate (version is nested in the namespace payload) ---
                 raw_version = hints.get("version")
                 if raw_version is not None and (
-                    type(raw_version) is not int
-                    or raw_version not in SUPPORTED_VALIDATION_VERSIONS
+                    type(raw_version) is not int or raw_version not in SUPPORTED_VALIDATION_VERSIONS
                 ):
                     logger.warning(
                         "Skipping metadata on %r: unsupported version %r (supported: %s)",
@@ -361,13 +363,9 @@ def _read_endpoint_hints(handler: Any) -> dict[str, Any] | None:
             hints = toolkit_meta.get(ENDPOINT_NAMESPACE)
             if isinstance(hints, dict):
                 raw_version = hints.get("version")
-                if (
-                    type(raw_version) is not int
-                    or raw_version not in SUPPORTED_ENDPOINT_VERSIONS
-                ):
+                if type(raw_version) is not int or raw_version not in SUPPORTED_ENDPOINT_VERSIONS:
                     logger.warning(
-                        "Skipping endpoint metadata on %r: unsupported version %r "
-                        "(supported: %s)",
+                        "Skipping endpoint metadata on %r: unsupported version %r (supported: %s)",
                         current,
                         raw_version,
                         ", ".join(str(v) for v in sorted(SUPPORTED_ENDPOINT_VERSIONS)),
@@ -387,11 +385,35 @@ def _read_endpoint_hints(handler: Any) -> dict[str, Any] | None:
     return None
 
 
-def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -> None:
-    """Scan function builders for validation metadata and register OpenAPI operations.
+def _has_endpoint_namespace(handler: Any) -> bool:
+    """Return whether *any* handler in the wrapped chain carries an ``endpoint`` namespace.
 
-    This function reads the convention-based ``_azure_functions_metadata``
-    attribute (namespace ``"validation"``) from each handler.  No import from
+    Unlike :func:`_read_endpoint_hints`, this ignores version validity: it reports
+    mere *presence* of ``_azure_functions_metadata["endpoint"]`` as a dict. It lets
+    the scan loop distinguish "no endpoint contract at all" from "endpoint contract
+    present but rejected (e.g. unsupported version)", so a silent downgrade to the
+    ``validation`` namespace can be surfaced to the user.
+    """
+    current: Any = handler
+    for _ in range(_MAX_WRAPPED_DEPTH):
+        toolkit_meta = getattr(current, HANDLER_METADATA_ATTR, None)
+        if isinstance(toolkit_meta, dict) and isinstance(
+            toolkit_meta.get(ENDPOINT_NAMESPACE), dict
+        ):
+            return True
+        wrapped = getattr(current, "__wrapped__", None)
+        if wrapped is None or wrapped is current:
+            break
+        current = wrapped
+    return False
+
+
+def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -> None:
+    """Scan function builders for toolkit metadata and register OpenAPI operations.
+
+    Reads the convention-based ``_azure_functions_metadata`` attribute from each
+    handler, preferring the self-contained ``"endpoint"`` namespace and falling
+    back to the ``"validation"`` namespace. No import from
     ``azure-functions-validation`` is required.
 
     ``route_prefix`` mirrors ``host.json`` ``extensions.http.routePrefix``
@@ -415,6 +437,15 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
         metadata = None if endpoint_hints is not None else _read_validation_hints(handler)
         if endpoint_hints is None and metadata is None:
             continue
+
+        if endpoint_hints is None and metadata is not None and _has_endpoint_namespace(handler):
+            logger.warning(
+                "Function '%s' carries an unsupported or malformed endpoint "
+                "namespace; falling back to the validation namespace for OpenAPI "
+                "generation. The generated spec may differ from the intended "
+                "endpoint contract.",
+                function_name,
+            )
 
         canonical_id = canonical_function_id(handler)
 
@@ -496,3 +527,21 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
                     parameters=discovered.get("parameters") or None,
                 )
             logger.debug("Registered validation metadata for endpoint '%s'", endpoint_key)
+
+
+def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -> None:
+    """Deprecated alias for :func:`scan_endpoint_metadata`.
+
+    The scanner now primarily consumes the namespace-neutral ``"endpoint"``
+    contract (the ``"validation"`` namespace is only a fallback), so the
+    ``scan_validation_metadata`` name is a misnomer. Use
+    :func:`scan_endpoint_metadata` instead. This alias forwards unchanged and
+    will be removed in a future minor release.
+    """
+    warnings.warn(
+        "scan_validation_metadata() is deprecated; use scan_endpoint_metadata() "
+        "instead. It will be removed in a future minor release.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    scan_endpoint_metadata(app, route_prefix)

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -15,7 +15,7 @@ from azure_functions_openapi.routes import (
     apply_route_prefix,
     normalize_route_prefix,
 )
-from azure_functions_openapi.utils import model_to_schema
+from azure_functions_openapi.utils import hoist_inline_defs, model_to_schema
 
 logger = logging.getLogger(__name__)
 
@@ -273,6 +273,19 @@ def generate_openapi_spec(
                 for status, detail in meta.get("response", {}).items():
                     resp = dict(detail)
                     resp.setdefault("description", "")
+                    resp_content = resp.get("content")
+                    if isinstance(resp_content, dict):
+                        hoisted_content: dict[str, Any] = {}
+                        for media, media_obj in resp_content.items():
+                            if isinstance(media_obj, dict) and "schema" in media_obj:
+                                media_obj = {
+                                    **media_obj,
+                                    "schema": hoist_inline_defs(
+                                        media_obj["schema"], components
+                                    ),
+                                }
+                            hoisted_content[media] = media_obj
+                        resp["content"] = hoisted_content
                     responses[str(status)] = resp
 
                 if meta.get("response_model"):
@@ -321,7 +334,12 @@ def generate_openapi_spec(
                 # parameters ------------------------------------------------------
                 parameters: list[dict[str, Any]] = meta.get("parameters", [])
                 if parameters:
-                    op["parameters"] = parameters
+                    op["parameters"] = [
+                        {**param, "schema": hoist_inline_defs(param["schema"], components)}
+                        if isinstance(param, dict) and "schema" in param
+                        else param
+                        for param in parameters
+                    ]
 
                 # security --------------------------------------------------------
                 security: list[dict[str, list[str]]] = meta.get("security", [])
@@ -334,7 +352,13 @@ def generate_openapi_spec(
                     if meta.get("request_body"):
                         op["requestBody"] = {
                             "required": required,
-                            "content": {"application/json": {"schema": meta["request_body"]}},
+                            "content": {
+                                "application/json": {
+                                    "schema": hoist_inline_defs(
+                                        meta["request_body"], components
+                                    )
+                                }
+                            },
                         }
                     elif meta.get("request_model"):
                         try:

--- a/src/azure_functions_openapi/utils.py
+++ b/src/azure_functions_openapi/utils.py
@@ -99,6 +99,81 @@ def _rewrite_refs_with_map(obj: Any, name_map: dict[str, str]) -> Any:
     return obj
 
 
+def _needs_hoisting(obj: Any) -> bool:
+    """Return ``True`` if *obj* contains an inline ``$defs``/``definitions`` block
+    or a local ``#/$defs/`` / ``#/definitions/`` ``$ref`` anywhere in the tree.
+
+    Flat schemas (no nested definitions and no local refs) return ``False`` so
+    callers can short-circuit and embed them verbatim without copying.
+    """
+    if isinstance(obj, dict):
+        if "$defs" in obj or "definitions" in obj:
+            return True
+        for key, value in obj.items():
+            if (
+                key == "$ref"
+                and isinstance(value, str)
+                and (value.startswith("#/$defs/") or value.startswith("#/definitions/"))
+            ):
+                return True
+            if _needs_hoisting(value):
+                return True
+        return False
+    if isinstance(obj, list):
+        return any(_needs_hoisting(item) for item in obj)
+    return False
+
+
+def hoist_inline_defs(schema: Any, components: dict[str, Any]) -> Any:
+    """Hoist inline ``$defs`` from a raw JSON Schema into ``components['schemas']``.
+
+    Producer-authored ``endpoint`` schemas embed nested-model definitions inline
+    as ``$defs`` with local ``#/$defs/{Model}`` refs. This lifts each definition
+    into the shared ``components.schemas`` section (resolving name collisions the
+    same way :func:`model_to_schema` does) and rewrites refs to
+    ``#/components/schemas/{Model}``. The root schema itself stays **inline** (a
+    raw endpoint body has no canonical component name), but any of its refs that
+    point at renamed definitions are rewritten.
+
+    Flat schemas -- those with no ``$defs`` and no local ``#/$defs/`` refs -- are
+    returned unchanged, preserving the verbatim behaviour from #311.
+
+    The input *schema* is never mutated; :func:`_collect_schemas` rebuilds every
+    nested structure via :func:`_rewrite_refs` before any in-place ``pop``.
+    """
+    if not isinstance(schema, dict) or not _needs_hoisting(schema):
+        return schema
+
+    normalized_root, definitions = _collect_schemas(schema)
+    if not definitions:
+        return normalized_root
+
+    schemas = components.setdefault("schemas", {})
+
+    name_map: dict[str, str] = {}
+    for name, definition in definitions.items():
+        resolved_name = _resolve_name_collision(name, definition, schemas)
+        if resolved_name != name:
+            name_map[name] = resolved_name
+
+    if name_map:
+        definitions = {
+            name_map.get(name, name): cast(
+                dict[str, Any], _rewrite_refs_with_map(definition, name_map)
+            )
+            for name, definition in definitions.items()
+        }
+        normalized_root = cast(
+            dict[str, Any], _rewrite_refs_with_map(normalized_root, name_map)
+        )
+
+    for name, definition in definitions.items():
+        if name not in schemas or schemas[name] != definition:
+            schemas[name] = definition
+
+    return normalized_root
+
+
 def model_to_schema(model_cls: Any, components: dict[str, Any] | None = None) -> dict[str, Any]:
     """Return OpenAPI schema from a Pydantic model class.
     Parameters:

--- a/src/azure_functions_openapi/utils.py
+++ b/src/azure_functions_openapi/utils.py
@@ -1,12 +1,15 @@
 # src/azure_functions_openapi/utils.py
 from __future__ import annotations
 
+import logging
 import re
 from typing import Any, cast, get_origin
 
 from pydantic import BaseModel, TypeAdapter
 
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+
+logger = logging.getLogger(__name__)
 
 
 def _rewrite_ref(ref: str) -> str:
@@ -72,6 +75,13 @@ def _resolve_name_collision(
     while True:
         candidate = f"{name}_{index}"
         if candidate not in existing:
+            logger.warning(
+                "Schema name collision while hoisting $defs: %r already exists in "
+                "components.schemas with different content; emitting deterministic "
+                "alias %r instead. Rename the producer model to silence this warning.",
+                name,
+                candidate,
+            )
             return candidate
         if existing[candidate] == schema:
             return candidate

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -17,7 +17,7 @@ from azure_functions_openapi.bridge import (
     _normalize_method,
     _normalize_path,
     _read_validation_hints,
-    scan_validation_metadata,
+    scan_endpoint_metadata,
 )
 from azure_functions_openapi.decorator import (
     _openapi_registry,
@@ -105,7 +105,7 @@ def _make_app(
 def test_scan_discovers_validation_metadata() -> None:
     app = _make_app(metadata={"body": CreateBody, "response_model": ResponseModel})
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     registry = get_openapi_registry()
     entry = registry["post::/api/users"]
@@ -116,7 +116,7 @@ def test_scan_discovers_validation_metadata() -> None:
 def test_scan_skips_non_validated_functions() -> None:
     app = _make_app(metadata=None)
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     assert get_openapi_registry() == {}
 
@@ -125,7 +125,7 @@ def test_explicit_openapi_wins() -> None:
     register_openapi_metadata(path="/api/users", method="post", summary="explicit")
     app = _make_app(metadata={"body": CreateBody, "response_model": ResponseModel})
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     entry = get_openapi_registry()["post::/api/users"]
     assert entry["summary"] == "explicit"
@@ -134,7 +134,7 @@ def test_explicit_openapi_wins() -> None:
 def test_body_model_registered_as_request_body() -> None:
     app = _make_app(metadata={"body": CreateBody})
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     schema = get_openapi_registry()["post::/api/users"]["request_body"]
     assert schema["type"] == "object"
@@ -144,7 +144,7 @@ def test_body_model_registered_as_request_body() -> None:
 def test_query_model_registered_as_parameters() -> None:
     app = _make_app(metadata={"query": QueryModel})
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     params = get_openapi_registry()["post::/api/users"]["parameters"]
     assert any(p["in"] == "query" and p["name"] == "limit" for p in params)
@@ -153,7 +153,7 @@ def test_query_model_registered_as_parameters() -> None:
 def test_path_model_registered_as_parameters() -> None:
     app = _make_app(route="users/{user_id}", metadata={"path": PathModel})
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     params = get_openapi_registry()["post::/api/users/{user_id}"]["parameters"]
     path_param = next(p for p in params if p["name"] == "user_id")
@@ -164,7 +164,7 @@ def test_path_model_registered_as_parameters() -> None:
 def test_response_model_registered() -> None:
     app = _make_app(metadata={"response_model": ResponseModel})
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     assert get_openapi_registry()["post::/api/users"]["response_model"] is ResponseModel
 
@@ -176,13 +176,13 @@ def test_scan_without_validation_metadata() -> None:
     fn = MockFunction(_name="create_user", _func=handler_fn, _bindings=[binding])
     app = MockApp(_function_builders=[MockBuilder(_function=fn)])
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     assert get_openapi_registry() == {}
 
 
 def test_scan_empty_app() -> None:
-    scan_validation_metadata(MockApp(_function_builders=[]))
+    scan_endpoint_metadata(MockApp(_function_builders=[]))
     assert get_openapi_registry() == {}
 
 
@@ -198,7 +198,7 @@ def test_conflict_detection() -> None:
     app = _make_app(metadata={"response_model": ResponseModel})
 
     with pytest.raises(OpenAPISpecConfigError):
-        scan_validation_metadata(app)
+        scan_endpoint_metadata(app)
 
 
 def test_scan_skips_non_http_bindings() -> None:
@@ -210,7 +210,7 @@ def test_scan_skips_non_http_bindings() -> None:
     )
     app = MockApp(_function_builders=[MockBuilder(_function=fn)])
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     assert get_openapi_registry() == {}
 
@@ -221,7 +221,7 @@ def test_scan_defaults_method_to_get_when_unspecified() -> None:
     fn = MockFunction(_name="get_users", _func=handler, _bindings=[binding])
     app = MockApp(_function_builders=[MockBuilder(_function=fn)])
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     assert "get::/api/users" in get_openapi_registry()
 
@@ -248,7 +248,7 @@ def test_scan_merges_explicit_function_name_entry() -> None:
         }
 
     app = _make_app(name="create_user", metadata={"body": CreateBody})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     entry = get_openapi_registry()["create_user"]
     assert entry["summary"] == "explicit"
@@ -266,7 +266,7 @@ def test_parameter_conflict_detection() -> None:
     app = _make_app(metadata={"query": QueryModel})
 
     with pytest.raises(OpenAPISpecConfigError, match="Conflicting validation"):
-        scan_validation_metadata(app)
+        scan_endpoint_metadata(app)
 
 
 def test_type_to_schema_registers_defs_for_generic_types() -> None:
@@ -528,7 +528,7 @@ class TestDeepCopyMutationSafety:
 def test_scan_uses_default_api_prefix() -> None:
     app = _make_app(metadata={"body": CreateBody})
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     assert "post::/api/users" in get_openapi_registry()
 
@@ -536,7 +536,7 @@ def test_scan_uses_default_api_prefix() -> None:
 def test_scan_supports_empty_prefix_for_disabled_host_prefix() -> None:
     app = _make_app(metadata={"body": CreateBody})
 
-    scan_validation_metadata(app, route_prefix="")
+    scan_endpoint_metadata(app, route_prefix="")
 
     assert "post::/users" in get_openapi_registry()
 
@@ -544,7 +544,7 @@ def test_scan_supports_empty_prefix_for_disabled_host_prefix() -> None:
 def test_scan_supports_custom_prefix() -> None:
     app = _make_app(metadata={"body": CreateBody})
 
-    scan_validation_metadata(app, route_prefix="/v1")
+    scan_endpoint_metadata(app, route_prefix="/v1")
 
     assert "post::/v1/users" in get_openapi_registry()
 
@@ -552,7 +552,7 @@ def test_scan_supports_custom_prefix() -> None:
 def test_scan_does_not_double_apply_prefix() -> None:
     app = _make_app(route="/api/users", metadata={"body": CreateBody})
 
-    scan_validation_metadata(app, route_prefix="/api")
+    scan_endpoint_metadata(app, route_prefix="/api")
 
     assert "post::/api/users" in get_openapi_registry()
     assert "post::/api/api/users" not in get_openapi_registry()
@@ -561,7 +561,7 @@ def test_scan_does_not_double_apply_prefix() -> None:
 def test_scan_normalizes_prefix_with_trailing_slash() -> None:
     app = _make_app(metadata={"body": CreateBody})
 
-    scan_validation_metadata(app, route_prefix="v1/")
+    scan_endpoint_metadata(app, route_prefix="v1/")
 
     assert "post::/v1/users" in get_openapi_registry()
 
@@ -575,7 +575,7 @@ def test_scan_does_not_treat_substring_match_as_already_prefixed() -> None:
     """
     app = _make_app(route="/apiary", metadata={"body": CreateBody})
 
-    scan_validation_metadata(app, route_prefix="/api")
+    scan_endpoint_metadata(app, route_prefix="/api")
 
     assert "post::/api/apiary" in get_openapi_registry()
     assert "post::/apiary" not in get_openapi_registry()
@@ -584,7 +584,7 @@ def test_scan_does_not_treat_substring_match_as_already_prefixed() -> None:
 def test_scan_does_not_treat_apidocs_as_already_prefixed() -> None:
     app = _make_app(route="/apidocs", metadata={"body": CreateBody})
 
-    scan_validation_metadata(app, route_prefix="/api")
+    scan_endpoint_metadata(app, route_prefix="/api")
 
     assert "post::/api/apidocs" in get_openapi_registry()
     assert "post::/apidocs" not in get_openapi_registry()
@@ -593,7 +593,7 @@ def test_scan_does_not_treat_apidocs_as_already_prefixed() -> None:
 def test_scan_treats_exact_prefix_match_as_already_prefixed() -> None:
     app = _make_app(route="/api", metadata={"body": CreateBody})
 
-    scan_validation_metadata(app, route_prefix="/api")
+    scan_endpoint_metadata(app, route_prefix="/api")
 
     assert "post::/api" in get_openapi_registry()
     assert "post::/api/api" not in get_openapi_registry()
@@ -656,7 +656,7 @@ def test_scan_includes_headers_model_as_header_parameters() -> None:
         x_request_id: str
 
     app = _make_app(metadata={"headers": HeaderModel})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     params = get_openapi_registry()["post::/api/users"]["parameters"]
     header_param = next(p for p in params if p["name"] == "x_request_id")
@@ -669,9 +669,8 @@ def test_scan_skips_builders_without_function_or_handler() -> None:
     builder_without_handler = MockBuilder(_function=function_without_handler)
     app = MockApp(_function_builders=cast(Any, [builder_without_function, builder_without_handler]))
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
     assert get_openapi_registry() == {}
-
 
 
 class TestNestedVersionGate:

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_openapi.bridge import (
+    _HANDLER_METADATA_ATTR,
+    _discovered_operation_from_endpoint,
+    _models_conflict,
+    _read_endpoint_hints,
+    scan_validation_metadata,
+)
+from azure_functions_openapi.decorator import (
+    clear_openapi_registry,
+    get_openapi_registry,
+    register_openapi_metadata,
+)
+from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+# A representative flat endpoint payload (all JSON Schema, no model classes).
+FLAT_ENDPOINT: dict[str, Any] = {
+    "version": 1,
+    "request_body": {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    },
+    "request_body_required": True,
+    "parameters": [
+        {"name": "limit", "in": "query", "required": False, "schema": {"type": "integer"}},
+    ],
+    "responses": {
+        "200": {"schema": {"type": "object", "properties": {"id": {"type": "integer"}}}},
+    },
+}
+
+
+class MockBinding:
+    def __init__(self, route: str, methods: list[str] | None, type: str = "httpTrigger") -> None:
+        self.route = route
+        self.methods = methods
+        self.type = type
+
+
+class MockFunction:
+    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
+        self._name = name
+        self._func = func
+        self._bindings = bindings
+
+
+class MockBuilder:
+    def __init__(self, function: MockFunction) -> None:
+        self._function = function
+
+
+class MockApp:
+    def __init__(self, builders: list[MockBuilder]) -> None:
+        self._function_builders = builders
+
+
+def _make_handler(namespaces: dict[str, Any]) -> Any:
+    def handler(req: Any) -> Any:
+        return req
+
+    setattr(handler, _HANDLER_METADATA_ATTR, namespaces)
+    return handler
+
+
+def _make_app(
+    namespaces: dict[str, Any],
+    *,
+    name: str = "create_user",
+    route: str = "users",
+    methods: list[str] | None = None,
+) -> MockApp:
+    handler = _make_handler(namespaces)
+    binding = MockBinding(route=route, methods=methods or ["POST"])
+    fn = MockFunction(name=name, func=handler, bindings=[binding])
+    return MockApp([MockBuilder(fn)])
+
+
+# ---------------------------------------------------------------------------
+# _read_endpoint_hints
+# ---------------------------------------------------------------------------
+
+
+def test_read_endpoint_hints_accepts_version_1() -> None:
+    handler = _make_handler({"endpoint": FLAT_ENDPOINT})
+    result = _read_endpoint_hints(handler)
+    assert result is not None
+    assert result["request_body"]["properties"]["name"]["type"] == "string"
+
+
+def test_read_endpoint_hints_missing_version_rejected() -> None:
+    # ``version`` is a required key for the endpoint contract (unlike validation).
+    handler = _make_handler({"endpoint": {"request_body": {"type": "object"}}})
+    assert _read_endpoint_hints(handler) is None
+
+
+def test_read_endpoint_hints_unsupported_version_rejected(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    handler = _make_handler({"endpoint": {"version": 999}})
+    with caplog.at_level("WARNING", logger="azure_functions_openapi.bridge"):
+        assert _read_endpoint_hints(handler) is None
+    assert any("unsupported version" in m for m in caplog.messages)
+
+
+def test_read_endpoint_hints_boolean_version_rejected() -> None:
+    handler = _make_handler({"endpoint": {"version": True}})
+    assert _read_endpoint_hints(handler) is None
+
+
+def test_read_endpoint_hints_walks_wrapped_chain() -> None:
+    inner: Any = lambda req: req  # noqa: E731
+    setattr(inner, _HANDLER_METADATA_ATTR, {"endpoint": FLAT_ENDPOINT})
+    outer: Any = lambda req: inner(req)  # noqa: E731
+    outer.__wrapped__ = inner
+
+    result = _read_endpoint_hints(outer)
+    assert result is not None
+    assert result["version"] == 1
+
+
+def test_read_endpoint_hints_invalid_outer_valid_inner() -> None:
+    inner: Any = lambda req: req  # noqa: E731
+    setattr(inner, _HANDLER_METADATA_ATTR, {"endpoint": FLAT_ENDPOINT})
+    outer: Any = lambda req: inner(req)  # noqa: E731
+    setattr(outer, _HANDLER_METADATA_ATTR, {"endpoint": {"version": 999}})
+    outer.__wrapped__ = inner
+
+    result = _read_endpoint_hints(outer)
+    assert result is not None
+    assert result["version"] == 1
+
+
+def test_read_endpoint_hints_self_referencing_stops() -> None:
+    handler: Any = lambda req: req  # noqa: E731
+    setattr(handler, _HANDLER_METADATA_ATTR, {"endpoint": {"version": 999}})
+    handler.__wrapped__ = handler
+    assert _read_endpoint_hints(handler) is None
+
+
+def test_read_endpoint_hints_returns_deep_copy() -> None:
+    handler = _make_handler({"endpoint": FLAT_ENDPOINT})
+    result = _read_endpoint_hints(handler)
+    assert result is not None
+    result["request_body"]["properties"]["name"]["type"] = "mutated"
+
+    stored = getattr(handler, _HANDLER_METADATA_ATTR)["endpoint"]
+    assert stored["request_body"]["properties"]["name"]["type"] == "string"
+
+
+def test_read_endpoint_hints_absent_namespace() -> None:
+    handler = _make_handler({"validation": {"body": None}})
+    assert _read_endpoint_hints(handler) is None
+
+
+# ---------------------------------------------------------------------------
+# _discovered_operation_from_endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_discovered_operation_from_endpoint_shape() -> None:
+    discovered = _discovered_operation_from_endpoint(
+        "create_user", FLAT_ENDPOINT, "/api/users", "post"
+    )
+    assert discovered["request_body"]["type"] == "object"
+    assert discovered["request_body_required"] is True
+    assert discovered["parameters"][0]["name"] == "limit"
+    assert discovered["response"][200]["content"]["application/json"]["schema"] == {
+        "type": "object",
+        "properties": {"id": {"type": "integer"}},
+    }
+    assert discovered["response"][200]["description"] == ""
+
+
+def test_discovered_operation_from_endpoint_defaults_and_filters() -> None:
+    payload: dict[str, Any] = {
+        "version": 1,
+        "request_body": "not-a-dict",
+        "parameters": ["bad", {"name": "ok", "in": "query"}],
+        "responses": {
+            "not-an-int": {"schema": {"type": "string"}},
+            "201": "not-a-dict",
+            "204": {"schema": {"type": "null"}},
+        },
+    }
+    discovered = _discovered_operation_from_endpoint("fn", payload, "/api/x", "post")
+    assert discovered["request_body"] is None
+    assert discovered["request_body_required"] is True  # defaulted
+    assert discovered["parameters"] == [{"name": "ok", "in": "query"}]
+    assert set(discovered["response"].keys()) == {204}
+
+
+def test_discovered_operation_from_endpoint_non_dict_responses() -> None:
+    payload: dict[str, Any] = {"version": 1, "responses": "nope"}
+    discovered = _discovered_operation_from_endpoint("fn", payload, "/api/x", "get")
+    assert discovered["response"] == {}
+
+
+# ---------------------------------------------------------------------------
+# scan_validation_metadata — endpoint namespace happy path
+# ---------------------------------------------------------------------------
+
+
+def test_scan_registers_from_endpoint_namespace() -> None:
+    app = _make_app({"endpoint": FLAT_ENDPOINT})
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["request_body"]["properties"]["name"]["type"] == "string"
+    assert entry["request_body_required"] is True
+    assert entry["response"][200]["content"]["application/json"]["schema"]["properties"] == {
+        "id": {"type": "integer"}
+    }
+    assert entry["parameters"][0]["name"] == "limit"
+
+
+def test_scan_endpoint_request_body_not_required() -> None:
+    payload = dict(FLAT_ENDPOINT)
+    payload["request_body_required"] = False
+    app = _make_app({"endpoint": payload})
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["request_body_required"] is False
+
+
+# ---------------------------------------------------------------------------
+# Version-skew: endpoint preferred, validation fallback
+# ---------------------------------------------------------------------------
+
+
+class _Body(BaseModel):
+    name: str
+
+
+class _Resp(BaseModel):
+    id: int
+
+
+def test_scan_prefers_endpoint_over_validation_when_both_present() -> None:
+    app = _make_app(
+        {
+            "endpoint": FLAT_ENDPOINT,
+            "validation": {"body": _Body, "response_model": _Resp},
+        }
+    )
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    # Endpoint path does NOT set response_model (it uses the raw ``response`` slot).
+    assert entry["response_model"] is None
+    assert entry["response"][200]["content"]["application/json"]["schema"]["properties"] == {
+        "id": {"type": "integer"}
+    }
+
+
+def test_scan_falls_back_to_validation_when_only_validation_present() -> None:
+    app = _make_app({"validation": {"body": _Body, "response_model": _Resp}})
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["response_model"] is _Resp
+
+
+def test_scan_falls_back_to_validation_when_endpoint_version_unsupported() -> None:
+    app = _make_app(
+        {
+            "endpoint": {"version": 999, "request_body": {"type": "object"}},
+            "validation": {"body": _Body, "response_model": _Resp},
+        }
+    )
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["response_model"] is _Resp
+
+
+# ---------------------------------------------------------------------------
+# Merge into existing @openapi entry
+# ---------------------------------------------------------------------------
+
+
+def test_scan_endpoint_merges_into_existing_openapi_entry() -> None:
+    register_openapi_metadata(path="/api/users", method="post", summary="explicit")
+    app = _make_app({"endpoint": FLAT_ENDPOINT})
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["summary"] == "explicit"  # explicit metadata preserved
+    assert entry["request_body"]["properties"]["name"]["type"] == "string"
+    assert entry["request_body_required"] is True
+    assert 200 in entry["response"]
+
+
+def test_scan_endpoint_conflicting_response_raises() -> None:
+    register_openapi_metadata(
+        path="/api/users",
+        method="post",
+        response={200: {"content": {"application/json": {"schema": {"type": "string"}}}}},
+    )
+    app = _make_app({"endpoint": FLAT_ENDPOINT})
+    with pytest.raises(OpenAPISpecConfigError):
+        scan_validation_metadata(app)
+
+
+# ---------------------------------------------------------------------------
+# _models_conflict — response dict
+# ---------------------------------------------------------------------------
+
+
+def test_models_conflict_response_dict_same_status_differs() -> None:
+    assert (
+        _models_conflict(
+            {"response": {200: {"a": 1}}},
+            {"response": {200: {"a": 2}}},
+        )
+        is True
+    )
+
+
+def test_models_conflict_response_dict_disjoint_status_ok() -> None:
+    assert (
+        _models_conflict(
+            {"response": {200: {"a": 1}}},
+            {"response": {404: {"a": 1}}},
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Nested-model known limitation (verbatim embed of $defs refs)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_endpoint_embeds_nested_defs_verbatim() -> None:
+    """Path A (MVP): nested-model ``$defs``/``#/$defs/`` refs are embedded
+    verbatim rather than hoisted into ``components.schemas``. This documents the
+    known limitation tracked by the follow-up hoisting issue.
+    """
+    nested_payload: dict[str, Any] = {
+        "version": 1,
+        "request_body": {
+            "type": "object",
+            "properties": {"child": {"$ref": "#/$defs/Child"}},
+            "$defs": {"Child": {"type": "object", "properties": {"x": {"type": "integer"}}}},
+        },
+        "request_body_required": True,
+    }
+    app = _make_app({"endpoint": nested_payload})
+    scan_validation_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    # The producer's $defs are preserved inline, unresolved (not hoisted).
+    assert entry["request_body"]["$defs"]["Child"]["properties"]["x"]["type"] == "integer"
+    assert entry["request_body"]["properties"]["child"]["$ref"] == "#/$defs/Child"

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -18,6 +18,7 @@ from azure_functions_openapi.decorator import (
     register_openapi_metadata,
 )
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+from azure_functions_openapi.spec import generate_openapi_spec
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -347,14 +348,13 @@ def test_models_conflict_response_dict_disjoint_status_ok() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Nested-model known limitation (verbatim embed of $defs refs)
+# Nested-model $defs hoisting into components.schemas (issue #315)
 # ---------------------------------------------------------------------------
 
 
-def test_scan_endpoint_embeds_nested_defs_verbatim() -> None:
-    """Path A (MVP): nested-model ``$defs``/``#/$defs/`` refs are embedded
-    verbatim rather than hoisted into ``components.schemas``. This documents the
-    known limitation tracked by the follow-up hoisting issue.
+def test_scan_endpoint_keeps_nested_defs_verbatim_in_registry() -> None:
+    """The bridge still stores producer schemas verbatim in the registry;
+    hoisting is a spec-generation concern handled by ``generate_openapi_spec``.
     """
     nested_payload: dict[str, Any] = {
         "version": 1,
@@ -369,6 +369,185 @@ def test_scan_endpoint_embeds_nested_defs_verbatim() -> None:
     scan_validation_metadata(app)
 
     entry = get_openapi_registry()["post::/api/users"]
-    # The producer's $defs are preserved inline, unresolved (not hoisted).
+    # Bridge contract: producer $defs are preserved inline in the registry.
     assert entry["request_body"]["$defs"]["Child"]["properties"]["x"]["type"] == "integer"
     assert entry["request_body"]["properties"]["child"]["$ref"] == "#/$defs/Child"
+
+
+def test_generate_spec_hoists_request_body_defs() -> None:
+    """Inline ``$defs`` in an endpoint request body are hoisted into
+    ``components.schemas`` and the ``#/$defs/`` ref is rewritten (issue #315)."""
+    nested_payload: dict[str, Any] = {
+        "version": 1,
+        "request_body": {
+            "type": "object",
+            "properties": {"child": {"$ref": "#/$defs/Child"}},
+            "$defs": {"Child": {"type": "object", "properties": {"x": {"type": "integer"}}}},
+        },
+        "request_body_required": True,
+    }
+    app = _make_app({"endpoint": nested_payload})
+    scan_validation_metadata(app)
+
+    spec = generate_openapi_spec()
+    schema = spec["paths"]["/api/users"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    # Root stays inline, but its ref now points at components.schemas.
+    assert schema["properties"]["child"]["$ref"] == "#/components/schemas/Child"
+    assert "$defs" not in schema
+    # Child is hoisted into the shared components.schemas section.
+    assert spec["components"]["schemas"]["Child"]["properties"]["x"]["type"] == "integer"
+
+
+def test_generate_spec_hoists_response_and_parameter_defs() -> None:
+    """``$defs`` in response and parameter schemas are also hoisted (issue #315)."""
+    payload: dict[str, Any] = {
+        "version": 1,
+        "parameters": [
+            {
+                "name": "body",
+                "in": "query",
+                "required": False,
+                "schema": {
+                    "properties": {"p": {"$ref": "#/$defs/ParamModel"}},
+                    "$defs": {"ParamModel": {"type": "object"}},
+                },
+            }
+        ],
+        "responses": {
+            "200": {
+                "schema": {
+                    "properties": {"r": {"$ref": "#/$defs/RespModel"}},
+                    "$defs": {"RespModel": {"type": "object"}},
+                }
+            }
+        },
+    }
+    app = _make_app({"endpoint": payload})
+    scan_validation_metadata(app)
+
+    spec = generate_openapi_spec()
+    op = spec["paths"]["/api/users"]["post"]
+    param_schema = op["parameters"][0]["schema"]
+    resp_schema = op["responses"]["200"]["content"]["application/json"]["schema"]
+    assert param_schema["properties"]["p"]["$ref"] == "#/components/schemas/ParamModel"
+    assert resp_schema["properties"]["r"]["$ref"] == "#/components/schemas/RespModel"
+    assert "ParamModel" in spec["components"]["schemas"]
+    assert "RespModel" in spec["components"]["schemas"]
+
+
+def test_generate_spec_hoists_nested_of_nested_defs() -> None:
+    """Recursively nested ``$defs`` (a def that references another def) are all
+    hoisted flat into ``components.schemas``."""
+    payload: dict[str, Any] = {
+        "version": 1,
+        "request_body": {
+            "type": "object",
+            "properties": {"parent": {"$ref": "#/$defs/Parent"}},
+            "$defs": {
+                "Parent": {
+                    "type": "object",
+                    "properties": {"kid": {"$ref": "#/$defs/Kid"}},
+                    "$defs": {"Kid": {"type": "object", "properties": {"y": {"type": "integer"}}}},
+                }
+            },
+        },
+        "request_body_required": True,
+    }
+    app = _make_app({"endpoint": payload})
+    scan_validation_metadata(app)
+
+    spec = generate_openapi_spec()
+    schemas = spec["components"]["schemas"]
+    assert "Parent" in schemas
+    assert "Kid" in schemas
+    assert schemas["Parent"]["properties"]["kid"]["$ref"] == "#/components/schemas/Kid"
+    assert "$defs" not in schemas["Parent"]
+
+
+def test_generate_spec_hoists_defs_referenced_inside_allof_items() -> None:
+    """A local ``#/$defs/`` ref buried inside ``allOf[].items`` is detected by the
+    recursive ``_needs_hoisting`` walk (through nested dict/list levels) and the
+    definition is hoisted rather than embedded verbatim (issue #315)."""
+    payload: dict[str, Any] = {
+        "version": 1,
+        "request_body": {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "items": {"allOf": [{"items": {"$ref": "#/$defs/Buried"}}]},
+                }
+            },
+            "$defs": {"Buried": {"type": "object", "properties": {"z": {"type": "string"}}}},
+        },
+        "request_body_required": True,
+    }
+    app = _make_app({"endpoint": payload})
+    scan_validation_metadata(app)
+
+    spec = generate_openapi_spec()
+    schema = spec["paths"]["/api/users"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    buried_ref = schema["properties"]["items"]["items"]["allOf"][0]["items"]["$ref"]
+    assert buried_ref == "#/components/schemas/Buried"
+    assert "$defs" not in schema
+    assert spec["components"]["schemas"]["Buried"]["properties"]["z"]["type"] == "string"
+
+def test_generate_spec_flat_schema_embedded_verbatim() -> None:
+    """Flat schemas (no ``$defs``) are embedded verbatim with no components entry
+    created for them (no regression to #311)."""
+    app = _make_app({"endpoint": FLAT_ENDPOINT})
+    scan_validation_metadata(app)
+
+    spec = generate_openapi_spec()
+    schema = spec["paths"]["/api/users"]["post"]["requestBody"]["content"][
+        "application/json"
+    ]["schema"]
+    assert schema["properties"]["name"]["type"] == "string"
+    assert "$defs" not in schema
+    assert "components" not in spec or "schemas" not in spec.get("components", {})
+
+
+def test_generate_spec_resolves_conflicting_defs_across_operations() -> None:
+    """Two operations that each define a differently-shaped ``Child`` get a
+    collision-resolved second component name."""
+    payload_a: dict[str, Any] = {
+        "version": 1,
+        "request_body": {
+            "type": "object",
+            "properties": {"child": {"$ref": "#/$defs/Child"}},
+            "$defs": {"Child": {"type": "object", "properties": {"x": {"type": "integer"}}}},
+        },
+        "request_body_required": True,
+    }
+    payload_b: dict[str, Any] = {
+        "version": 1,
+        "request_body": {
+            "type": "object",
+            "properties": {"child": {"$ref": "#/$defs/Child"}},
+            "$defs": {"Child": {"type": "object", "properties": {"z": {"type": "string"}}}},
+        },
+        "request_body_required": True,
+    }
+    handler_a = _make_handler({"endpoint": payload_a})
+    handler_b = _make_handler({"endpoint": payload_b})
+    app = MockApp(
+        [
+            MockBuilder(MockFunction("create_a", handler_a, [MockBinding("a", ["POST"])])),
+            MockBuilder(MockFunction("create_b", handler_b, [MockBinding("b", ["POST"])])),
+        ]
+    )
+    scan_validation_metadata(app)
+
+    spec = generate_openapi_spec()
+    schemas = spec["components"]["schemas"]
+    # Both distinct shapes are present under collision-resolved names.
+    assert "Child" in schemas
+    assert "Child_2" in schemas
+    shapes = {"Child": schemas["Child"], "Child_2": schemas["Child_2"]}
+    property_keys = {name: set(s["properties"]) for name, s in shapes.items()}
+    assert {"x"} in property_keys.values()
+    assert {"z"} in property_keys.values()

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -10,7 +10,7 @@ from azure_functions_openapi.bridge import (
     _discovered_operation_from_endpoint,
     _models_conflict,
     _read_endpoint_hints,
-    scan_validation_metadata,
+    scan_endpoint_metadata,
 )
 from azure_functions_openapi.decorator import (
     clear_openapi_registry,
@@ -216,13 +216,13 @@ def test_discovered_operation_from_endpoint_non_dict_responses() -> None:
 
 
 # ---------------------------------------------------------------------------
-# scan_validation_metadata — endpoint namespace happy path
+# scan_endpoint_metadata — endpoint namespace happy path
 # ---------------------------------------------------------------------------
 
 
 def test_scan_registers_from_endpoint_namespace() -> None:
     app = _make_app({"endpoint": FLAT_ENDPOINT})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     entry = get_openapi_registry()["post::/api/users"]
     assert entry["request_body"]["properties"]["name"]["type"] == "string"
@@ -237,7 +237,7 @@ def test_scan_endpoint_request_body_not_required() -> None:
     payload = dict(FLAT_ENDPOINT)
     payload["request_body_required"] = False
     app = _make_app({"endpoint": payload})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     entry = get_openapi_registry()["post::/api/users"]
     assert entry["request_body_required"] is False
@@ -263,7 +263,7 @@ def test_scan_prefers_endpoint_over_validation_when_both_present() -> None:
             "validation": {"body": _Body, "response_model": _Resp},
         }
     )
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     entry = get_openapi_registry()["post::/api/users"]
     # Endpoint path does NOT set response_model (it uses the raw ``response`` slot).
@@ -273,25 +273,42 @@ def test_scan_prefers_endpoint_over_validation_when_both_present() -> None:
     }
 
 
-def test_scan_falls_back_to_validation_when_only_validation_present() -> None:
+def test_scan_falls_back_to_validation_when_only_validation_present(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     app = _make_app({"validation": {"body": _Body, "response_model": _Resp}})
-    scan_validation_metadata(app)
+    with caplog.at_level("WARNING", logger="azure_functions_openapi.bridge"):
+        scan_endpoint_metadata(app)
+
+    entry = get_openapi_registry()["post::/api/users"]
+    assert entry["response_model"] is _Resp
+    # No endpoint namespace at all -> plain validation path, no fallback warning.
+    assert not any("falling back to the validation namespace" in m for m in caplog.messages)
+    app = _make_app({"validation": {"body": _Body, "response_model": _Resp}})
+    scan_endpoint_metadata(app)
 
     entry = get_openapi_registry()["post::/api/users"]
     assert entry["response_model"] is _Resp
 
 
-def test_scan_falls_back_to_validation_when_endpoint_version_unsupported() -> None:
+def test_scan_falls_back_to_validation_when_endpoint_version_unsupported(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     app = _make_app(
         {
             "endpoint": {"version": 999, "request_body": {"type": "object"}},
             "validation": {"body": _Body, "response_model": _Resp},
         }
     )
-    scan_validation_metadata(app)
+    with caplog.at_level("WARNING", logger="azure_functions_openapi.bridge"):
+        scan_endpoint_metadata(app)
 
     entry = get_openapi_registry()["post::/api/users"]
     assert entry["response_model"] is _Resp
+    # A present-but-rejected endpoint namespace that silently downgrades to the
+    # validation namespace must surface an explicit, actionable warning (#318).
+    assert any("falling back to the validation namespace" in m for m in caplog.messages)
+    assert any("create_user" in m for m in caplog.messages)
 
 
 # ---------------------------------------------------------------------------
@@ -302,7 +319,7 @@ def test_scan_falls_back_to_validation_when_endpoint_version_unsupported() -> No
 def test_scan_endpoint_merges_into_existing_openapi_entry() -> None:
     register_openapi_metadata(path="/api/users", method="post", summary="explicit")
     app = _make_app({"endpoint": FLAT_ENDPOINT})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     entry = get_openapi_registry()["post::/api/users"]
     assert entry["summary"] == "explicit"  # explicit metadata preserved
@@ -319,7 +336,7 @@ def test_scan_endpoint_conflicting_response_raises() -> None:
     )
     app = _make_app({"endpoint": FLAT_ENDPOINT})
     with pytest.raises(OpenAPISpecConfigError):
-        scan_validation_metadata(app)
+        scan_endpoint_metadata(app)
 
 
 # ---------------------------------------------------------------------------
@@ -366,7 +383,7 @@ def test_scan_endpoint_keeps_nested_defs_verbatim_in_registry() -> None:
         "request_body_required": True,
     }
     app = _make_app({"endpoint": nested_payload})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     entry = get_openapi_registry()["post::/api/users"]
     # Bridge contract: producer $defs are preserved inline in the registry.
@@ -387,12 +404,12 @@ def test_generate_spec_hoists_request_body_defs() -> None:
         "request_body_required": True,
     }
     app = _make_app({"endpoint": nested_payload})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     spec = generate_openapi_spec()
-    schema = spec["paths"]["/api/users"]["post"]["requestBody"]["content"][
-        "application/json"
-    ]["schema"]
+    schema = spec["paths"]["/api/users"]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]
     # Root stays inline, but its ref now points at components.schemas.
     assert schema["properties"]["child"]["$ref"] == "#/components/schemas/Child"
     assert "$defs" not in schema
@@ -425,7 +442,7 @@ def test_generate_spec_hoists_response_and_parameter_defs() -> None:
         },
     }
     app = _make_app({"endpoint": payload})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     spec = generate_openapi_spec()
     op = spec["paths"]["/api/users"]["post"]
@@ -456,7 +473,7 @@ def test_generate_spec_hoists_nested_of_nested_defs() -> None:
         "request_body_required": True,
     }
     app = _make_app({"endpoint": payload})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     spec = generate_openapi_spec()
     schemas = spec["components"]["schemas"]
@@ -485,27 +502,28 @@ def test_generate_spec_hoists_defs_referenced_inside_allof_items() -> None:
         "request_body_required": True,
     }
     app = _make_app({"endpoint": payload})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     spec = generate_openapi_spec()
-    schema = spec["paths"]["/api/users"]["post"]["requestBody"]["content"][
-        "application/json"
-    ]["schema"]
+    schema = spec["paths"]["/api/users"]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]
     buried_ref = schema["properties"]["items"]["items"]["allOf"][0]["items"]["$ref"]
     assert buried_ref == "#/components/schemas/Buried"
     assert "$defs" not in schema
     assert spec["components"]["schemas"]["Buried"]["properties"]["z"]["type"] == "string"
 
+
 def test_generate_spec_flat_schema_embedded_verbatim() -> None:
     """Flat schemas (no ``$defs``) are embedded verbatim with no components entry
     created for them (no regression to #311)."""
     app = _make_app({"endpoint": FLAT_ENDPOINT})
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     spec = generate_openapi_spec()
-    schema = spec["paths"]["/api/users"]["post"]["requestBody"]["content"][
-        "application/json"
-    ]["schema"]
+    schema = spec["paths"]["/api/users"]["post"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ]
     assert schema["properties"]["name"]["type"] == "string"
     assert "$defs" not in schema
     assert "components" not in spec or "schemas" not in spec.get("components", {})
@@ -540,7 +558,7 @@ def test_generate_spec_resolves_conflicting_defs_across_operations() -> None:
             MockBuilder(MockFunction("create_b", handler_b, [MockBinding("b", ["POST"])])),
         ]
     )
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     spec = generate_openapi_spec()
     schemas = spec["components"]["schemas"]
@@ -551,3 +569,36 @@ def test_generate_spec_resolves_conflicting_defs_across_operations() -> None:
     property_keys = {name: set(s["properties"]) for name, s in shapes.items()}
     assert {"x"} in property_keys.values()
     assert {"z"} in property_keys.values()
+
+
+# ---------------------------------------------------------------------------
+# Deprecated alias: scan_validation_metadata (#319)
+# ---------------------------------------------------------------------------
+
+
+def test_scan_validation_metadata_alias_emits_deprecation_warning() -> None:
+    from azure_functions_openapi.bridge import scan_validation_metadata
+
+    app = _make_app({"endpoint": FLAT_ENDPOINT})
+    with pytest.warns(DeprecationWarning, match="scan_endpoint_metadata"):
+        scan_validation_metadata(app)
+
+    # Behavior is identical to the canonical function.
+    assert "post::/api/users" in get_openapi_registry()
+
+
+def test_scan_validation_metadata_alias_matches_canonical_output() -> None:
+    from azure_functions_openapi.bridge import scan_validation_metadata
+
+    app_alias = _make_app({"endpoint": FLAT_ENDPOINT})
+    with pytest.warns(DeprecationWarning):
+        scan_validation_metadata(app_alias)
+    via_alias = generate_openapi_spec()
+
+    clear_openapi_registry()
+
+    app_canonical = _make_app({"endpoint": FLAT_ENDPOINT})
+    scan_endpoint_metadata(app_canonical)
+    via_canonical = generate_openapi_spec()
+
+    assert via_alias == via_canonical

--- a/tests/test_bridge_endpoint_golden.py
+++ b/tests/test_bridge_endpoint_golden.py
@@ -141,8 +141,6 @@ def _canonical(spec: dict[str, Any]) -> str:
     would weaken the byte-identity guarantee this golden test enforces.
     """
     return json.dumps(spec, sort_keys=True)
-    """Deterministic, order-insensitive serialization for byte comparison."""
-    return json.dumps(spec, sort_keys=True, default=str)
 
 
 # ---------------------------------------------------------------------------
@@ -176,9 +174,10 @@ class Color(str, Enum):
 class EnumBody(BaseModel):
     """Flat body whose enum field forces an inline ``$defs`` block.
 
-    Both code paths embed ``request_body`` verbatim (the validation path also
-    uses ``type_to_schema(body, components=None)``), so even a ``$defs``-bearing
-    body stays byte-identical — hoisting only applies to ``response_model``.
+    Both code paths run ``request_body`` through the same inline-``$defs``
+    hoisting (``hoist_inline_defs`` now applies to request bodies, parameters,
+    and responses alike), so even a ``$defs``-bearing body stays byte-identical
+    across the endpoint and validation paths.
     """
 
     color: Color

--- a/tests/test_bridge_endpoint_golden.py
+++ b/tests/test_bridge_endpoint_golden.py
@@ -37,7 +37,7 @@ from typing import Any
 from pydantic import BaseModel
 import pytest
 
-from azure_functions_openapi.bridge import _model_to_parameters, scan_validation_metadata
+from azure_functions_openapi.bridge import _model_to_parameters, scan_endpoint_metadata
 from azure_functions_openapi.decorator import clear_openapi_registry
 from azure_functions_openapi.spec import generate_openapi_spec
 from azure_functions_openapi.utils import type_to_schema
@@ -127,7 +127,7 @@ def _spec_for(namespaces: dict[str, Any], *, route: str, methods: list[str]) -> 
     clear_openapi_registry()
     try:
         app = _make_app(namespaces, route=route, methods=methods)
-        scan_validation_metadata(app)
+        scan_endpoint_metadata(app)
         return generate_openapi_spec()
     finally:
         clear_openapi_registry()

--- a/tests/test_bridge_endpoint_golden.py
+++ b/tests/test_bridge_endpoint_golden.py
@@ -181,6 +181,20 @@ class Resp(BaseModel):
     id: int
 
 
+class OptionalResp(BaseModel):
+    """Response model with an ``Optional`` field.
+
+    Exercises the OpenAPI 3.1 conversion (``_convert_schema_to_3_1``) on both
+    paths: the endpoint inline schema goes through
+    ``_convert_operation_schemas_to_3_1`` while the hoisted validation schema
+    goes through ``_convert_schemas_to_3_1``. Semantic equivalence must still
+    hold after conversion.
+    """
+
+    id: int
+    note: str | None = None
+
+
 # ---------------------------------------------------------------------------
 # Tier 1 — full byte identity
 # ---------------------------------------------------------------------------
@@ -229,7 +243,10 @@ def _response_schema(spec: dict[str, Any], path: str, method: str) -> dict[str, 
     return schema
 
 
-def test_response_model_diverges_but_is_semantically_equivalent() -> None:
+@pytest.mark.parametrize("response_model", [Resp, OptionalResp])
+def test_response_model_diverges_but_is_semantically_equivalent(
+    response_model: type[BaseModel],
+) -> None:
     """response_model: validation hoists to ``$ref``; endpoint inlines.
 
     Full byte identity is intentionally NOT expected under the Path-A endpoint
@@ -237,7 +254,7 @@ def test_response_model_diverges_but_is_semantically_equivalent() -> None:
     prove semantic equivalence by resolving the validation ``$ref``. Byte
     identity is tracked by the ``$defs`` hoisting follow-up (#315).
     """
-    validation: dict[str, Any] = {"response_model": Resp}
+    validation: dict[str, Any] = {"response_model": response_model}
     route, method = "get_item", "get"
 
     spec_validation = _spec_for({"validation": validation}, route=route, methods=["GET"])
@@ -247,6 +264,10 @@ def test_response_model_diverges_but_is_semantically_equivalent() -> None:
     path = "/api/get_item"
 
     # --- documented structural divergence ---
+    # NOTE: When the $defs-hoisting follow-up (#315) lands, the endpoint path
+    # will also hoist into components.schemas and this `!=` becomes `==`; this
+    # assertion will then fail loudly, signalling the Tier-2 case can be
+    # promoted to Tier-1 full identity.
     assert _canonical(spec_endpoint) != _canonical(spec_validation)
 
     validation_schema = _response_schema(spec_validation, path, method)

--- a/tests/test_bridge_endpoint_golden.py
+++ b/tests/test_bridge_endpoint_golden.py
@@ -1,0 +1,291 @@
+"""Golden equivalence test for issue #312.
+
+Confirms that the OpenAPI spec generated from the shared ``endpoint`` metadata
+namespace is *identical* to the spec generated from the legacy ``validation``
+fallback path for the same handler — the confirming experiment that makes the
+umbrella convergence (validation-python#270) safe to roll out.
+
+Two-tier assertion strategy (per the pre-implementation design gate):
+
+* **Tier 1 — full byte identity** for handlers whose response schema is not a
+  Pydantic ``response_model`` class: body-only, query/path/header params, and
+  combinations. For these, both code paths embed request-body and parameter
+  schemas the same way, so ``json.dumps(spec, sort_keys=True)`` must match.
+
+* **Tier 2 — documented divergence** for ``response_model`` handlers. Under the
+  Path-A / MVP endpoint reader (openapi-python#311), producer response schemas
+  are embedded *verbatim inline*, whereas the ``validation`` path hoists the
+  Pydantic model into ``components.schemas`` and emits a ``$ref``. The two specs
+  are therefore structurally different but *semantically equivalent*: resolving
+  the validation ``$ref`` yields exactly the inline endpoint schema. Full byte
+  identity for this case is deferred to the ``$defs`` hoisting follow-up
+  (openapi-python#315).
+
+To keep the hand-authored ``endpoint`` payload honest without importing the
+producer package (this repo is the *consumer*), the endpoint namespace is
+derived from the *same* Pydantic models using this repo's own helpers
+(:func:`type_to_schema`, :func:`_model_to_parameters`) — exactly the schemas a
+conforming producer is specified to emit.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+import json
+from typing import Any
+
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_openapi.bridge import _model_to_parameters, scan_validation_metadata
+from azure_functions_openapi.decorator import clear_openapi_registry
+from azure_functions_openapi.spec import generate_openapi_spec
+from azure_functions_openapi.utils import type_to_schema
+
+# ---------------------------------------------------------------------------
+# Mock Azure Functions app scaffolding (mirrors tests/test_bridge_endpoint.py)
+# ---------------------------------------------------------------------------
+
+
+class MockBinding:
+    def __init__(self, route: str, methods: list[str], type: str = "httpTrigger") -> None:
+        self.route = route
+        self.methods = methods
+        self.type = type
+
+
+class MockFunction:
+    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
+        self._name = name
+        self._func = func
+        self._bindings = bindings
+
+
+class MockBuilder:
+    def __init__(self, function: MockFunction) -> None:
+        self._function = function
+
+
+class MockApp:
+    def __init__(self, builders: list[MockBuilder]) -> None:
+        self._function_builders = builders
+
+
+def _make_app(
+    namespaces: dict[str, Any],
+    *,
+    name: str = "create_user",
+    route: str = "users",
+    methods: list[str],
+) -> MockApp:
+    def handler(req: Any) -> Any:
+        return req
+
+    setattr(handler, "_azure_functions_metadata", namespaces)
+    binding = MockBinding(route=route, methods=methods)
+    fn = MockFunction(name=name, func=handler, bindings=[binding])
+    return MockApp([MockBuilder(fn)])
+
+
+# ---------------------------------------------------------------------------
+# Honest derivation of the endpoint namespace from the same models
+# ---------------------------------------------------------------------------
+
+
+def _endpoint_from_validation(validation: dict[str, Any]) -> dict[str, Any]:
+    """Derive the shared ``endpoint`` payload a conforming producer would emit.
+
+    Request bodies become ``model_json_schema()`` (via :func:`type_to_schema`
+    with ``components=None``); parameters use :func:`_model_to_parameters`;
+    a ``response_model`` becomes an inline ``responses`` map. This is precisely
+    the contract the producer packages are specified to follow, so reusing the
+    consumer's own helpers keeps the two hand-authored inputs faithful.
+    """
+    endpoint: dict[str, Any] = {"version": 1}
+
+    body = validation.get("body")
+    if body is not None:
+        endpoint["request_body"] = type_to_schema(body)
+        endpoint["request_body_required"] = True
+
+    parameters: list[dict[str, Any]] = []
+    for location, key in (("query", "query"), ("path", "path"), ("header", "headers")):
+        model = validation.get(key)
+        if model is not None:
+            parameters.extend(_model_to_parameters(model, location))
+    endpoint["parameters"] = parameters
+
+    response_model = validation.get("response_model")
+    if response_model is not None:
+        endpoint["responses"] = {"200": {"schema": type_to_schema(response_model)}}
+
+    return endpoint
+
+
+def _spec_for(namespaces: dict[str, Any], *, route: str, methods: list[str]) -> dict[str, Any]:
+    """Generate a full OpenAPI spec for a single handler carrying *namespaces*."""
+    clear_openapi_registry()
+    try:
+        app = _make_app(namespaces, route=route, methods=methods)
+        scan_validation_metadata(app)
+        return generate_openapi_spec()
+    finally:
+        clear_openapi_registry()
+
+
+def _canonical(spec: dict[str, Any]) -> str:
+    """Deterministic, order-insensitive serialization for byte comparison."""
+    return json.dumps(spec, sort_keys=True, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class Body(BaseModel):
+    name: str
+    age: int
+
+
+class QueryParams(BaseModel):
+    limit: int
+    cursor: str | None = None
+
+
+class PathParams(BaseModel):
+    item_id: int
+
+
+class HeaderParams(BaseModel):
+    x_token: str
+
+
+class Color(str, Enum):
+    red = "red"
+    blue = "blue"
+
+
+class EnumBody(BaseModel):
+    """Flat body whose enum field forces an inline ``$defs`` block.
+
+    Both code paths embed ``request_body`` verbatim (the validation path also
+    uses ``type_to_schema(body, components=None)``), so even a ``$defs``-bearing
+    body stays byte-identical — hoisting only applies to ``response_model``.
+    """
+
+    color: Color
+
+
+class Resp(BaseModel):
+    id: int
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — full byte identity
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("case_id", "validation", "route", "methods"),
+    [
+        ("body_only", {"body": Body}, "users", ["POST"]),
+        ("query_params", {"query": QueryParams}, "search", ["GET"]),
+        (
+            "path_and_header",
+            {"path": PathParams, "headers": HeaderParams},
+            "items/{item_id}",
+            ["GET"],
+        ),
+        ("body_and_query", {"body": Body, "query": QueryParams}, "users", ["POST"]),
+        ("enum_body_inline_defs", {"body": EnumBody}, "users", ["POST"]),
+    ],
+)
+def test_endpoint_spec_identical_to_validation(
+    case_id: str,
+    validation: dict[str, Any],
+    route: str,
+    methods: list[str],
+) -> None:
+    endpoint = _endpoint_from_validation(validation)
+
+    spec_validation = _spec_for({"validation": validation}, route=route, methods=methods)
+    spec_endpoint = _spec_for({"endpoint": endpoint}, route=route, methods=methods)
+
+    assert _canonical(spec_endpoint) == _canonical(spec_validation), (
+        f"endpoint-driven spec diverged from validation-driven spec for {case_id!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — documented divergence with semantic equivalence (response_model)
+# ---------------------------------------------------------------------------
+
+
+def _response_schema(spec: dict[str, Any], path: str, method: str) -> dict[str, Any]:
+    op = spec["paths"][path][method]
+    schema = op["responses"]["200"]["content"]["application/json"]["schema"]
+    assert isinstance(schema, dict)
+    return schema
+
+
+def test_response_model_diverges_but_is_semantically_equivalent() -> None:
+    """response_model: validation hoists to ``$ref``; endpoint inlines.
+
+    Full byte identity is intentionally NOT expected under the Path-A endpoint
+    reader (openapi-python#311). Instead we assert the documented divergence and
+    prove semantic equivalence by resolving the validation ``$ref``. Byte
+    identity is tracked by the ``$defs`` hoisting follow-up (#315).
+    """
+    validation: dict[str, Any] = {"response_model": Resp}
+    route, method = "get_item", "get"
+
+    spec_validation = _spec_for({"validation": validation}, route=route, methods=["GET"])
+    spec_endpoint = _spec_for(
+        {"endpoint": _endpoint_from_validation(validation)}, route=route, methods=["GET"]
+    )
+    path = "/api/get_item"
+
+    # --- documented structural divergence ---
+    assert _canonical(spec_endpoint) != _canonical(spec_validation)
+
+    validation_schema = _response_schema(spec_validation, path, method)
+    endpoint_schema = _response_schema(spec_endpoint, path, method)
+
+    # validation path -> $ref into components.schemas
+    assert "$ref" in validation_schema
+    ref_name = validation_schema["$ref"].rsplit("/", 1)[-1]
+    assert spec_validation["components"]["schemas"][ref_name]  # hoisted
+
+    # endpoint path -> inline schema, no hoisted component schemas
+    assert "$ref" not in endpoint_schema
+    assert not (spec_endpoint.get("components") or {}).get("schemas")
+
+    # --- semantic equivalence: resolving the $ref yields the inline schema ---
+    resolved = spec_validation["components"]["schemas"][ref_name]
+    assert resolved == endpoint_schema
+
+
+def test_response_model_with_body_shares_identical_request_body() -> None:
+    """POST with body + response_model: request_body identical, response diverges.
+
+    The request-body subtree is embedded verbatim by both paths and must match
+    byte-for-byte; only the response subtree diverges under Path A.
+    """
+    validation: dict[str, Any] = {"body": Body, "response_model": Resp}
+    route, method = "users", "post"
+
+    spec_validation = _spec_for({"validation": validation}, route=route, methods=["POST"])
+    spec_endpoint = _spec_for(
+        {"endpoint": _endpoint_from_validation(validation)}, route=route, methods=["POST"]
+    )
+    path = "/api/users"
+
+    request_body_validation = spec_validation["paths"][path][method]["requestBody"]
+    request_body_endpoint = spec_endpoint["paths"][path][method]["requestBody"]
+    assert request_body_endpoint == request_body_validation
+
+    # Response still diverges (validation $ref vs endpoint inline).
+    assert _response_schema(spec_endpoint, path, method) != _response_schema(
+        spec_validation, path, method
+    )

--- a/tests/test_bridge_endpoint_golden.py
+++ b/tests/test_bridge_endpoint_golden.py
@@ -134,6 +134,13 @@ def _spec_for(namespaces: dict[str, Any], *, route: str, methods: list[str]) -> 
 
 
 def _canonical(spec: dict[str, Any]) -> str:
+    """Deterministic, order-insensitive serialization for byte comparison.
+
+    No ``default=`` fallback: the spec must be natively JSON-serializable so a
+    non-serializable value raises instead of being silently stringified, which
+    would weaken the byte-identity guarantee this golden test enforces.
+    """
+    return json.dumps(spec, sort_keys=True)
     """Deterministic, order-insensitive serialization for byte comparison."""
     return json.dumps(spec, sort_keys=True, default=str)
 

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -21,6 +21,8 @@ class TestAPISurface:
             "openapi",
             "register_openapi_metadata",
             "render_swagger_ui",
+            "scan_endpoint_metadata",
+            "scan_validation_metadata",
             "scan_validation_metadata",
         }
 
@@ -46,6 +48,7 @@ class TestAPISurface:
             openapi,
             register_openapi_metadata,
             render_swagger_ui,
+            scan_endpoint_metadata,  # noqa: F401
             scan_validation_metadata,
         )
 

--- a/tests/test_registry_identity.py
+++ b/tests/test_registry_identity.py
@@ -11,7 +11,7 @@ from typing import Any
 from pydantic import BaseModel
 import pytest
 
-from azure_functions_openapi.bridge import scan_validation_metadata
+from azure_functions_openapi.bridge import scan_endpoint_metadata
 from azure_functions_openapi.decorator import (
     clear_openapi_registry,
     get_openapi_registry,
@@ -147,7 +147,7 @@ def test_bridge_merges_into_correct_handler_on_name_collision(register_a_first: 
     # Attach validation metadata only to handler A and scan it.
     _set_validation(handler_a, {"body": Body})
     app = _make_app(name="create_user", route="users", handler=handler_a)
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
 
     reg = get_openapi_registry()
     a_id = canonical_function_id(handler_a)
@@ -167,9 +167,9 @@ def test_bridge_double_scan_does_not_duplicate(caplog: pytest.LogCaptureFixture)
     _set_validation(handler_a, {"body": Body})
     app = _make_app(name="create_user", route="users", handler=handler_a)
 
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
     count_after_first = len(get_openapi_registry())
-    scan_validation_metadata(app)
+    scan_endpoint_metadata(app)
     count_after_second = len(get_openapi_registry())
 
     assert count_after_first == count_after_second
@@ -189,7 +189,7 @@ def test_bridge_refuses_ambiguous_short_name_fallback(caplog: pytest.LogCaptureF
     app = _make_app(name="create_user", route="unrelated", handler=create_user)
 
     with caplog.at_level("WARNING"):
-        scan_validation_metadata(app)
+        scan_endpoint_metadata(app)
 
     assert any("ambiguous" in rec.message.lower() for rec in caplog.records)
     # A standalone endpoint was registered instead of a wrong merge.

--- a/tests/test_spec_hoist_collision.py
+++ b/tests/test_spec_hoist_collision.py
@@ -1,0 +1,237 @@
+"""Deterministic ``$defs`` hoisting: collision aliasing, byte-identical output,
+and combinator/recursive edge cases (issue #315).
+
+``hoist_inline_defs`` lifts producer-authored inline ``$defs`` into
+``components.schemas``. Same-name definitions with identical content are merged;
+same-name definitions with *different* content receive a deterministic ``_2``
+alias plus a ``WARNING`` (so a silent last-write-wins overwrite can never ship).
+These tests pin that contract and prove the output is stable across runs.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from azure_functions_openapi.bridge import _HANDLER_METADATA_ATTR, scan_endpoint_metadata
+from azure_functions_openapi.decorator import clear_openapi_registry, get_openapi_registry
+from azure_functions_openapi.spec import get_openapi_json
+from azure_functions_openapi.utils import hoist_inline_defs
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+def _iter_dicts(node: Any) -> Any:
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_dicts(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_dicts(item)
+
+
+def _has_defs_key(node: Any) -> bool:
+    return any("$defs" in d for d in _iter_dicts(node))
+
+
+def _collect_refs(node: Any) -> list[str]:
+    return [d["$ref"] for d in _iter_dicts(node) if isinstance(d.get("$ref"), str)]
+
+
+class MockBinding:
+    def __init__(self, route: str, methods: list[str] | None, type: str = "httpTrigger") -> None:
+        self.route = route
+        self.methods = methods
+        self.type = type
+
+
+class MockFunction:
+    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
+        self._name = name
+        self._func = func
+        self._bindings = bindings
+
+
+class MockBuilder:
+    def __init__(self, function: MockFunction) -> None:
+        self._function = function
+
+
+class MockApp:
+    def __init__(self, builders: list[MockBuilder]) -> None:
+        self._function_builders = builders
+
+
+def _make_app(request_body: dict[str, Any], *, route: str = "users") -> MockApp:
+    def handler(req: Any) -> Any:
+        return req
+
+    setattr(
+        handler,
+        _HANDLER_METADATA_ATTR,
+        {
+            "endpoint": {
+                "version": 1,
+                "request_body": request_body,
+                "request_body_required": True,
+                "responses": {"200": {"schema": {"type": "object"}}},
+            }
+        },
+    )
+    binding = MockBinding(route=route, methods=["POST"])
+    fn = MockFunction(name="create_user", func=handler, bindings=[binding])
+    return MockApp([MockBuilder(fn)])
+
+
+# ---------------------------------------------------------------------------
+# Collision aliasing — same name, different content → deterministic _2 + WARNING
+# ---------------------------------------------------------------------------
+
+
+def test_collision_different_content_gets_deterministic_alias_and_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    components: dict[str, Any] = {"schemas": {"Child": {"type": "object", "properties": {}}}}
+    schema = {
+        "type": "object",
+        "properties": {"child": {"$ref": "#/$defs/Child"}},
+        "$defs": {
+            "Child": {"type": "object", "properties": {"nickname": {"type": "string"}}},
+        },
+    }
+
+    with caplog.at_level("WARNING", logger="azure_functions_openapi.utils"):
+        root = hoist_inline_defs(schema, components)
+
+    # Original "Child" is preserved; the colliding definition is aliased to Child_2.
+    assert components["schemas"]["Child"] == {"type": "object", "properties": {}}
+    assert "Child_2" in components["schemas"]
+    assert components["schemas"]["Child_2"]["properties"]["nickname"] == {"type": "string"}
+    # The referring $ref was rewritten to the alias.
+    assert root["properties"]["child"]["$ref"] == "#/components/schemas/Child_2"
+    # A WARNING was emitted naming both the original and the alias.
+    assert any("collision" in m and "Child" in m and "Child_2" in m for m in caplog.messages)
+
+
+def test_collision_identical_content_merges_without_warning(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    child = {"type": "object", "properties": {"nickname": {"type": "string"}}}
+    components: dict[str, Any] = {"schemas": {"Child": dict(child)}}
+    schema = {
+        "type": "object",
+        "properties": {"child": {"$ref": "#/$defs/Child"}},
+        "$defs": {"Child": dict(child)},
+    }
+
+    with caplog.at_level("WARNING", logger="azure_functions_openapi.utils"):
+        root = hoist_inline_defs(schema, components)
+
+    # Identical content → merged onto the existing name, no alias, no warning.
+    assert "Child_2" not in components["schemas"]
+    assert root["properties"]["child"]["$ref"] == "#/components/schemas/Child"
+    assert not any("collision" in m for m in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# Determinism — same input yields byte-identical output across runs
+# ---------------------------------------------------------------------------
+
+
+_NESTED_BODY: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "a": {"$ref": "#/$defs/A"},
+        "b": {"$ref": "#/$defs/B"},
+    },
+    "required": ["a", "b"],
+    "$defs": {
+        "A": {"type": "object", "properties": {"x": {"$ref": "#/$defs/B"}}},
+        "B": {"type": "object", "properties": {"y": {"type": "integer"}}},
+    },
+}
+
+
+def test_hoisting_is_byte_identical_across_runs() -> None:
+    def _one() -> str:
+        clear_openapi_registry()
+        scan_endpoint_metadata(_make_app(_NESTED_BODY))
+        assert get_openapi_registry()
+        return get_openapi_json(openapi_version="3.1.0")
+
+    first = _one()
+    second = _one()
+    assert first == second  # byte-for-byte stable
+    # And the payload actually hoisted (no residual $defs, refs resolve).
+    doc = json.loads(first)
+    assert not _has_defs_key(doc)
+    for ref in _collect_refs(doc):
+        assert ref.startswith("#/components/schemas/")
+
+
+# ---------------------------------------------------------------------------
+# Edge cases — recursive defs and anyOf / oneOf / allOf sharing refs
+# ---------------------------------------------------------------------------
+
+
+def test_recursive_defs_hoist_without_infinite_loop() -> None:
+    components: dict[str, Any] = {"schemas": {}}
+    schema = {
+        "type": "object",
+        "properties": {"node": {"$ref": "#/$defs/Node"}},
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {
+                    "value": {"type": "integer"},
+                    "next": {"$ref": "#/$defs/Node"},
+                },
+            }
+        },
+    }
+    root = hoist_inline_defs(schema, components)
+    assert "Node" in components["schemas"]
+    # Self-reference rewritten into components.schemas and still points at Node.
+    assert (
+        components["schemas"]["Node"]["properties"]["next"]["$ref"] == "#/components/schemas/Node"
+    )
+    assert root["properties"]["node"]["$ref"] == "#/components/schemas/Node"
+    assert not _has_defs_key(components["schemas"])
+
+
+@pytest.mark.parametrize("combinator", ["anyOf", "oneOf", "allOf"])
+def test_combinators_sharing_defs_are_hoisted(combinator: str) -> None:
+    components: dict[str, Any] = {"schemas": {}}
+    schema = {
+        "type": "object",
+        "properties": {
+            "either": {
+                combinator: [
+                    {"$ref": "#/$defs/Cat"},
+                    {"$ref": "#/$defs/Dog"},
+                ]
+            }
+        },
+        "$defs": {
+            "Cat": {"type": "object", "properties": {"meow": {"type": "boolean"}}},
+            "Dog": {"type": "object", "properties": {"bark": {"type": "boolean"}}},
+        },
+    }
+    root = hoist_inline_defs(schema, components)
+    assert {"Cat", "Dog"} <= set(components["schemas"])
+    branch = root["properties"]["either"][combinator]
+    assert branch[0]["$ref"] == "#/components/schemas/Cat"
+    assert branch[1]["$ref"] == "#/components/schemas/Dog"
+    assert not _has_defs_key(root)

--- a/tests/test_spec_hoist_versions.py
+++ b/tests/test_spec_hoist_versions.py
@@ -1,0 +1,224 @@
+"""Audit hoisted ``$defs`` for OpenAPI 3.0 / 3.1 correctness (issue #320).
+
+``hoist_inline_defs`` lifts producer-authored inline ``$defs`` out of an
+``endpoint`` schema into ``components.schemas`` and rewrites local
+``#/$defs/{Model}`` refs to ``#/components/schemas/{Model}``. These tests pin
+the interaction between hoisting and the 3.0-vs-3.1 emit path so a regression
+cannot silently leak a raw ``$defs`` block (invalid in both versions) or a
+3.1-only construct into a 3.0 document.
+
+Design note (see #215): the 3.0 path does **not** down-convert Pydantic-v2
+nullable patterns to ``nullable: true`` — it emits a *compatibility warning*
+via ``_check_schemas_3_0_compatible`` (and raises in ``strict`` mode). The 3.1
+path preserves the 2020-12 ``anyOf`` + ``{"type": "null"}`` nullable syntax.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from azure_functions_openapi.bridge import _HANDLER_METADATA_ATTR, scan_endpoint_metadata
+from azure_functions_openapi.decorator import (
+    clear_openapi_registry,
+    get_openapi_registry,
+)
+from azure_functions_openapi.spec import generate_openapi_spec
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+class MockBinding:
+    def __init__(self, route: str, methods: list[str] | None, type: str = "httpTrigger") -> None:
+        self.route = route
+        self.methods = methods
+        self.type = type
+
+
+class MockFunction:
+    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
+        self._name = name
+        self._func = func
+        self._bindings = bindings
+
+
+class MockBuilder:
+    def __init__(self, function: MockFunction) -> None:
+        self._function = function
+
+
+class MockApp:
+    def __init__(self, builders: list[MockBuilder]) -> None:
+        self._function_builders = builders
+
+
+def _make_app(request_body: dict[str, Any]) -> MockApp:
+    def handler(req: Any) -> Any:
+        return req
+
+    setattr(
+        handler,
+        _HANDLER_METADATA_ATTR,
+        {
+            "endpoint": {
+                "version": 1,
+                "request_body": request_body,
+                "request_body_required": True,
+                "responses": {"200": {"schema": {"type": "object"}}},
+            }
+        },
+    )
+    binding = MockBinding(route="users", methods=["POST"])
+    fn = MockFunction(name="create_user", func=handler, bindings=[binding])
+    return MockApp([MockBuilder(fn)])
+
+
+def _iter_dicts(node: Any) -> Any:
+    """Yield every dict nested anywhere within *node* (inclusive)."""
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from _iter_dicts(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from _iter_dicts(item)
+
+
+def _collect_refs(node: Any) -> list[str]:
+    return [d["$ref"] for d in _iter_dicts(node) if isinstance(d.get("$ref"), str)]
+
+
+def _has_defs_key(node: Any) -> bool:
+    return any("$defs" in d for d in _iter_dicts(node))
+
+
+# A request body whose inline ``$defs.Child`` carries a Pydantic-v2 nullable
+# field (``anyOf`` containing ``{"type": "null"}``) — a 3.1-only construct.
+NULLABLE_DEFS_BODY: dict[str, Any] = {
+    "type": "object",
+    "properties": {"child": {"$ref": "#/$defs/Child"}},
+    "required": ["child"],
+    "$defs": {
+        "Child": {
+            "type": "object",
+            "properties": {
+                "nickname": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+            },
+        }
+    },
+}
+
+# A request body whose inline ``$defs.Child`` is 3.0-clean (no nullable/list types).
+PLAIN_DEFS_BODY: dict[str, Any] = {
+    "type": "object",
+    "properties": {"child": {"$ref": "#/$defs/Child"}},
+    "required": ["child"],
+    "$defs": {
+        "Child": {
+            "type": "object",
+            "properties": {"nickname": {"type": "string"}},
+        }
+    },
+}
+
+
+def _request_schema(spec: dict[str, Any]) -> dict[str, Any]:
+    op = spec["paths"]["/api/users"]["post"]
+    schema: dict[str, Any] = op["requestBody"]["content"]["application/json"]["schema"]
+    return schema
+
+
+# ---------------------------------------------------------------------------
+# 3.0 — plain (clean) hoisted defs
+# ---------------------------------------------------------------------------
+
+
+def test_hoisted_defs_30_no_defs_leak_and_refs_resolve(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    scan_endpoint_metadata(_make_app(PLAIN_DEFS_BODY))
+    assert get_openapi_registry()
+
+    with caplog.at_level("WARNING", logger="azure_functions_openapi.spec"):
+        spec = generate_openapi_spec(openapi_version="3.0.0")
+
+    # No raw $defs key survives anywhere in the document.
+    assert not _has_defs_key(spec)
+
+    # Child was hoisted into components.schemas and the ref rewritten.
+    assert "Child" in spec["components"]["schemas"]
+    body_schema = _request_schema(spec)
+    assert body_schema["properties"]["child"]["$ref"] == "#/components/schemas/Child"
+
+    # Every ref points at components.schemas and resolves.
+    for ref in _collect_refs(spec):
+        assert ref.startswith("#/components/schemas/")
+        assert ref.rsplit("/", 1)[-1] in spec["components"]["schemas"]
+
+    # A 3.0-clean schema must not emit a compatibility warning.
+    assert not any("3.0 compatibility" in m for m in caplog.messages)
+
+
+# ---------------------------------------------------------------------------
+# 3.0 — nullable hoisted defs → compatibility warning, still no leak
+# ---------------------------------------------------------------------------
+
+
+def test_hoisted_nullable_defs_30_warns_without_leak(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    scan_endpoint_metadata(_make_app(NULLABLE_DEFS_BODY))
+
+    with caplog.at_level("WARNING", logger="azure_functions_openapi.spec"):
+        spec = generate_openapi_spec(openapi_version="3.0.0")
+
+    # Hoisting must not leave a raw $defs block even for nullable defs.
+    assert not _has_defs_key(spec)
+    assert "Child" in spec["components"]["schemas"]
+
+    # The nullable construct is surfaced as a 3.0 compatibility warning
+    # (design #215: warn, do not silently down-convert).
+    assert any("3.0 compatibility" in m and "Child" in m for m in caplog.messages), caplog.messages
+
+
+def test_hoisted_nullable_defs_30_strict_raises() -> None:
+    from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+
+    scan_endpoint_metadata(_make_app(NULLABLE_DEFS_BODY))
+
+    with pytest.raises(OpenAPISpecConfigError, match="3.1-only constructs"):
+        generate_openapi_spec(openapi_version="3.0.0", strict=True)
+
+
+# ---------------------------------------------------------------------------
+# 3.1 — nullable hoisted defs preserved, refs resolve, no leak
+# ---------------------------------------------------------------------------
+
+
+def test_hoisted_nullable_defs_31_preserved_and_refs_resolve() -> None:
+    scan_endpoint_metadata(_make_app(NULLABLE_DEFS_BODY))
+    spec = generate_openapi_spec(openapi_version="3.1.0")
+
+    # No raw $defs anywhere.
+    assert not _has_defs_key(spec)
+
+    child = spec["components"]["schemas"]["Child"]
+    nickname = child["properties"]["nickname"]
+    # 3.1 preserves the 2020-12 nullable syntax (anyOf with a null type).
+    assert "anyOf" in nickname
+    assert {"type": "null"} in nickname["anyOf"]
+
+    # Ref rewriting survived the 3.1 conversion.
+    for ref in _collect_refs(spec):
+        assert ref.startswith("#/components/schemas/")
+        assert ref.rsplit("/", 1)[-1] in spec["components"]["schemas"]


### PR DESCRIPTION
## Summary
- Endpoint (raw JSON Schema) request bodies, responses, and parameters that embed nested-model definitions inline as `$defs` (with local `#/$defs/{Model}` refs) are now hoisted into the shared `components.schemas` section, matching the behaviour the Pydantic path already provides. Refs are rewritten to `#/components/schemas/{Model}` and name collisions are resolved the same way `model_to_schema` does.
- Flat schemas (no `$defs`, no local refs) are still embedded verbatim — no regression to #311.
- New `hoist_inline_defs()` + `_needs_hoisting()` helpers in `utils.py`, wired into the three embed sites in `spec.generate_openapi_spec`.

## Tests
- Added coverage for request-body / response / parameter hoisting, recursively nested defs, cross-operation collision resolution, flat-schema verbatim embedding, and a `$ref` buried inside `allOf[].items` (recursion path).
- `make check-all` green — 547 tests pass, coverage 96.24%, ruff + mypy + bandit clean.

Closes #315