### PR TITLE
feat(cli): discover endpoint-metadata routes via module:variable

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,6 +11,8 @@
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
+> **翻訳保留:** CLI の `--app module:variable` エンドポイントメタデータ検出セクション（#331 で英語版 [README.md](README.md) に追加）はまだ翻訳されていません。追跡: [#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334)。
+
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
 **Azure Functions Python v2 プログラミング モデル**向けの OpenAPI（Swagger）ドキュメント生成と Swagger UI を提供します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,6 +11,8 @@
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
+> **Translation pending:** The CLI `--app module:variable` endpoint-metadata discovery section (added to the English [README.md](README.md) in #331) is not yet translated here. Tracking: [#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334).
+
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
 **Azure Functions Python v2 프로그래밍 모델**을 위한 OpenAPI(Swagger) 문서화와 Swagger UI를 제공합니다.

--- a/README.md
+++ b/README.md
@@ -151,10 +151,14 @@ azure-functions-openapi generate --app function_app --title "My API" --pretty --
 azure-functions-openapi generate --app function_app --format yaml --output openapi.yaml
 ```
 
-Pass `module:variable` when the `FunctionApp` instance has a non-default name:
+Pass `module:variable` to resolve the `FunctionApp` instance and also discover
+endpoint-metadata routes — those registered by producers like `@validate_http`
+or `azure-functions-langgraph` — merging them with your `@openapi` routes into a
+single spec. With `module` alone the CLI imports the module (firing `@openapi`
+decorators) but does not scan for endpoint metadata:
 
 ```bash
-azure-functions-openapi generate --app function_app:my_app --title "My API"
+azure-functions-openapi generate --app function_app:app --title "My API"
 ```
 
 See the [CLI Guide](docs/cli.md) for all options and CI integration examples.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,6 +11,8 @@
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
+> **翻译待处理：** CLI 的 `--app module:variable` 端点元数据发现部分（已在 #331 中添加到英文 [README.md](README.md)）尚未翻译。跟踪：[#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334)。
+
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
 
 为 **Azure Functions Python v2 编程模型**提供 OpenAPI（Swagger）文档生成和 Swagger UI。

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -78,11 +78,49 @@ Pretty-print JSON output:
 azure-functions-openapi generate --app function_app --pretty --output openapi.json
 ```
 
+### Endpoint-metadata discovery (`module:variable`)
+
+`@openapi`-decorated routes register themselves the moment the module is
+imported, so `--app module` is enough to see them. Producers that register
+**only** through the shared endpoint-metadata namespace — `@validate_http`
+(azure-functions-validation), `azure-functions-langgraph`, and other
+third-party producers — are attached to the live `FunctionApp` object and are
+discovered by scanning it.
+
+To include those endpoints, pass an explicit `module:variable` so the CLI can
+resolve the `FunctionApp` instance and run discovery on it:
+
+```bash
+# Imports function_app, resolves `app`, then discovers BOTH decorator-
+# registered and endpoint-metadata routes into a single spec.
+azure-functions-openapi generate --app function_app:app --output openapi.json
+```
+
+Discovery semantics:
+
+- **`--app function_app`** (module only): the module is imported so `@openapi`
+  decorators fire, but endpoint-metadata discovery is **not** run — the CLI
+  never guesses the `FunctionApp` variable name. A note is printed reminding
+  you to pass `module:variable` to also discover endpoint-metadata routes.
+- **`--app function_app:app`** (module + variable): the named `FunctionApp`
+  attribute is resolved and scanned, merging endpoint-metadata routes into the
+  same registry as the decorator routes.
+- Discovery is **one-shot** per run and uses the idempotent
+  `FunctionBuilder.build()` path. The CLI never calls
+  `FunctionApp.get_functions()`, which is non-idempotent on all supported SDK
+  versions (1.21–1.25): it accumulates into `functions_bindings` and raises on
+  a second call.
+- **Blueprints** (raw or registered via `register_functions` /
+  `register_blueprint`) are enumerated through the same path — no special
+  casing is required.
+- Re-running discovery on the same app is safe: the registry merges by
+  function id, so no duplicate paths or operations are produced.
+
 ### Options reference
 
 | Option | Alias | Values | Default | Description |
 | --- | --- | --- | --- | --- |
-| `--app` | - | `module` or `module:var` | - | Import module before generating so `@openapi` decorators register routes |
+| `--app` | - | `module` or `module:var` | - | Import module so `@openapi` decorators register routes; with `module:var`, also resolve the `FunctionApp` and discover endpoint-metadata routes (see [Endpoint-metadata discovery](#endpoint-metadata-discovery-modulevariable)) |
 | `--title` | - | any string | `API` | OpenAPI `info.title` |
 | `--version` | - | any string | `1.0.0` | OpenAPI `info.version` |
 | `--description` | - | any string | library default | OpenAPI `info.description` (Markdown / CommonMark supported) |

--- a/src/azure_functions_openapi/cli.py
+++ b/src/azure_functions_openapi/cli.py
@@ -6,6 +6,7 @@ import importlib
 from pathlib import Path
 import sys
 
+from azure_functions_openapi.bridge import scan_endpoint_metadata
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
 from azure_functions_openapi.spec import (
     DEFAULT_OPENAPI_INFO_DESCRIPTION,
@@ -15,32 +16,57 @@ from azure_functions_openapi.spec import (
 )
 
 
-def _import_app_module(app: str) -> None:
+def _import_app_module(app: str) -> tuple[object | None, bool]:
     """Import a user module to trigger @openapi decorator registration.
 
     Accepts either ``module_name`` or ``module_name:variable`` format.
-    When the ``variable`` part is provided it is validated to exist on the
-    imported module so that typos are caught early.
+    When the ``variable`` part is provided it is resolved on the imported
+    module and returned so the caller can run endpoint-metadata discovery on
+    the live ``FunctionApp`` object. No variable-name guessing is performed:
+    metadata discovery only runs when an explicit ``:variable`` is supplied.
 
     Parameters:
         app: Module import path, optionally with a ``:variable`` suffix.
 
+    Returns:
+        A ``(resolved_app, variable_given)`` tuple. ``resolved_app`` is the
+        named attribute when a ``:variable`` suffix is present, otherwise
+        ``None``. ``variable_given`` records whether a ``:variable`` suffix
+        was supplied so the caller can emit an accurate discovery note.
+
     Raises:
+        ValueError: If the ``--app`` value is malformed (empty module, a
+            trailing ``:`` with no variable name, or a ``:variable`` that
+            resolves to ``None``).
         ImportError: If the module cannot be found or fails to import.
         AttributeError: If the named variable does not exist on the module.
     """
-    module_name, _, variable = app.partition(":")
+    module_name, sep, variable = app.partition(":")
     module_name = module_name.strip()
     if not module_name:
         raise ValueError(f"Invalid --app value: {app!r}. Expected 'module' or 'module:variable'.")
     mod = importlib.import_module(module_name)
-    if variable:
-        variable = variable.strip()
-        if not hasattr(mod, variable):
-            raise AttributeError(
-                f"Module '{module_name}' has no attribute '{variable}'. "
-                f"Check the variable name after the colon in --app {app!r}."
-            )
+    if not sep:
+        # No ``:variable`` suffix supplied — module-only import.
+        return None, False
+    variable = variable.strip()
+    if not variable:
+        raise ValueError(
+            f"Invalid --app value: {app!r}. Expected a non-empty variable name after "
+            "the ':' (e.g. 'function_app:app')."
+        )
+    if not hasattr(mod, variable):
+        raise AttributeError(
+            f"Module '{module_name}' has no attribute '{variable}'. "
+            f"Check the variable name after the colon in --app {app!r}."
+        )
+    resolved = getattr(mod, variable)
+    if resolved is None:
+        raise ValueError(
+            f"Variable '{variable}' resolved to None in --app {app!r}; expected a "
+            "FunctionApp object for endpoint-metadata discovery."
+        )
+    return resolved, True
 
 
 def main() -> int:
@@ -150,15 +176,33 @@ def handle_generate(args: argparse.Namespace) -> int:
     """Handle generate command."""
     try:
         # Import user module first so @openapi decorators populate the registry.
+        # When an explicit ``module:variable`` is given, resolve the FunctionApp
+        # object and run endpoint-metadata discovery so producers that register
+        # only via the ``endpoint`` namespace (e.g. @validate_http) are included.
         if getattr(args, "app", None):
             try:
-                _import_app_module(args.app)
+                resolved_app, variable_given = _import_app_module(args.app)
             except (ImportError, ValueError, AttributeError) as e:
                 print(
                     f"Error: Could not import module from --app {args.app!r}: {e}",
                     file=sys.stderr,
                 )
                 return 1
+
+            if variable_given and resolved_app is not None:
+                # One-shot discovery through the #325 adapter. `build()` is
+                # idempotent; we never call the non-idempotent `get_functions()`.
+                scan_endpoint_metadata(
+                    resolved_app, route_prefix=getattr(args, "route_prefix", "/api")
+                )
+            else:
+                print(
+                    "Note: metadata discovery skipped — no ':variable' given in "
+                    f"--app {args.app!r}. Only @openapi-decorated routes were "
+                    "registered on import. Pass 'module:variable' (e.g. "
+                    "function_app:app) to also discover endpoint-metadata routes.",
+                    file=sys.stderr,
+                )
 
         openapi_version = (
             OPENAPI_VERSION_3_1 if args.openapi_version == "3.1" else OPENAPI_VERSION_3_0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -446,6 +446,33 @@ class TestImportAppModule:
             with pytest.raises(AttributeError, match="no attribute 'nonexistent'"):
                 _import_app_module("fake_mod:nonexistent")
 
+    def test_trailing_colon_raises_value_error(self) -> None:
+        """'module:' (trailing colon, no variable) raises ValueError."""
+        import types
+
+        fake_mod = types.ModuleType("fake_mod")
+        with mock.patch("importlib.import_module", return_value=fake_mod):
+            with pytest.raises(ValueError, match="non-empty variable name"):
+                _import_app_module("fake_mod:")
+
+    def test_trailing_colon_whitespace_raises_value_error(self) -> None:
+        """'module:   ' (whitespace-only variable) raises ValueError."""
+        import types
+
+        fake_mod = types.ModuleType("fake_mod")
+        with mock.patch("importlib.import_module", return_value=fake_mod):
+            with pytest.raises(ValueError, match="non-empty variable name"):
+                _import_app_module("fake_mod:   ")
+
+    def test_variable_resolving_to_none_raises_value_error(self) -> None:
+        """'module:variable' where the attribute is None raises ValueError."""
+        import types
+
+        fake_mod = types.ModuleType("fake_mod")
+        fake_mod.app = None  # type: ignore[attr-defined]
+        with mock.patch("importlib.import_module", return_value=fake_mod):
+            with pytest.raises(ValueError, match="resolved to None"):
+                _import_app_module("fake_mod:app")
 
 class TestHandleGenerateWithApp:
     """Tests for --app option in handle_generate."""
@@ -462,6 +489,7 @@ class TestHandleGenerateWithApp:
         args.app = "my_function_app"
 
         with mock.patch("azure_functions_openapi.cli._import_app_module") as mock_import:
+            mock_import.return_value = (None, False)
             with mock.patch("builtins.print"):
                 result = handle_generate(args)
 
@@ -518,6 +546,7 @@ class TestHandleGenerateWithApp:
         args.app = None
 
         with mock.patch("azure_functions_openapi.cli._import_app_module") as mock_import:
+            mock_import.return_value = (None, False)
             with mock.patch("builtins.print"):
                 result = handle_generate(args)
 
@@ -602,6 +631,7 @@ class TestCLIAppFlag:
             ["azure-functions-openapi", "generate", "--app", "function_app"],
         ):
             with mock.patch("azure_functions_openapi.cli._import_app_module") as mock_import:
+                mock_import.return_value = (None, False)
                 with mock.patch("builtins.print"):
                     result = main()
 
@@ -616,6 +646,7 @@ class TestCLIAppFlag:
             ["azure-functions-openapi", "generate", "--app", "function_app:app"],
         ):
             with mock.patch("azure_functions_openapi.cli._import_app_module") as mock_import:
+                mock_import.return_value = (None, False)
                 with mock.patch("builtins.print"):
                     result = main()
 

--- a/tests/test_cli_discovery.py
+++ b/tests/test_cli_discovery.py
@@ -1,0 +1,233 @@
+"""CLI unified one-shot discovery wiring (issue #326).
+
+The ``generate`` command imports ``--app`` (triggering ``@openapi`` decorators)
+and, when an explicit ``module:variable`` is given, resolves the ``FunctionApp``
+object and runs :func:`scan_endpoint_metadata` on it. This closes the DX gap
+where endpoint-metadata producers (``@validate_http``, langgraph, third-party)
+were silently missing from the generated spec.
+
+These tests assert the CLI-generated spec (``module:app`` form) includes:
+
+* decorator-registered endpoints (``@openapi`` / :func:`register_openapi_metadata`),
+* endpoint-metadata endpoints (discovered via the scan), and
+* both together (mixed),
+
+plus that the **module-only** form imports without scanning and prints a note,
+and that repeated registry merge of the same handler metadata is idempotent
+(no duplicate paths/operations) — verified at the registry layer, independent
+of SDK enumeration.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest import mock
+
+import pytest
+
+from azure_functions_openapi.bridge import _HANDLER_METADATA_ATTR, scan_endpoint_metadata
+from azure_functions_openapi.cli import handle_generate
+from azure_functions_openapi.decorator import (
+    clear_openapi_registry,
+    register_openapi_metadata,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+# A representative flat endpoint payload (all JSON Schema, no model classes).
+FLAT_ENDPOINT: dict[str, Any] = {
+    "version": 1,
+    "request_body": {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    },
+    "request_body_required": True,
+    "responses": {
+        "200": {"schema": {"type": "object", "properties": {"id": {"type": "integer"}}}},
+    },
+}
+
+
+class MockBinding:
+    def __init__(self, route: str, methods: list[str] | None, type: str = "httpTrigger") -> None:
+        self.route = route
+        self.methods = methods
+        self.type = type
+
+
+class MockFunction:
+    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
+        self._name = name
+        self._func = func
+        self._bindings = bindings
+
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return any(str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings)
+
+
+class MockBuilder:
+    def __init__(self, function: MockFunction) -> None:
+        self._function = function
+
+    def build(self, auth_level: Any = None) -> MockFunction:
+        return self._function
+
+
+class MockApp:
+    def __init__(self, builders: list[MockBuilder]) -> None:
+        self._function_builders = builders
+
+
+def _endpoint_app(
+    *,
+    name: str = "create_user",
+    route: str = "users",
+    methods: list[str] | None = None,
+) -> MockApp:
+    """Build a FunctionApp-like object whose handler carries endpoint metadata."""
+
+    def handler(req: Any) -> Any:
+        return req
+
+    setattr(handler, _HANDLER_METADATA_ATTR, {"endpoint": FLAT_ENDPOINT})
+    binding = MockBinding(route=route, methods=methods or ["POST"])
+    fn = MockFunction(name=name, func=handler, bindings=[binding])
+    return MockApp([MockBuilder(fn)])
+
+
+def _empty_app() -> MockApp:
+    """A FunctionApp-like object with no discoverable metadata handlers."""
+    return MockApp([])
+
+
+def _generate_args(app: str, output: Path) -> Any:
+    args = mock.Mock()
+    args.title = "Test API"
+    args.version = "1.0.0"
+    args.description = None
+    args.format = "json"
+    args.output = str(output)
+    args.pretty = False
+    args.openapi_version = "3.1"
+    args.route_prefix = "/api"
+    args.strict = False
+    args.fail_on_empty_paths = False
+    args.app = app
+    return args
+
+
+def _run_generate(
+    app: str, resolved: MockApp | None, variable_given: bool, output: Path
+) -> dict[str, Any]:
+    args = _generate_args(app, output)
+    with mock.patch(
+        "azure_functions_openapi.cli._import_app_module",
+        return_value=(resolved, variable_given),
+    ):
+        result = handle_generate(args)
+    assert result == 0
+    data: dict[str, Any] = json.loads(output.read_text(encoding="utf-8"))
+    return data
+
+
+# ---------------------------------------------------------------------------
+# module:variable form — endpoint metadata discovery is wired in
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_only_app_is_discovered_via_module_variable(tmp_path: Path) -> None:
+    """An endpoint-metadata-only app yields its route through CLI discovery."""
+    app = _endpoint_app(route="users", methods=["POST"])
+    spec = _run_generate("function_app:app", app, True, tmp_path / "openapi.json")
+    assert "/api/users" in spec["paths"]
+    assert "post" in spec["paths"]["/api/users"]
+
+
+def test_decorator_only_app_is_included_via_module_variable(tmp_path: Path) -> None:
+    """Decorator-registered routes (populated on import) appear in the spec."""
+    # Simulate an @openapi decorator firing during module import.
+    register_openapi_metadata(path="/api/items", method="get", summary="List items")
+    spec = _run_generate("function_app:app", _empty_app(), True, tmp_path / "openapi.json")
+    assert "/api/items" in spec["paths"]
+    assert "get" in spec["paths"]["/api/items"]
+
+
+def test_mixed_decorator_and_endpoint_routes_both_present(tmp_path: Path) -> None:
+    """Decorator-only and endpoint-metadata routes converge into one spec."""
+    register_openapi_metadata(path="/api/items", method="get", summary="List items")
+    app = _endpoint_app(route="users", methods=["POST"])
+    spec = _run_generate("function_app:app", app, True, tmp_path / "openapi.json")
+    assert "/api/items" in spec["paths"]
+    assert "/api/users" in spec["paths"]
+
+
+# ---------------------------------------------------------------------------
+# module-only form — import only, no scan, explicit note
+# ---------------------------------------------------------------------------
+
+
+def test_module_only_form_skips_scan_and_prints_note(tmp_path: Path) -> None:
+    """Without a ':variable', discovery is skipped and a note is emitted."""
+    register_openapi_metadata(path="/api/items", method="get", summary="List items")
+    args = _generate_args("function_app", tmp_path / "openapi.json")
+    with mock.patch(
+        "azure_functions_openapi.cli._import_app_module",
+        return_value=(None, False),
+    ) as mock_import:
+        with mock.patch("azure_functions_openapi.cli.scan_endpoint_metadata") as mock_scan:
+            with mock.patch("builtins.print") as mock_print:
+                result = handle_generate(args)
+
+    assert result == 0
+    mock_import.assert_called_once_with("function_app")
+    mock_scan.assert_not_called()
+    printed = " ".join(str(c.args[0]) for c in mock_print.call_args_list if c.args)
+    assert "metadata discovery skipped" in printed
+    # Decorator-only routes are still present (they registered on import).
+    spec = json.loads((tmp_path / "openapi.json").read_text(encoding="utf-8"))
+    assert "/api/items" in spec["paths"]
+
+
+# ---------------------------------------------------------------------------
+# Registry-merge idempotency (independent of SDK enumeration)
+# ---------------------------------------------------------------------------
+
+
+def test_repeated_scan_is_registry_merge_idempotent() -> None:
+    """Merging the same discovered metadata twice must not duplicate paths."""
+    app = _endpoint_app(route="users", methods=["POST"])
+
+    scan_endpoint_metadata(app, route_prefix="/api")
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    first = generate_openapi_spec("API", "1.0.0")
+
+    # Re-run discovery on the same app: build() is idempotent and the registry
+    # merges by function id, so no duplicate path/operation may be created.
+    scan_endpoint_metadata(app, route_prefix="/api")
+    second = generate_openapi_spec("API", "1.0.0")
+
+    assert first["paths"] == second["paths"]
+    assert list(second["paths"]["/api/users"].keys()) == ["post"]


### PR DESCRIPTION
## Summary
- `azure-functions-openapi generate --app module:variable` now resolves the `FunctionApp` and runs one-shot `scan_endpoint_metadata`, merging endpoint-metadata routes with `@openapi` routes idempotently.
- `--app module` (no `:variable`) still imports the module for `@openapi` registration and prints a note.
- `_import_app_module` returns `tuple[object|None, bool]`; new `tests/test_cli_discovery.py` (5 tests); cli.py 96% cov; docs/cli.md + README updated.

## Notes
- Stacked on #325. Base: `refactor/325-sdk-discovery-adapter`.

Closes #326