### PR TITLE
test(sdk): pin adapter-boundary SDK compatibility contract and guards

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,7 @@
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> **翻訳保留:** CLI の `--app module:variable` エンドポイントメタデータ検出セクション（#331 で英語版 [README.md](README.md) に追加）はまだ翻訳されていません。追跡: [#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334)。
+> **翻訳保留:** CLI の `--app module:variable` エンドポイントメタデータ検出セクション（#331）および **SDK 互換性** セクション（#332）は英語版 [README.md](README.md) に追加されましたが、まだ翻訳されていません。追跡: [#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334)。
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,7 +11,7 @@
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> **Translation pending:** The CLI `--app module:variable` endpoint-metadata discovery section (added to the English [README.md](README.md) in #331) is not yet translated here. Tracking: [#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334).
+> **Translation pending:** The CLI `--app module:variable` endpoint-metadata discovery section (#331) and the **SDK Compatibility** section (#332), added to the English [README.md](README.md), are not yet translated here. Tracking: [#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334).
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ azure-functions-openapi
 
 ## SDK Compatibility
 
-This package extracts route and method metadata from `FunctionBuilder` produced by the `azure-functions` SDK. Because that extraction reads private SDK attributes, we validate the package against an explicit matrix in CI. See [issue #258](https://github.com/yeongseon/azure-functions-openapi-python/issues/258) for background.
+This package discovers routes, methods, and handlers from the `azure-functions` SDK through a single isolated adapter (`azure_functions_openapi.adapters`). Discovery is **public-API-first**: it enumerates via the public, idempotent `FunctionBuilder.build()` and reads everything else through public `Function` accessors (`get_function_name` / `get_user_function` / `get_bindings` / `is_http_function`). The adapter never calls the non-idempotent `FunctionApp.get_functions()`. The **one** unavoidable private token — `app._function_builders`, which has no public substitute for enumeration — lives exclusively in the adapter and is covered by a mandatory guard test. We validate the package against an explicit matrix in CI. See [issue #258](https://github.com/yeongseon/azure-functions-openapi-python/issues/258) and [issue #327](https://github.com/yeongseon/azure-functions-openapi-python/issues/327) for background.
 
 | `azure-functions` | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 | Python 3.14 |
 | ----------------- | :---------: | :---------: | :---------: | :---------: | :---------: |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,7 +11,7 @@
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> **翻译待处理：** CLI 的 `--app module:variable` 端点元数据发现部分（已在 #331 中添加到英文 [README.md](README.md)）尚未翻译。跟踪：[#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334)。
+> **翻译待处理：** CLI 的 `--app module:variable` 端点元数据发现部分（#331）和 **SDK 兼容性** 部分（#332）已添加到英文 [README.md](README.md)，但尚未翻译。跟踪：[#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334)。
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
 

--- a/tests/test_core_sdk_boundary.py
+++ b/tests/test_core_sdk_boundary.py
@@ -215,7 +215,7 @@ def test_adapters_package_is_the_only_function_builders_seam() -> None:
     """Only the adapters package may touch the SDK-private discovery token."""
     offenders: list[str] = []
     for path in sorted(SRC_ROOT.rglob("*.py")):
-        if path.parent.name == "adapters":
+        if "adapters" in path.relative_to(SRC_ROOT).parts:
             continue
         source = path.read_text(encoding="utf-8")
         if "_function_builders" in source:
@@ -232,4 +232,56 @@ def test_adapters_package_actually_encapsulates_the_sdk() -> None:
     assert "_function_builders" in adapter_src, (
         "Expected the discovery adapter to encapsulate '_function_builders'; "
         "if this fails the #325 adapter guard is vacuous."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #327: finer-grained SDK-private tokens live NOWHERE outside adapters.
+# ---------------------------------------------------------------------------
+
+# The per-function private attributes the package historically reached into
+# before the adapter isolation. Post-#325 discovery reads these exclusively
+# through public `Function` accessors, so they must not appear as attribute or
+# name references anywhere in the package outside the adapters package.
+FINE_GRAINED_SDK_TOKENS = ("_function", "_func", "_bindings")
+
+
+def test_no_fine_grained_sdk_tokens_outside_adapter_package() -> None:
+    """Only `_function_builders` (in adapters) is an allowed private token (#327).
+
+    Every other SDK-private discovery token must be gone from the whole package
+    source outside the adapters package — discovery goes through public
+    `Function` accessors instead. This is the package-wide public-API-only
+    guarantee that complements the per-module #325 consumer guard.
+    """
+    offenders: list[str] = []
+    for path in sorted(SRC_ROOT.rglob("*.py")):
+        if "adapters" in path.relative_to(SRC_ROOT).parts:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and node.attr in FINE_GRAINED_SDK_TOKENS:
+                offenders.append(f"{path.relative_to(SRC_ROOT)}: accesses '.{node.attr}'")
+            elif isinstance(node, ast.Name) and node.id in FINE_GRAINED_SDK_TOKENS:
+                offenders.append(f"{path.relative_to(SRC_ROOT)}: references '{node.id}'")
+    assert not offenders, (
+        "SDK-private per-function tokens must not appear outside the adapters "
+        "package; discovery must use public Function accessors instead:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_adapter_itself_avoids_fine_grained_private_tokens() -> None:
+    """The adapter encapsulates enumeration but still reads per-function data
+    through public accessors — it must not fall back to `_function`/`_func`/
+    `_bindings` either (proving the public surface is sufficient)."""
+    tree = ast.parse((SRC_ROOT / "adapters" / "azure_functions.py").read_text(encoding="utf-8"))
+    offenders = [
+        node.attr
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Attribute) and node.attr in FINE_GRAINED_SDK_TOKENS
+    ]
+    assert not offenders, (
+        "The adapter reached into per-function SDK internals "
+        f"{sorted(set(offenders))}; use public Function accessors instead."
     )

--- a/tests/test_sdk_compat_adapter.py
+++ b/tests/test_sdk_compat_adapter.py
@@ -1,0 +1,260 @@
+"""Adapter-boundary SDK compatibility contract and guard tests (issue #327).
+
+After the adapter isolation (#325), all Azure Functions SDK discovery flows
+through :mod:`azure_functions_openapi.adapters.azure_functions`. This module
+pins that contract against the *installed* SDK so the CI matrix
+(``azure-functions`` 1.21 → latest ``<2.0``, Python 3.10–3.14) proves the
+package works on every supported line before the ``<2.0.0`` ceiling is ever
+relaxed.
+
+Verified support matrix (enforced by CI; see ``pyproject.toml`` pin
+``azure-functions>=1.21.0,<2.0.0`` and the README "SDK Compatibility" table):
+
+    azure-functions | Python
+    --------------- | ----------------------------
+    1.21.0 (floor)  | 3.10
+    1.24.0          | 3.10
+    latest (<2.0)   | 3.10, 3.11, 3.12, 3.13, 3.14
+
+Three guarantees are asserted here:
+
+* **Mandatory private-token guard** — enumeration has no public substitute, so
+  ``app._function_builders`` (and each builder's callable ``build``) must exist.
+  This guard is *unconditional*: the adapter always depends on that single
+  private structure, and it must fail loudly if the SDK ever drops it.
+* **Contract tests through the adapter boundary** — route/method/handler
+  discovery works via the public ``build()`` + ``Function`` accessors, and
+  ``get_functions()`` is *never* invoked (it is non-idempotent and would poison
+  the worker's indexing state).
+* **Public-API-only discovery** — a minimal fake builder exposing only the
+  documented public surface (no ``_function`` / ``_func`` / ``_bindings``)
+  drives the full adapter, proving no finer-grained private access is needed.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata as _metadata
+from typing import Any
+from unittest import mock
+
+import azure.functions as func
+import pytest
+
+from azure_functions_openapi import adapters
+
+
+def _make_app() -> Any:
+    """A real FunctionApp with one HTTP route, for SDK-shape contract tests."""
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    @app.route(route="users/{id}", methods=["PUT"])
+    def update_user(req: func.HttpRequest) -> func.HttpResponse:
+        return func.HttpResponse("OK", status_code=200)
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Installed-version sanity
+# ---------------------------------------------------------------------------
+
+
+def test_installed_sdk_is_within_supported_matrix() -> None:
+    """The installed SDK must satisfy the ``>=1.21.0,<2.0.0`` pin."""
+    installed = _metadata.version("azure-functions")
+    major_minor = tuple(int(p) for p in installed.split(".")[:2])
+    assert major_minor >= (1, 21), (
+        f"azure-functions {installed} is below the >=1.21.0 floor in "
+        "pyproject.toml. The floor exists because earlier releases return None "
+        "from FunctionBuilder.__call__. See issue #327."
+    )
+    assert major_minor < (2, 0), (
+        f"azure-functions {installed} is above the <2.0.0 ceiling. The ceiling "
+        "is only widened after the #327 compatibility matrix is green."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mandatory private-token guard (unconditional)
+# ---------------------------------------------------------------------------
+
+
+def test_function_builders_private_token_exists_and_is_shaped() -> None:
+    """MANDATORY guard: ``_function_builders`` + callable ``build`` must exist.
+
+    Enumeration has no public substitute, so this is the one private structure
+    the adapter is permitted to depend on. If a future SDK removes or reshapes
+    it, this test fails loudly — pointing maintainers at the adapter before
+    end-users hit an import-time break.
+    """
+    app = _make_app()
+    assert hasattr(app, "_function_builders"), (
+        "FunctionApp no longer exposes '_function_builders' — the adapter's "
+        "only enumeration primitive is gone. See issue #327."
+    )
+    builders = app._function_builders
+    assert builders, "Expected at least one registered FunctionBuilder."
+    for builder in builders:
+        assert callable(getattr(builder, "build", None)), (
+            "FunctionBuilder no longer exposes a callable 'build' — the public, "
+            "idempotent enumeration primitive is gone. See issue #327."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Contract tests through the adapter boundary
+# ---------------------------------------------------------------------------
+
+
+def test_iter_functions_discovers_route_method_and_handler() -> None:
+    """Route/method/handler discovery works through the adapter boundary."""
+    app = _make_app()
+
+    functions = adapters.iter_functions(app)
+
+    assert len(functions) == 1
+    fn = functions[0]
+    assert adapters.get_function_name(fn) == "update_user"
+    assert adapters.is_http_function(fn) is True
+    assert callable(adapters.get_user_handler(fn))
+
+    binding = adapters.extract_http_binding(fn)
+    assert binding is not None
+    assert binding.route == "users/{id}"
+    assert [str(getattr(m, "value", m)).upper() for m in binding.methods] == ["PUT"]
+
+
+def test_iter_functions_never_invokes_get_functions() -> None:
+    """The adapter must not call the non-idempotent ``get_functions()``."""
+    app = _make_app()
+    sentinel = mock.Mock(side_effect=AssertionError("get_functions must never be called"))
+
+    with mock.patch.object(app, "get_functions", sentinel):
+        functions = adapters.iter_functions(app)
+
+    assert functions, "Discovery must still succeed via the build() path."
+    sentinel.assert_not_called()
+
+
+def _http_binding_signature(fn: Any) -> tuple[str | None, tuple[str, ...]]:
+    """Observable HTTP-binding shape (route + sorted methods) for a Function."""
+    binding = adapters.extract_http_binding(fn)
+    if binding is None:
+        return (None, ())
+    methods = tuple(sorted(str(getattr(m, "value", m)).upper() for m in binding.methods))
+    return (binding.route, methods)
+
+
+def test_iter_functions_is_idempotent_and_leaves_indexing_state_clean() -> None:
+    """Repeated enumeration returns the same cached Function and does not poison
+    the SDK's ``functions_bindings`` indexing state."""
+    app = _make_app()
+
+    first = adapters.iter_functions(app)
+    second = adapters.iter_functions(app)
+
+    # Idempotent in the way callers actually depend on: repeated enumeration
+    # yields the same observable functions (stable count, names, and HTTP
+    # bindings). We deliberately do NOT assert object identity (``first[0] is
+    # second[0]``) — a future ``azure-functions`` release may hand back a fresh
+    # ``Function`` object each call while remaining functionally idempotent, and
+    # pinning identity would make the compatibility matrix needlessly fragile.
+    assert len(first) == len(second)
+    assert [adapters.get_function_name(f) for f in first] == [
+        adapters.get_function_name(f) for f in second
+    ]
+    assert [_http_binding_signature(f) for f in first] == [
+        _http_binding_signature(f) for f in second
+    ]
+
+    # A single get_functions() call still succeeds afterwards — proof that the
+    # adapter left the worker's indexing state untouched. (get_functions itself
+    # is non-idempotent, so we call it exactly once here.)
+    names = [f.get_function_name() for f in app.get_functions()]
+    assert "update_user" in names
+
+
+# ---------------------------------------------------------------------------
+# Public-API-only discovery (no private attributes beyond _function_builders)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBinding:
+    type = "httpTrigger"
+    route = "ping"
+    methods = ["GET"]
+
+
+class _FakeFunction:
+    """A Function stand-in exposing ONLY the public accessor surface."""
+
+    def get_function_name(self) -> str:
+        return "ping"
+
+    def get_user_function(self) -> Any:
+        return lambda req: req
+
+    def get_bindings(self) -> list[Any]:
+        return [_FakeBinding()]
+
+    def is_http_function(self) -> bool:
+        return True
+
+
+class _FakeBuilder:
+    def build(self, auth_level: Any = None) -> _FakeFunction:
+        return _FakeFunction()
+
+
+class _FakeApp:
+    _function_builders = [_FakeBuilder()]
+    auth_level = None
+
+
+def test_adapter_drives_discovery_through_public_accessors_only() -> None:
+    """A fake exposing only the public API drives the full adapter path.
+
+    ``_FakeFunction`` deliberately omits ``_function`` / ``_func`` /
+    ``_bindings``; if the adapter still works end-to-end, it proves discovery
+    needs no private attribute beyond the ``_function_builders`` enumeration
+    token.
+    """
+    app = _FakeApp()
+
+    functions = adapters.iter_functions(app)
+
+    assert len(functions) == 1
+    fn = functions[0]
+    assert adapters.get_function_name(fn) == "ping"
+    assert adapters.is_http_function(fn) is True
+    assert adapters.get_bindings(fn)[0].route == "ping"
+    ping_binding = adapters.extract_http_binding(fn)
+    assert ping_binding is not None
+    assert ping_binding.route == "ping"
+    assert callable(adapters.get_user_handler(fn))
+
+
+def test_iter_functions_returns_empty_for_app_without_builders() -> None:
+    """An app with no registered functions enumerates to an empty list."""
+
+    class _EmptyApp:
+        _function_builders: list[Any] = []
+        auth_level = None
+
+    assert adapters.iter_functions(_EmptyApp()) == []
+
+
+@pytest.mark.parametrize("bad_type", ["queueTrigger", "timerTrigger", ""])
+def test_extract_http_binding_ignores_non_http_triggers(bad_type: str) -> None:
+    """Only httpTrigger bindings are returned; other trigger types yield None."""
+
+    class _Binding:
+        type = bad_type
+        route = "x"
+        methods = ["GET"]
+
+    class _Fn:
+        def get_bindings(self) -> list[Any]:
+            return [_Binding()]
+
+    assert adapters.extract_http_binding(_Fn()) is None


### PR DESCRIPTION
## Summary
- New `tests/test_sdk_compat_adapter.py` (10 tests): mandatory `app._function_builders` guard, adapter contract, assertion that `get_functions()` is never called, public-API-only fake app.
- Add 2 architecture tests to `tests/test_core_sdk_boundary.py` (11 total).
- README SDK Compatibility matrix section updated.

## Notes
- Stacked on #326. Base: `feat/326-cli-unified-discovery`.

Closes #327