### PR TITLE
fix(adapter): skip unbuildable functions during discovery

### DIFF
--- a/src/azure_functions_openapi/adapters/azure_functions.py
+++ b/src/azure_functions_openapi/adapters/azure_functions.py
@@ -37,11 +37,14 @@ See issue #325 for the full rationale and empirical reproduction.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, cast
 
 from azure.functions.decorators.function_app import Function, FunctionBuilder
 
 from azure_functions_openapi.exceptions import SDKIncompatibleError
+
+_logger = logging.getLogger(__name__)
 
 _HTTP_TRIGGER_TYPE = "httptrigger"
 
@@ -86,14 +89,24 @@ def iter_functions(app: Any) -> list[Function]:
     would poison the app's ``functions_bindings`` indexing state and break the
     user's Function App at boot.
 
-    Returns an empty list when *app* exposes no builders (e.g. an app with no
-    registered functions), matching the previous "skip quietly" behaviour.
+    Skips any builder whose :meth:`FunctionBuilder.build` raises ``ValueError``
+    (e.g. a function with no trigger, or a trigger not present in its bindings).
+    Such a function is a *user app state*, not an SDK incompatibility, so it is
+    logged at debug and omitted rather than aborting the whole scan. Returns an
+    empty list when *app* exposes no builders (e.g. an app with no registered
+    functions), matching the previous "skip quietly" behaviour.
     """
     builders = getattr(app, "_function_builders", None)
     if not builders:
         return []
     auth_level = getattr(app, "auth_level", None)
-    return [build_function(builder, auth_level) for builder in builders]
+    functions: list[Function] = []
+    for builder in builders:
+        try:
+            functions.append(build_function(builder, auth_level))
+        except ValueError as exc:  # no trigger / trigger not in bindings
+            _logger.debug("Skipping unbuildable function during discovery: %s", exc)
+    return functions
 
 
 def get_function_name(function: Any) -> str:

--- a/tests/test_sdk_compat_adapter.py
+++ b/tests/test_sdk_compat_adapter.py
@@ -244,6 +244,31 @@ def test_iter_functions_returns_empty_for_app_without_builders() -> None:
     assert adapters.iter_functions(_EmptyApp()) == []
 
 
+def test_iter_functions_skips_builder_that_fails_to_build() -> None:
+    """Regression (#337): a trigger-less builder is skipped, not fatal.
+
+    ``FunctionBuilder.build()`` raises ``ValueError`` for a function with no
+    trigger. Before #337 that ``ValueError`` propagated out of
+    ``iter_functions`` and aborted the entire scan, breaking the user's
+    Function App at import time. The adapter must skip the unbuildable builder
+    and still return the validly-built functions.
+    """
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    @app.route(route="healthy", methods=["GET"])
+    def healthy(req: func.HttpRequest) -> func.HttpResponse:
+        return func.HttpResponse("OK", status_code=200)
+
+    @app.function_name(name="orphan")  # builder with no trigger decorator
+    def orphan(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("nope")
+
+    functions = adapters.iter_functions(app)
+
+    names = [adapters.get_function_name(fn) for fn in functions]
+    assert names == ["healthy"]
+
+
 @pytest.mark.parametrize("bad_type", ["queueTrigger", "timerTrigger", ""])
 def test_extract_http_binding_ignores_non_http_triggers(bad_type: str) -> None:
     """Only httpTrigger bindings are returned; other trigger types yield None."""


### PR DESCRIPTION
## Summary
- `iter_functions` now skips any builder whose `build()` raises `ValueError` (e.g. a function with no trigger) and logs at debug, rather than aborting the entire scan.
- Before this fix, a single trigger-less function made `scan_endpoint_metadata(app)` raise `ValueError` at import time, breaking the user's whole Function App at boot (regression from the #325 adapter refactor).
- `build_function` still raises `SDKIncompatibleError` on `AttributeError` (a genuine SDK-shape incompatibility) — unchanged. A trigger-less function is user app state, not SDK incompatibility, so it is skipped rather than promoted to an error.

## Test
- New regression test `test_iter_functions_skips_builder_that_fails_to_build`: an app mixing a trigger-less builder with a valid HTTP function → discovery succeeds and returns only the valid function.
- `make check-all` passes; coverage 96%.

Closes #337