### PR TITLE
refactor(discovery): funnel Azure Functions SDK access through an adapter

### DIFF
--- a/src/azure_functions_openapi/adapters/__init__.py
+++ b/src/azure_functions_openapi/adapters/__init__.py
@@ -1,0 +1,30 @@
+"""Azure-facing adapters that isolate all Azure Functions SDK coupling.
+
+The :mod:`azure_functions_openapi.adapters.azure_functions` module is the single
+boundary that reads Azure Functions SDK internals; the rest of the package stays
+SDK-agnostic and consumes only the neutral surface re-exported here.
+"""
+
+from __future__ import annotations
+
+from azure_functions_openapi.adapters.azure_functions import (
+    build_function,
+    extract_http_binding,
+    get_bindings,
+    get_function_name,
+    get_user_handler,
+    is_function_builder,
+    is_http_function,
+    iter_functions,
+)
+
+__all__ = [
+    "build_function",
+    "extract_http_binding",
+    "get_bindings",
+    "get_function_name",
+    "get_user_handler",
+    "is_function_builder",
+    "is_http_function",
+    "iter_functions",
+]

--- a/src/azure_functions_openapi/adapters/azure_functions.py
+++ b/src/azure_functions_openapi/adapters/azure_functions.py
@@ -1,0 +1,129 @@
+"""Azure Functions SDK discovery adapter.
+
+This is the **single** place in the package that is allowed to touch Azure
+Functions SDK internals. Everything else (spec generation, the registry, the
+validation bridge) consumes the neutral, fully-public surface exposed here.
+
+Two SDK facts shape this module:
+
+1. **Enumeration has no public, side-effect-free alternative.**
+   ``FunctionRegister.get_functions()`` is *not* idempotent: it funnels through
+   ``validate_function_names()``, which accumulates into ``self.functions_bindings``
+   and only initializes that dict when it is falsy (``function_app.py``, verified
+   on azure-functions 1.21–1.25). Calling it more than once raises
+   ``ValueError: Function <name> does not have a unique function name``. Because
+   :func:`azure_functions_openapi.bridge.scan_endpoint_metadata` is meant to run
+   at import time inside ``function_app.py``, calling ``get_functions()`` there
+   would poison ``functions_bindings`` and then the Azure worker's own indexing
+   (which also calls ``get_functions()``) would raise — the user's Function App
+   would fail to boot. **We therefore never call ``get_functions()``.**
+
+   The only enumeration primitive left is reading ``app._function_builders`` and
+   calling the *public*, idempotent :meth:`FunctionBuilder.build`. ``build`` runs
+   the guarded, apply-once ``_validate_function`` and returns the *same*
+   ``Function`` instance on every call, without touching ``functions_bindings``.
+   ``_function_builders`` is thus the one — and only — SDK-private token we keep,
+   and it lives exclusively in this module. ``Blueprint`` is a ``DecoratorApi``
+   and exposes ``_function_builders`` identically, so raw Blueprints, registered
+   Blueprints, and ``FunctionApp`` instances all enumerate through this one path.
+
+2. **Per-function reads are entirely public.** Once a builder is built into a
+   ``Function``, the name, user handler, bindings, HTTP-ness, and trigger are all
+   available through documented public accessors — no ``_function`` / ``_func`` /
+   ``_bindings`` access is required anywhere.
+
+See issue #325 for the full rationale and empirical reproduction.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from azure.functions.decorators.function_app import Function, FunctionBuilder
+
+from azure_functions_openapi.exceptions import SDKIncompatibleError
+
+_HTTP_TRIGGER_TYPE = "httptrigger"
+
+
+def is_function_builder(obj: Any) -> bool:
+    """Return whether *obj* is an Azure Functions ``FunctionBuilder``.
+
+    Centralizes the SDK-type check so callers never import ``FunctionBuilder``
+    themselves.
+    """
+    return isinstance(obj, FunctionBuilder)
+
+
+def build_function(builder: Any, auth_level: Any = None) -> Function:
+    """Build a single ``FunctionBuilder`` into a ``Function`` (idempotent).
+
+    Wraps :meth:`FunctionBuilder.build`, the public, side-effect-free primitive
+    that returns the same cached ``Function`` on every call. Raises
+    :class:`SDKIncompatibleError` if the installed SDK does not expose ``build``
+    or it fails structurally, so incompatibility surfaces as an actionable error
+    rather than an opaque ``AttributeError``.
+    """
+    try:
+        return cast(Function, builder.build(auth_level))
+    except AttributeError as exc:  # pragma: no cover - depends on SDK internals
+        raise SDKIncompatibleError(
+            "Unable to build a FunctionBuilder via the public build() API; the "
+            "installed azure-functions SDK appears incompatible with @openapi. "
+            "Please report this issue at "
+            "https://github.com/yeongseon/azure-functions-openapi-python/issues "
+            f"with your azure-functions version. (underlying error: {exc})"
+        ) from exc
+
+
+def iter_functions(app: Any) -> list[Function]:
+    """Enumerate the built ``Function`` objects registered on *app*.
+
+    Enumerates via the SDK-private ``_function_builders`` list (the only
+    private token we are forced to read — see the module docstring) and the
+    *public*, idempotent :meth:`FunctionBuilder.build`. It deliberately does
+    **not** call ``FunctionApp.get_functions()``, which is non-idempotent and
+    would poison the app's ``functions_bindings`` indexing state and break the
+    user's Function App at boot.
+
+    Returns an empty list when *app* exposes no builders (e.g. an app with no
+    registered functions), matching the previous "skip quietly" behaviour.
+    """
+    builders = getattr(app, "_function_builders", None)
+    if not builders:
+        return []
+    auth_level = getattr(app, "auth_level", None)
+    return [build_function(builder, auth_level) for builder in builders]
+
+
+def get_function_name(function: Any) -> str:
+    """Return the function's registered name via the public accessor."""
+    return str(function.get_function_name())
+
+
+def get_user_handler(function: Any) -> Any:
+    """Return the user's handler callable via the public accessor."""
+    return function.get_user_function()
+
+
+def get_bindings(function: Any) -> list[Any]:
+    """Return the function's bindings via the public accessor."""
+    return list(function.get_bindings())
+
+
+def is_http_function(function: Any) -> bool:
+    """Return whether the function is HTTP-triggered via the public accessor."""
+    return bool(function.is_http_function())
+
+
+def extract_http_binding(function: Any) -> Any | None:
+    """Return the function's HTTP-trigger binding, or ``None`` if it has none.
+
+    Scans the public :meth:`Function.get_bindings` result for the HTTP-trigger
+    binding, mirroring the previous private ``_bindings`` scan but without any
+    SDK-private access.
+    """
+    for binding in get_bindings(function):
+        if str(getattr(binding, "type", "")).lower() == _HTTP_TRIGGER_TYPE:
+            return binding
+    return None

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -8,6 +8,7 @@ import warnings
 
 from pydantic import BaseModel
 
+from azure_functions_openapi import adapters
 from azure_functions_openapi._endpoint_contract import (
     ENDPOINT_NAMESPACE,
     SUPPORTED_ENDPOINT_VERSIONS,
@@ -62,11 +63,8 @@ def _normalize_path(
     return f"{prefix}{raw}"
 
 
-def _extract_http_binding(function_obj: Any) -> Any | None:
-    for binding in getattr(function_obj, "_bindings", []):
-        if str(getattr(binding, "type", "")).lower() == "httptrigger":
-            return binding
-    return None
+def _extract_http_binding(function: Any) -> Any | None:
+    return adapters.extract_http_binding(function)
 
 
 def _extract_methods(binding: Any) -> list[str]:
@@ -428,17 +426,14 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
     (default ``"/api"``). Pass ``""`` for hosts that disable the prefix or
     a custom value such as ``"/v1"`` to match a non-default deployment.
     """
-    builders = getattr(app, "_function_builders", None)
-    if not builders:
+    functions = adapters.iter_functions(app)
+    if not functions:
         logger.debug("No function builders found on app; skipping validation scan")
         return
 
-    for builder in builders:
-        function_obj = getattr(builder, "_function", None)
-        if function_obj is None:
-            continue
-        function_name = str(getattr(function_obj, "_name", ""))
-        handler = getattr(function_obj, "_func", None)
+    for function in functions:
+        function_name = adapters.get_function_name(function)
+        handler = adapters.get_user_handler(function)
         if handler is None:
             continue
         endpoint_hints = _read_endpoint_hints(handler)
@@ -457,7 +452,7 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
 
         canonical_id = canonical_function_id(handler)
 
-        binding = _extract_http_binding(function_obj)
+        binding = _extract_http_binding(function)
         if binding is None:
             logger.debug(
                 "Function '%s' has validation metadata but is not HTTP triggered", function_name

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -5,10 +5,10 @@ import logging
 from typing import Any, Callable, TypeVar, cast
 import warnings
 
-from azure.functions.decorators.function_app import FunctionBuilder
 from pydantic import BaseModel
 
-from azure_functions_openapi.exceptions import OpenAPISpecConfigError, SDKIncompatibleError
+from azure_functions_openapi import adapters
+from azure_functions_openapi.exceptions import OpenAPISpecConfigError
 from azure_functions_openapi.registry import OpenAPIRegistry, canonical_function_id, registry
 from azure_functions_openapi.utils import sanitize_operation_id, validate_route_path
 
@@ -29,20 +29,13 @@ logger = logging.getLogger(__name__)
 
 def _resolve_metadata_target(func: Any) -> tuple[Any, Callable[..., Any]]:
     """Return the original decorated object and the underlying callable used for metadata."""
-    if isinstance(func, FunctionBuilder):
-        # ``FunctionBuilder._function._func`` is a private attribute of the
-        # ``azure-functions`` SDK. Guard against future renames/restructures so
-        # callers get an actionable error instead of an opaque AttributeError.
-        try:
-            return func, func._function._func
-        except AttributeError as exc:  # pragma: no cover - depends on SDK internals
-            raise SDKIncompatibleError(
-                "Unable to access FunctionBuilder._function._func; the installed "
-                "azure-functions SDK appears incompatible with @openapi. "
-                "Please report this issue at "
-                "https://github.com/yeongseon/azure-functions-openapi-python/issues "
-                f"with your azure-functions version. (underlying error: {exc})"
-            ) from exc
+    if adapters.is_function_builder(func):
+        # The user handler and bindings live on the SDK's FunctionBuilder, which
+        # only exposes them via private attributes. Route the access through the
+        # adapter so all SDK coupling (and the SDKIncompatibleError contract for
+        # renamed/restructured internals) stays in one place.
+        function = adapters.build_function(func)
+        return func, adapters.get_user_handler(function)
 
     if not callable(func):
         raise TypeError(f"Unsupported decorated object: {type(func).__name__}")
@@ -59,14 +52,11 @@ def _extract_binding_hints(func: Any) -> tuple[str | None, str | None, bool]:
       HTTP method; in that case ``method`` is ``None`` and the caller must
       require an explicit ``method=`` argument from the user.
     """
-    if not isinstance(func, FunctionBuilder):
+    if not adapters.is_function_builder(func):
         return None, None, False
 
-    try:
-        function_obj = func._function
-        bindings = getattr(function_obj, "_bindings", [])
-    except AttributeError:
-        return None, None, False
+    function = adapters.build_function(func)
+    bindings = adapters.get_bindings(function)
 
     for binding in bindings:
         if str(getattr(binding, "type", "")).lower() != "httptrigger":

--- a/src/azure_functions_openapi/exceptions.py
+++ b/src/azure_functions_openapi/exceptions.py
@@ -15,11 +15,11 @@ class SDKIncompatibleError(OpenAPISpecConfigError):
     """Raised when the installed ``azure-functions`` SDK is incompatible with
     ``@openapi``.
 
-    The bridge and decorator read private ``azure-functions`` SDK internals
-    (e.g. ``FunctionBuilder._function._func`` and the ``__wrapped__`` chain).
-    When a future SDK release renames or restructures those attributes, this
-    dedicated exception makes SDK-incompatibility failures distinguishable from
-    ordinary caller-fixable configuration errors.
+    The Azure Functions SDK discovery adapter reads private SDK internals
+    behind the public ``FunctionBuilder.build`` primitive (and callers walk the
+    ``__wrapped__`` chain). When a future SDK release renames or restructures
+    those internals, this dedicated exception makes SDK-incompatibility failures
+    distinguishable from ordinary caller-fixable configuration errors.
 
     Subclasses :class:`OpenAPISpecConfigError` (and therefore :class:`ValueError`)
     so existing ``except OpenAPISpecConfigError`` / ``except ValueError`` call-sites

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -70,10 +70,31 @@ class MockFunction:
     _func: Any
     _bindings: list[Any]
 
+    # Public accessors mirroring azure.functions Function; the adapter reads the
+    # function exclusively through these (never the underscored fields).
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return any(
+            str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings
+        )
+
 
 @dataclass
 class MockBuilder:
     _function: MockFunction
+
+    # Public, idempotent build() mirroring FunctionBuilder.build; the adapter
+    # enumerates via _function_builders + this method (never get_functions()).
+    def build(self, auth_level: Any = None) -> MockFunction:
+        return self._function
 
 
 @dataclass
@@ -664,10 +685,16 @@ def test_scan_includes_headers_model_as_header_parameters() -> None:
 
 
 def test_scan_skips_builders_without_function_or_handler() -> None:
-    builder_without_function: Any = type("Builder", (), {"_function": None})()
+    # Under the public-accessor contract the only "skip" signal is a built
+    # function whose user handler is None (get_user_function() -> None).
     function_without_handler = MockFunction(_name="no_handler", _func=None, _bindings=[])
     builder_without_handler = MockBuilder(_function=function_without_handler)
-    app = MockApp(_function_builders=cast(Any, [builder_without_function, builder_without_handler]))
+    another_without_handler = MockBuilder(
+        _function=MockFunction(_name="also_no_handler", _func=None, _bindings=[])
+    )
+    app = MockApp(
+        _function_builders=cast(Any, [builder_without_handler, another_without_handler])
+    )
 
     scan_endpoint_metadata(app)
     assert get_openapi_registry() == {}

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -63,10 +63,27 @@ class MockFunction:
         self._func = func
         self._bindings = bindings
 
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return any(
+            str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings
+        )
+
 
 class MockBuilder:
     def __init__(self, function: MockFunction) -> None:
         self._function = function
+
+    def build(self, auth_level: Any = None) -> MockFunction:
+        return self._function
 
 
 class MockApp:

--- a/tests/test_bridge_endpoint_golden.py
+++ b/tests/test_bridge_endpoint_golden.py
@@ -60,10 +60,25 @@ class MockFunction:
         self._func = func
         self._bindings = bindings
 
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return any(str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings)
+
 
 class MockBuilder:
     def __init__(self, function: MockFunction) -> None:
         self._function = function
+
+    def build(self, auth_level: Any = None) -> MockFunction:
+        return self._function
 
 
 class MockApp:

--- a/tests/test_core_sdk_boundary.py
+++ b/tests/test_core_sdk_boundary.py
@@ -167,3 +167,69 @@ def test_azure_facing_modules_are_allowed_to_import_sdk() -> None:
         "Expected at least one Azure-facing module to import the Azure Functions "
         "SDK; if this fails the SDK-free-core guard is vacuous."
     )
+
+
+# ---------------------------------------------------------------------------
+# Issue #325: SDK discovery is funneled through the adapters package.
+# ---------------------------------------------------------------------------
+
+# SDK-private tokens that must only ever be touched inside adapters/. The
+# discovery adapter is the single, audited seam onto the Azure Functions SDK's
+# undocumented internals; decorator.py and bridge.py must go through it.
+SDK_PRIVATE_ATTRS = ("_function", "_func", "_bindings", "_function_builders")
+SDK_DISCOVERY_CALLS = ("get_functions",)
+
+# Azure-facing modules that were refactored in #325 to delegate SDK access to
+# the adapters package instead of reaching into private SDK internals directly.
+ADAPTER_CONSUMERS = ("decorator", "bridge")
+
+
+def _sdk_internal_violations(module: str) -> list[str]:
+    """Report direct SDK-private attribute access / discovery calls in *module*."""
+    module_path = _resolve(module)
+    assert module_path is not None, f"cannot locate source for module '{module}'"
+    tree = ast.parse(module_path.read_text(encoding="utf-8"))
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and node.attr in SDK_PRIVATE_ATTRS:
+            violations.append(f"{module}: accesses SDK-private attribute '.{node.attr}'")
+        elif isinstance(node, ast.Attribute) and node.attr in SDK_DISCOVERY_CALLS:
+            violations.append(f"{module}: calls SDK discovery method '.{node.attr}()'")
+        elif isinstance(node, ast.Name) and node.id in SDK_PRIVATE_ATTRS:
+            violations.append(f"{module}: references SDK-private name '{node.id}'")
+    return violations
+
+
+@pytest.mark.parametrize("module", ADAPTER_CONSUMERS)
+def test_adapter_consumers_do_not_touch_sdk_internals(module: str) -> None:
+    """decorator.py and bridge.py must delegate SDK access to adapters (#325)."""
+    violations = _sdk_internal_violations(module)
+    assert not violations, (
+        f"'{module}.py' must not reach into Azure Functions SDK internals "
+        "directly; route the access through the 'adapters' package instead:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_adapters_package_is_the_only_function_builders_seam() -> None:
+    """Only the adapters package may touch the SDK-private discovery token."""
+    offenders: list[str] = []
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        if path.parent.name == "adapters":
+            continue
+        source = path.read_text(encoding="utf-8")
+        if "_function_builders" in source:
+            offenders.append(str(path.relative_to(SRC_ROOT)))
+    assert not offenders, (
+        "'_function_builders' is an undocumented SDK internal and may only be "
+        f"accessed from the adapters package; found in: {offenders}"
+    )
+
+
+def test_adapters_package_actually_encapsulates_the_sdk() -> None:
+    """Sanity check: the adapter must genuinely own the SDK discovery token."""
+    adapter_src = (SRC_ROOT / "adapters" / "azure_functions.py").read_text(encoding="utf-8")
+    assert "_function_builders" in adapter_src, (
+        "Expected the discovery adapter to encapsulate '_function_builders'; "
+        "if this fails the #325 adapter guard is vacuous."
+    )

--- a/tests/test_registry_identity.py
+++ b/tests/test_registry_identity.py
@@ -46,10 +46,25 @@ class MockFunction:
     _func: Any
     _bindings: list[Any]
 
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return any(str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings)
+
 
 @dataclass
 class MockBuilder:
     _function: MockFunction
+
+    def build(self, auth_level: Any = None) -> MockFunction:
+        return self._function
 
 
 @dataclass

--- a/tests/test_spec_hoist_collision.py
+++ b/tests/test_spec_hoist_collision.py
@@ -63,10 +63,25 @@ class MockFunction:
         self._func = func
         self._bindings = bindings
 
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return any(str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings)
+
 
 class MockBuilder:
     def __init__(self, function: MockFunction) -> None:
         self._function = function
+
+    def build(self, auth_level: Any = None) -> MockFunction:
+        return self._function
 
 
 class MockApp:

--- a/tests/test_spec_hoist_versions.py
+++ b/tests/test_spec_hoist_versions.py
@@ -51,10 +51,25 @@ class MockFunction:
         self._func = func
         self._bindings = bindings
 
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return any(str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings)
+
 
 class MockBuilder:
     def __init__(self, function: MockFunction) -> None:
         self._function = function
+
+    def build(self, auth_level: Any = None) -> MockFunction:
+        return self._function
 
 
 class MockApp:


### PR DESCRIPTION
## Summary
- Introduce `azure_functions_openapi.adapters` as the single isolated seam for SDK discovery.
- Public-API-first enumeration via `FunctionBuilder.build()` + public `Function` accessors; the sole private token `app._function_builders` lives only in the adapter, guarded by a mandatory test.
- Never calls the non-idempotent `FunctionApp.get_functions()`.
- Refactor bridge/decorator/exceptions onto the adapter; migrate 6 mock tests; add 9 architecture tests.

## Notes
- Stacked on #324. Base: `refactor/324-decouple-spec-registry-sdk`.

Closes #325