### PR TITLE
refactor(spec): decouple spec generation from the Azure Functions SDK

### DIFF
--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -8,8 +8,9 @@ from typing import Any
 
 import yaml
 
-from azure_functions_openapi.decorator import get_openapi_registry
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+from azure_functions_openapi.registry import OpenAPIRegistry
+from azure_functions_openapi.registry import registry as _default_registry
 from azure_functions_openapi.routes import (
     DEFAULT_ROUTE_PREFIX,
     apply_route_prefix,
@@ -25,6 +26,18 @@ OPENAPI_VERSION_3_1 = "3.1.0"
 DEFAULT_OPENAPI_INFO_DESCRIPTION = (
     "Auto-generated OpenAPI documentation. Markdown supported in descriptions (CommonMark)."
 )
+
+
+def get_openapi_registry() -> dict[str, dict[str, Any]]:
+    """Return a snapshot of the process-wide OpenAPI metadata registry.
+
+    This is the default source consulted by :func:`generate_openapi_spec` when no
+    explicit ``registry`` is injected. It delegates to the registry module's
+    singleton so that the spec generator never has to import the decorator (and,
+    transitively, the Azure Functions SDK); callers wanting isolation should pass
+    an explicit :class:`~azure_functions_openapi.registry.OpenAPIRegistry` instead.
+    """
+    return _default_registry.snapshot()
 
 
 def _ensure_default_response(
@@ -224,6 +237,7 @@ def generate_openapi_spec(
     security_schemes: dict[str, dict[str, Any]] | None = None,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
     strict: bool = False,
+    registry: OpenAPIRegistry | None = None,
 ) -> dict[str, Any]:
     """
     Compile an OpenAPI specification from the registry.
@@ -256,11 +270,14 @@ def generate_openapi_spec(
     normalized_prefix = normalize_route_prefix(route_prefix)
 
     try:
-        registry = get_openapi_registry()
+        if registry is not None:
+            registry_entries = registry.snapshot()
+        else:
+            registry_entries = get_openapi_registry()
         paths: dict[str, dict[str, Any]] = {}
         components: dict[str, Any] = {"schemas": {}}
 
-        for func_name, meta in registry.items():
+        for func_name, meta in registry_entries.items():
             try:
                 logical_name = meta.get("function_name") or func_name
                 # route & method --------------------------------------------------
@@ -417,7 +434,7 @@ def generate_openapi_spec(
         all_security_schemes: dict[str, dict[str, Any]] = {}
         if security_schemes:
             all_security_schemes.update(security_schemes)
-        for _fn, meta in registry.items():
+        for _fn, meta in registry_entries.items():
             scheme = meta.get("security_scheme")
             if isinstance(scheme, dict):
                 for name, definition in scheme.items():
@@ -458,7 +475,7 @@ def generate_openapi_spec(
 
         logger.info(
             f"Generated OpenAPI {openapi_version} spec with {len(paths)} paths "
-            f"for {len(registry)} functions"
+            f"for {len(registry_entries)} functions"
         )
         return spec
 
@@ -599,6 +616,7 @@ def get_openapi_json(
     security_schemes: dict[str, dict[str, Any]] | None = None,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
     strict: bool = False,
+    registry: OpenAPIRegistry | None = None,
 ) -> str:
     """Return the spec as pretty-printed JSON (UTF-8).
 
@@ -626,6 +644,7 @@ def get_openapi_json(
             security_schemes=security_schemes,
             route_prefix=route_prefix,
             strict=strict,
+            registry=registry,
         )
         return json.dumps(spec, indent=2, ensure_ascii=False)
     except OpenAPISpecConfigError:
@@ -643,6 +662,7 @@ def get_openapi_yaml(
     security_schemes: dict[str, dict[str, Any]] | None = None,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
     strict: bool = False,
+    registry: OpenAPIRegistry | None = None,
 ) -> str:
     """Return the spec as YAML.
 
@@ -670,6 +690,7 @@ def get_openapi_yaml(
             security_schemes=security_schemes,
             route_prefix=route_prefix,
             strict=strict,
+            registry=registry,
         )
         return yaml.safe_dump(spec, sort_keys=False, allow_unicode=True)
     except OpenAPISpecConfigError:

--- a/tests/test_core_sdk_boundary.py
+++ b/tests/test_core_sdk_boundary.py
@@ -1,0 +1,136 @@
+"""Architecture guardrail: keep the OpenAPI core SDK-free.
+
+The OpenAPI *core* — spec compilation, the metadata registry, and the schema
+normalization helpers — must be able to run without importing the Azure
+Functions SDK. Discovery of live functions (which does need the SDK) lives in
+the Azure-facing surface (``decorator``, ``swagger_ui``, and the ``adapters``
+package introduced in #325).
+
+This test statically walks the transitive first-party import closure of each
+core module and asserts none of them:
+
+* import ``azure.functions`` (directly or transitively),
+* reference the ``FunctionBuilder`` SDK type, or
+* touch the SDK-private ``_function_builders`` attribute.
+
+See issue #324 for the module classification this enforces.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+PACKAGE = "azure_functions_openapi"
+SRC_ROOT = Path(__file__).resolve().parent.parent / "src" / PACKAGE
+
+# Modules that form the SDK-free core. Their entire first-party import closure
+# must stay free of the Azure Functions SDK.
+CORE_MODULES = ("spec", "registry", "utils")
+
+# Substrings that, if they appear as an *import target* or *referenced symbol*,
+# indicate SDK coupling. Kept deliberately narrow so docstrings mentioning these
+# names (e.g. exceptions.py explaining a traceback) do not trip the guard.
+FORBIDDEN_IMPORT_ROOTS = ("azure.functions", "azure_functions")
+FORBIDDEN_SYMBOLS = ("FunctionBuilder",)
+FORBIDDEN_ATTRS = ("_function_builders",)
+
+
+def _module_path(module: str) -> Path:
+    return SRC_ROOT / f"{module}.py"
+
+
+def _first_party_imports(tree: ast.AST) -> set[str]:
+    """Return the set of first-party sibling modules imported by *tree*."""
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if mod.startswith(f"{PACKAGE}."):
+                modules.add(mod.split(".", 1)[1].split(".", 1)[0])
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name.startswith(f"{PACKAGE}."):
+                    modules.add(alias.name.split(".", 1)[1].split(".", 1)[0])
+    # Only keep those that map to a real module file in the package.
+    return {m for m in modules if _module_path(m).exists()}
+
+
+def _import_closure(root: str) -> set[str]:
+    """Transitively collect all first-party modules reachable from *root*."""
+    seen: set[str] = set()
+    stack = [root]
+    while stack:
+        current = stack.pop()
+        if current in seen:
+            continue
+        seen.add(current)
+        path = _module_path(current)
+        if not path.exists():
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        stack.extend(_first_party_imports(tree) - seen)
+    return seen
+
+
+def _sdk_violations(module: str) -> list[str]:
+    """Return human-readable SDK-coupling violations for a single module."""
+    tree = ast.parse(_module_path(module).read_text(encoding="utf-8"))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        # Forbidden imports (direct SDK import).
+        if isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if any(mod == root or mod.startswith(root + ".") for root in FORBIDDEN_IMPORT_ROOTS):
+                violations.append(f"{module}: imports from '{mod}'")
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if any(
+                    alias.name == root or alias.name.startswith(root + ".")
+                    for root in FORBIDDEN_IMPORT_ROOTS
+                ):
+                    violations.append(f"{module}: imports '{alias.name}'")
+        # Forbidden referenced symbols (e.g. FunctionBuilder used as a name).
+        elif isinstance(node, ast.Name) and node.id in FORBIDDEN_SYMBOLS:
+            violations.append(f"{module}: references symbol '{node.id}'")
+        # Forbidden SDK-private attribute access (e.g. app._function_builders).
+        elif isinstance(node, ast.Attribute) and node.attr in FORBIDDEN_ATTRS:
+            violations.append(f"{module}: accesses SDK-private attribute '.{node.attr}'")
+    return violations
+
+
+@pytest.mark.parametrize("core_module", CORE_MODULES)
+def test_core_module_import_closure_is_sdk_free(core_module: str) -> None:
+    """Every module reachable from a core module must stay SDK-free."""
+    closure = _import_closure(core_module)
+    all_violations: list[str] = []
+    for module in sorted(closure):
+        all_violations.extend(_sdk_violations(module))
+    assert not all_violations, (
+        f"OpenAPI core module '{core_module}' has SDK coupling in its import "
+        f"closure {sorted(closure)}:\n  " + "\n  ".join(all_violations)
+    )
+
+
+def test_spec_does_not_import_decorator() -> None:
+    """spec.py must read the registry directly, never via decorator.py (#324)."""
+    closure = _import_closure("spec")
+    assert "decorator" not in closure, (
+        "spec.py must not depend on decorator.py; obtain the registry from "
+        f"registry.py instead. Closure was: {sorted(closure)}"
+    )
+
+
+def test_azure_facing_modules_are_allowed_to_import_sdk() -> None:
+    """Sanity check: the classification is meaningful, not vacuous.
+
+    At least one Azure-facing module must actually touch the SDK, otherwise the
+    core-vs-Azure split this test enforces would be trivially satisfied.
+    """
+    azure_facing = ("decorator", "swagger_ui")
+    assert any(_sdk_violations(module) for module in azure_facing), (
+        "Expected at least one Azure-facing module to import the Azure Functions "
+        "SDK; if this fails the SDK-free-core guard is vacuous."
+    )

--- a/tests/test_core_sdk_boundary.py
+++ b/tests/test_core_sdk_boundary.py
@@ -38,24 +38,54 @@ FORBIDDEN_SYMBOLS = ("FunctionBuilder",)
 FORBIDDEN_ATTRS = ("_function_builders",)
 
 
-def _module_path(module: str) -> Path:
-    return SRC_ROOT / f"{module}.py"
+def _resolve(dotted: str) -> Path | None:
+    """Resolve a first-party dotted module (relative to PACKAGE) to its file.
+
+    Handles both plain modules (``spec`` -> ``spec.py``) and packages
+    (``adapters`` -> ``adapters/__init__.py``, ``adapters.azure_functions`` ->
+    ``adapters/azure_functions.py``) so SDK coupling hidden inside a subpackage
+    is not silently dropped by truncating to the first path segment.
+    """
+    parts = dotted.split(".")
+    module_file = SRC_ROOT.joinpath(*parts).with_suffix(".py")
+    if module_file.exists():
+        return module_file
+    package_init = SRC_ROOT.joinpath(*parts, "__init__.py")
+    if package_init.exists():
+        return package_init
+    return None
 
 
 def _first_party_imports(tree: ast.AST) -> set[str]:
-    """Return the set of first-party sibling modules imported by *tree*."""
+    """Return first-party modules (dotted, relative to PACKAGE) imported by *tree*.
+
+    The full relative path after the package prefix is preserved so a submodule
+    import such as ``azure_functions_openapi.adapters.azure_functions`` resolves
+    to ``adapters/azure_functions.py`` instead of being truncated to
+    ``adapters`` (which would miss SDK coupling living in the submodule).
+    """
+    prefix = f"{PACKAGE}."
     modules: set[str] = set()
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
             mod = node.module or ""
-            if mod.startswith(f"{PACKAGE}."):
-                modules.add(mod.split(".", 1)[1].split(".", 1)[0])
+            if not mod.startswith(prefix):
+                continue
+            base = mod[len(prefix) :]
+            if _resolve(base) is not None:
+                modules.add(base)
+            # ``from pkg.sub import name`` may import a submodule, not a symbol.
+            for alias in node.names:
+                candidate = f"{base}.{alias.name}"
+                if _resolve(candidate) is not None:
+                    modules.add(candidate)
         elif isinstance(node, ast.Import):
             for alias in node.names:
-                if alias.name.startswith(f"{PACKAGE}."):
-                    modules.add(alias.name.split(".", 1)[1].split(".", 1)[0])
-    # Only keep those that map to a real module file in the package.
-    return {m for m in modules if _module_path(m).exists()}
+                if alias.name.startswith(prefix):
+                    base = alias.name[len(prefix) :]
+                    if _resolve(base) is not None:
+                        modules.add(base)
+    return modules
 
 
 def _import_closure(root: str) -> set[str]:
@@ -67,8 +97,8 @@ def _import_closure(root: str) -> set[str]:
         if current in seen:
             continue
         seen.add(current)
-        path = _module_path(current)
-        if not path.exists():
+        path = _resolve(current)
+        if path is None:
             continue
         tree = ast.parse(path.read_text(encoding="utf-8"))
         stack.extend(_first_party_imports(tree) - seen)
@@ -77,7 +107,10 @@ def _import_closure(root: str) -> set[str]:
 
 def _sdk_violations(module: str) -> list[str]:
     """Return human-readable SDK-coupling violations for a single module."""
-    tree = ast.parse(_module_path(module).read_text(encoding="utf-8"))
+    path = _resolve(module)
+    if path is None:
+        return []
+    tree = ast.parse(path.read_text(encoding="utf-8"))
     violations: list[str] = []
     for node in ast.walk(tree):
         # Forbidden imports (direct SDK import).

--- a/tests/test_openapi_enhanced.py
+++ b/tests/test_openapi_enhanced.py
@@ -190,6 +190,7 @@ class TestGetOpenAPIJSONEnhanced:
                 security_schemes=None,
                 route_prefix="/api",
                 strict=False,
+                registry=None,
             )
 
     def test_get_openapi_json_error(self) -> None:
@@ -218,6 +219,7 @@ class TestGetOpenAPIJSONEnhanced:
                 security_schemes=None,
                 route_prefix="/api",
                 strict=False,
+                registry=None,
             )
 
     def test_get_openapi_json_logging(self) -> None:
@@ -255,6 +257,7 @@ class TestGetOpenAPIYAMLEnhanced:
                 security_schemes=None,
                 route_prefix="/api",
                 strict=False,
+                registry=None,
             )
 
     def test_get_openapi_yaml_error(self) -> None:
@@ -283,6 +286,7 @@ class TestGetOpenAPIYAMLEnhanced:
                 security_schemes=None,
                 route_prefix="/api",
                 strict=False,
+                registry=None,
             )
 
     def test_get_openapi_yaml_logging(self) -> None:

--- a/tests/test_registry_identity.py
+++ b/tests/test_registry_identity.py
@@ -16,11 +16,13 @@ from azure_functions_openapi.decorator import (
     clear_openapi_registry,
     get_openapi_registry,
     openapi,
+    register_openapi_metadata,
 )
 from azure_functions_openapi.registry import (
     OpenAPIRegistry,
     canonical_function_id,
 )
+from azure_functions_openapi.spec import generate_openapi_spec
 
 
 @pytest.fixture(autouse=True)
@@ -194,3 +196,32 @@ def test_bridge_refuses_ambiguous_short_name_fallback(caplog: pytest.LogCaptureF
     assert any("ambiguous" in rec.message.lower() for rec in caplog.records)
     # A standalone endpoint was registered instead of a wrong merge.
     assert "post::/api/unrelated" in get_openapi_registry()
+
+
+# ── Injected registry: generate_openapi_spec(registry=...) (#324) ───────────
+def test_generate_openapi_spec_uses_injected_registry_not_global() -> None:
+    """An injected registry is used verbatim and the global one is not consulted."""
+    # Populate a detached registry with one entry...
+    register_openapi_metadata(path="/api/injected", method="get", summary="Injected")
+    injected = OpenAPIRegistry()
+    for key, entry in get_openapi_registry().items():
+        injected.set(key, entry)
+
+    # ...then empty the global registry so any leakage would be observable.
+    clear_openapi_registry()
+    assert get_openapi_registry() == {}
+
+    spec = generate_openapi_spec(registry=injected)
+
+    # The injected entry drives the spec even though the global registry is empty.
+    assert "/api/injected" in spec["paths"]
+    assert "get" in spec["paths"]["/api/injected"]
+
+
+def test_generate_openapi_spec_falls_back_to_global_when_registry_absent() -> None:
+    """Without an injected registry, the global registry remains the source."""
+    register_openapi_metadata(path="/api/global", method="get", summary="Global")
+
+    spec = generate_openapi_spec()
+
+    assert "/api/global" in spec["paths"]


### PR DESCRIPTION
## Summary
- Decouple spec generation/registry from direct `azure-functions` SDK access, isolating the coupling ahead of the adapter work.

## Notes
- First in a stacked series (#324 → #325 → #326 → #327 → #328). Base: `main`.

Closes #324