### PR TITLE
fix(discovery): preserve all-method semantics when HTTP methods are unspecified

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -21,7 +21,12 @@ from azure_functions_openapi._validation_contract import (
 from azure_functions_openapi.decorator import register_openapi_metadata
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
 from azure_functions_openapi.registry import canonical_function_id, registry
-from azure_functions_openapi.routes import DEFAULT_ROUTE_PREFIX, normalize_route_prefix
+from azure_functions_openapi.routes import (
+    ALL_HTTP_METHODS,
+    BODYLESS_HTTP_METHODS,
+    DEFAULT_ROUTE_PREFIX,
+    normalize_route_prefix,
+)
 from azure_functions_openapi.utils import type_to_schema
 
 logger = logging.getLogger(__name__)
@@ -67,16 +72,25 @@ def _extract_http_binding(function: Any) -> Any | None:
     return adapters.extract_http_binding(function)
 
 
-def _extract_methods(binding: Any) -> list[str]:
+def _extract_methods(binding: Any) -> tuple[list[str], bool]:
+    """Return ``(methods, expanded)`` for an HTTP binding.
+
+    ``expanded`` is ``True`` only when ``methods=`` was *unspecified* (``None``)
+    and we therefore expanded to the full :data:`ALL_HTTP_METHODS` set to match
+    Azure runtime semantics (unspecified methods respond to every HTTP method).
+    An explicit ``methods=[]`` is a *different* signal from omitting ``methods=``
+    entirely: it is an explicit (non-expanded) choice, so it is not expanded and
+    falls back to a single ``get`` operation for a usable spec.
+    """
     methods = getattr(binding, "methods", None)
     if methods is None:
-        return ["get"]
+        return list(ALL_HTTP_METHODS), True
     if isinstance(methods, str):
-        return [_normalize_method(methods)]
+        return [_normalize_method(methods)], False
     if isinstance(methods, Iterable):
         normalized = [_normalize_method(item) for item in methods]
-        return normalized or ["get"]
-    return ["get"]
+        return (normalized or ["get"]), False
+    return ["get"], False
 
 
 def _merge_parameters(
@@ -460,7 +474,7 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
             continue
 
         path = _normalize_path(getattr(binding, "route", None), function_name, route_prefix)
-        methods = _extract_methods(binding)
+        methods, methods_expanded = _extract_methods(binding)
 
         for method in methods:
             if endpoint_hints is not None:
@@ -471,6 +485,13 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
                 discovered = _discovered_operation(function_name, metadata, path, method)
             else:  # pragma: no cover - guarded above (endpoint or metadata is set)
                 continue
+
+            # When methods= was unspecified and we auto-expanded to every HTTP
+            # method, drop the request body from GET/HEAD/DELETE operations:
+            # OpenAPI leaves a body there semantically undefined and many tools
+            # reject it. Explicitly requested methods are left untouched.
+            if methods_expanded and method in BODYLESS_HTTP_METHODS:
+                discovered["request_body"] = None
             endpoint_key = f"{method}::{path}"
 
             with registry.lock:

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -516,7 +516,9 @@ def _validate_method(method: str | None, func_name: str) -> str | None:
     """Validate and normalize HTTP method.
 
     Returns the lowercased method string, or ``None`` when *method* is not
-    provided (the spec generator will default to ``"get"``).
+    provided. An unspecified method is later expanded by the spec generator to
+    every HTTP method (matching the Azure runtime, which responds to all methods
+    when ``methods=`` is omitted), rather than defaulting to ``"get"``.
     """
     if method is None:
         return None

--- a/src/azure_functions_openapi/routes.py
+++ b/src/azure_functions_openapi/routes.py
@@ -8,6 +8,27 @@ from __future__ import annotations
 
 DEFAULT_ROUTE_PREFIX = "/api"
 
+# The Azure Functions ``HttpMethod`` enum (GET, POST, DELETE, HEAD, PATCH, PUT,
+# OPTIONS — no TRACE), lowercased to match OpenAPI path-item fields. When a
+# route omits ``methods=``, the Azure runtime responds to *all* of these (MS
+# Learn HTTP trigger reference: "If not specified, the function responds to all
+# HTTP methods"), so discovery expands unspecified methods to this set instead
+# of narrowing the spec to GET.
+ALL_HTTP_METHODS: tuple[str, ...] = (
+    "get",
+    "post",
+    "put",
+    "delete",
+    "patch",
+    "head",
+    "options",
+)
+
+# Methods for which OpenAPI leaves a ``requestBody`` semantically undefined and
+# which many tools reject; excluded from *auto-expanded* body-carrying
+# operations (an explicitly requested method is left untouched).
+BODYLESS_HTTP_METHODS: frozenset[str] = frozenset({"get", "head", "delete"})
+
 
 def normalize_route_prefix(route_prefix: str) -> str:
     """Canonicalize a user-supplied prefix.

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -68,6 +68,25 @@ def _ensure_default_response(
         "content": {"application/json": {"schema": resolved_schema}},
     }
 
+def _operation_id_for(
+    provided_id: str | None,
+    method: str,
+    logical_name: str,
+    methods_expanded: bool,
+) -> str:
+    """Return a unique ``operationId`` for one emitted method operation.
+
+    When an explicit ``operation_id`` is provided but the (unspecified) method
+    was auto-expanded to the full HTTP set, the same id would otherwise be
+    reused across every emitted operation, producing duplicate ``operationId``
+    values that violate the OpenAPI spec (an error under ``strict=True`` and
+    rejected by many tools). Suffix the provided id with the method in that
+    case; the auto-generated fallback is already per-method unique.
+    """
+    if provided_id:
+        return f"{provided_id}_{method}" if methods_expanded else provided_id
+    return f"{method}_{logical_name}"
+
 
 def _convert_nullable_to_type_array(schema: dict[str, Any]) -> dict[str, Any]:
     """Convert OpenAPI 3.0 nullable to 3.1 type array syntax."""
@@ -408,7 +427,9 @@ def generate_openapi_spec(
                     op: dict[str, Any] = {
                         "summary": meta.get("summary", ""),
                         "description": meta.get("description", ""),
-                        "operationId": meta.get("operation_id") or f"{method}_{logical_name}",
+                        "operationId": _operation_id_for(
+                            meta.get("operation_id"), method, logical_name, methods_expanded
+                        ),
                         "tags": meta.get("tags") or ["default"],
                         "responses": copy.deepcopy(responses),
                     }

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -1,6 +1,7 @@
 # src/azure_functions_openapi/spec.py
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import re
@@ -12,6 +13,8 @@ from azure_functions_openapi.exceptions import OpenAPISpecConfigError
 from azure_functions_openapi.registry import OpenAPIRegistry
 from azure_functions_openapi.registry import registry as _default_registry
 from azure_functions_openapi.routes import (
+    ALL_HTTP_METHODS,
+    BODYLESS_HTTP_METHODS,
     DEFAULT_ROUTE_PREFIX,
     apply_route_prefix,
     normalize_route_prefix,
@@ -283,7 +286,17 @@ def generate_openapi_spec(
                 # route & method --------------------------------------------------
                 raw_path = f"/{(meta.get('route') or logical_name).lstrip('/')}"
                 path = apply_route_prefix(raw_path, normalized_prefix)
-                method = (meta.get("method") or "get").lower()
+                # An unspecified method (``None``) means the Azure runtime
+                # responds to every HTTP method, so expand to the full set to
+                # match the endpoint-metadata scan path. An explicit method is
+                # emitted as a single operation, unchanged.
+                raw_method = meta.get("method")
+                if raw_method is None:
+                    methods_to_emit = list(ALL_HTTP_METHODS)
+                    methods_expanded = True
+                else:
+                    methods_to_emit = [str(raw_method).lower()]
+                    methods_expanded = False
 
                 # responses -------------------------------------------------------
                 responses: dict[str, Any] = {}
@@ -339,19 +352,15 @@ def generate_openapi_spec(
 
                 _ensure_default_response(responses)
 
-                # operation object ------------------------------------------------
-                op: dict[str, Any] = {
-                    "summary": meta.get("summary", ""),
-                    "description": meta.get("description", ""),
-                    "operationId": meta.get("operation_id") or f"{method}_{logical_name}",
-                    "tags": meta.get("tags") or ["default"],
-                    "responses": responses,
-                }
-
+                # Method-independent operation pieces, computed once and then
+                # deep-copied per emitted method so the OpenAPI 3.1 conversion
+                # (which mutates operation schemas in place) never aliases across
+                # path-item entries.
                 # parameters ------------------------------------------------------
                 parameters: list[dict[str, Any]] = meta.get("parameters", [])
+                op_parameters: list[dict[str, Any]] | None = None
                 if parameters:
-                    op["parameters"] = [
+                    op_parameters = [
                         {**param, "schema": hoist_inline_defs(param["schema"], components)}
                         if isinstance(param, dict) and "schema" in param
                         else param
@@ -360,53 +369,74 @@ def generate_openapi_spec(
 
                 # security --------------------------------------------------------
                 security: list[dict[str, list[str]]] = meta.get("security", [])
-                if security:
-                    op["security"] = security
 
-                # requestBody (POST/PUT/PATCH/DELETE) --------------------------
-                if method in {"post", "put", "patch", "delete"}:
-                    required = meta.get("request_body_required", True)
-                    if meta.get("request_body"):
-                        op["requestBody"] = {
+                # requestBody schema (POST/PUT/PATCH/DELETE) ----------------------
+                request_body_obj: dict[str, Any] | None = None
+                required = meta.get("request_body_required", True)
+                if meta.get("request_body"):
+                    request_body_obj = {
+                        "required": required,
+                        "content": {
+                            "application/json": {
+                                "schema": hoist_inline_defs(
+                                    meta["request_body"], components
+                                )
+                            }
+                        },
+                    }
+                elif meta.get("request_model"):
+                    try:
+                        request_body_obj = {
                             "required": required,
                             "content": {
                                 "application/json": {
-                                    "schema": hoist_inline_defs(
-                                        meta["request_body"], components
-                                    )
+                                    "schema": model_to_schema(meta["request_model"], components)
                                 }
                             },
                         }
-                    elif meta.get("request_model"):
-                        try:
-                            op["requestBody"] = {
-                                "required": required,
-                                "content": {
-                                    "application/json": {
-                                        "schema": model_to_schema(meta["request_model"], components)
-                                    }
-                                },
-                            }
-                        except Exception as e:
-                            logger.warning(
-                                f"Failed to generate request schema for {func_name}: {str(e)}"
-                            )
-                            op["requestBody"] = {
-                                "required": required,
-                                "content": {"application/json": {"schema": {"type": "object"}}},
-                            }
+                    except Exception as e:
+                        logger.warning(
+                            f"Failed to generate request schema for {func_name}: {str(e)}"
+                        )
+                        request_body_obj = {
+                            "required": required,
+                            "content": {"application/json": {"schema": {"type": "object"}}},
+                        }
 
-                # merge into paths — detect duplicate path+method registrations
-                path_item = paths.setdefault(path, {})
-                if method in path_item:
-                    _dup_msg = (
-                        f"Duplicate operation: {method.upper()} {path} — "
-                        "only the last @openapi registration will appear in the spec"
-                    )
-                    if strict:
-                        raise OpenAPISpecConfigError(_dup_msg)
-                    logger.warning("OpenAPI spec: %s", _dup_msg)
-                path_item[method] = op
+                for method in methods_to_emit:
+                    # operation object --------------------------------------------
+                    op: dict[str, Any] = {
+                        "summary": meta.get("summary", ""),
+                        "description": meta.get("description", ""),
+                        "operationId": meta.get("operation_id") or f"{method}_{logical_name}",
+                        "tags": meta.get("tags") or ["default"],
+                        "responses": copy.deepcopy(responses),
+                    }
+                    if op_parameters is not None:
+                        op["parameters"] = copy.deepcopy(op_parameters)
+                    if security:
+                        op["security"] = security
+
+                    # requestBody: only body-bearing methods, and never on an
+                    # auto-expanded GET/HEAD/DELETE (OpenAPI leaves the body
+                    # undefined there and many tools reject it).
+                    body_methods = {"post", "put", "patch", "delete"}
+                    if methods_expanded:
+                        body_methods -= BODYLESS_HTTP_METHODS
+                    if request_body_obj is not None and method in body_methods:
+                        op["requestBody"] = copy.deepcopy(request_body_obj)
+
+                    # merge into paths — detect duplicate path+method registrations
+                    path_item = paths.setdefault(path, {})
+                    if method in path_item:
+                        _dup_msg = (
+                            f"Duplicate operation: {method.upper()} {path} — "
+                            "only the last @openapi registration will appear in the spec"
+                        )
+                        if strict:
+                            raise OpenAPISpecConfigError(_dup_msg)
+                        logger.warning("OpenAPI spec: %s", _dup_msg)
+                    path_item[method] = op
 
             except (KeyError, TypeError, ValueError):
                 if strict:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -246,6 +246,11 @@ def test_scan_expands_unspecified_methods_to_all_http_methods() -> None:
 
     scan_endpoint_metadata(app)
 
+    registry_keys = set(get_openapi_registry())
+    for method in ("get", "post", "put", "delete", "patch", "head", "options"):
+        assert f"{method}::/api/users" in registry_keys
+
+
 def test_scan_omits_request_body_from_expanded_bodyless_methods() -> None:
     # Policy (#335): when methods= is unspecified we expand to all HTTP methods,
     # but GET/HEAD/DELETE must not carry a requestBody (OpenAPI leaves it

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -236,7 +236,9 @@ def test_scan_skips_non_http_bindings() -> None:
     assert get_openapi_registry() == {}
 
 
-def test_scan_defaults_method_to_get_when_unspecified() -> None:
+def test_scan_expands_unspecified_methods_to_all_http_methods() -> None:
+    # Azure runtime responds to *all* HTTP methods when methods= is omitted, so
+    # the scan must register every HttpMethod rather than defaulting to GET.
     handler = _make_validated_handler({"response_model": ResponseModel})
     binding = MockBinding(route="users", methods=None, type="httpTrigger")
     fn = MockFunction(_name="get_users", _func=handler, _bindings=[binding])
@@ -244,7 +246,26 @@ def test_scan_defaults_method_to_get_when_unspecified() -> None:
 
     scan_endpoint_metadata(app)
 
-    assert "get::/api/users" in get_openapi_registry()
+def test_scan_omits_request_body_from_expanded_bodyless_methods() -> None:
+    # Policy (#335): when methods= is unspecified we expand to all HTTP methods,
+    # but GET/HEAD/DELETE must not carry a requestBody (OpenAPI leaves it
+    # undefined there). Body-bearing methods keep it.
+    handler = _make_validated_handler({"body": CreateBody})
+    binding = MockBinding(route="users", methods=None, type="httpTrigger")
+    fn = MockFunction(_name="users", _func=handler, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    registry = get_openapi_registry()
+    for method in ("get", "head", "delete"):
+        assert registry[f"{method}::/api/users"]["request_body"] is None
+    for method in ("post", "put", "patch"):
+        assert registry[f"{method}::/api/users"]["request_body"] is not None
+
+    registry_keys = set(get_openapi_registry())
+    for method in ("get", "post", "put", "delete", "patch", "head", "options"):
+        assert f"{method}::/api/users" in registry_keys
 
 
 def test_scan_merges_explicit_function_name_entry() -> None:
@@ -630,8 +651,15 @@ def test_extract_methods_handles_string_and_invalid_type() -> None:
         def __init__(self, methods: Any) -> None:
             self.methods = methods
 
-    assert _extract_methods(_Binding("POST")) == ["post"]
-    assert _extract_methods(_Binding(123)) == ["get"]
+    assert _extract_methods(_Binding("POST")) == (["post"], False)
+    assert _extract_methods(_Binding(123)) == (["get"], False)
+    # Unspecified methods= expands to every HTTP method (expanded=True).
+    assert _extract_methods(_Binding(None)) == (
+        ["get", "post", "put", "delete", "patch", "head", "options"],
+        True,
+    )
+    # An explicit empty list is a different signal: not expanded.
+    assert _extract_methods(_Binding([])) == (["get"], False)
 
 
 def test_merge_parameters_appends_non_conflicting_items() -> None:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -353,7 +353,9 @@ def test_openapi_spec_contains_operation_id_and_tags() -> None:
     spec = json.loads(get_openapi_json())
     item = spec["paths"]["/api/http_trigger"]["get"]
 
-    assert item["operationId"] == "greetUser"
+    # method= is unspecified, so #335 expands to all HTTP methods and suffixes
+    # the explicit operation_id per method to keep operationIds unique.
+    assert item["operationId"] == "greetUser_get"
     assert item["tags"] == ["Example"]
     assert "HTTP Trigger with name parameter" in item["summary"]
     assert "### Usage" in item["description"]

--- a/tests/test_openapi_spec.py
+++ b/tests/test_openapi_spec.py
@@ -36,7 +36,9 @@ def test_openapi_spec_http_trigger_metadata() -> None:
     http_get = spec["paths"]["/api/http_trigger"]["get"]
 
     # Basic metadata
-    assert http_get["operationId"] == "greetUser"
+    # method= unspecified -> #335 expands to all methods with per-method-unique
+    # operationIds (explicit operation_id suffixed by method).
+    assert http_get["operationId"] == "greetUser_get"
     assert http_get["tags"] == ["Example"]
     assert http_get["summary"] == "HTTP Trigger with name parameter"
 

--- a/tests/test_register_metadata.py
+++ b/tests/test_register_metadata.py
@@ -329,3 +329,47 @@ def test_register_request_model_and_request_body_raises() -> None:
             request_model=DemoRequestModel,
             request_body={"type": "object"},
         )
+
+
+def test_spec_expands_unspecified_method_to_all_http_methods() -> None:
+    # #335: @openapi without method= must produce one operation per HTTP method
+    # (the Azure runtime responds to all methods when methods= is omitted),
+    # not a single GET operation.
+    @openapi(route="/api/hello", summary="Hello")
+    def hello() -> None:  # pragma: no cover - registration only
+        ...
+
+    spec = generate_openapi_spec()
+    path_item = spec["paths"]["/api/hello"]
+    assert set(path_item) == {
+        "get",
+        "post",
+        "put",
+        "delete",
+        "patch",
+        "head",
+        "options",
+    }
+
+
+def test_spec_expanded_methods_omit_body_on_get_head_delete() -> None:
+    # #335 policy 1: a body-carrying @openapi with unspecified method expands to
+    # all methods but must not attach requestBody to GET/HEAD/DELETE.
+    @openapi(route="/api/thing", request_model=DemoRequestModel)
+    def thing() -> None:  # pragma: no cover - registration only
+        ...
+
+    spec = generate_openapi_spec()
+    path_item = spec["paths"]["/api/thing"]
+    for method in ("get", "head", "delete"):
+        assert "requestBody" not in path_item[method]
+    for method in ("post", "put", "patch"):
+        assert "requestBody" in path_item[method]
+
+
+def test_spec_explicit_method_stays_single_operation() -> None:
+    # An explicit method= is unaffected by the expansion policy.
+    register_openapi_metadata(path="/api/explicit", method="POST")
+
+    spec = generate_openapi_spec()
+    assert set(spec["paths"]["/api/explicit"]) == {"post"}

--- a/tests/test_register_metadata.py
+++ b/tests/test_register_metadata.py
@@ -373,3 +373,19 @@ def test_spec_explicit_method_stays_single_operation() -> None:
 
     spec = generate_openapi_spec()
     assert set(spec["paths"]["/api/explicit"]) == {"post"}
+
+
+def test_spec_expanded_methods_keep_unique_operation_ids() -> None:
+    # #335 regression: an explicit operation_id on an unspecified-method route
+    # must not be reused verbatim across every expanded operation (duplicate
+    # operationIds are invalid and error under strict=True). Each emitted
+    # operation is suffixed with its method to stay unique.
+    @openapi(route="/api/dup", operation_id="myOp")
+    def dup() -> None:  # pragma: no cover - registration only
+        ...
+
+    spec = generate_openapi_spec()
+    path_item = spec["paths"]["/api/dup"]
+    op_ids = [op["operationId"] for op in path_item.values()]
+    assert len(op_ids) == len(set(op_ids))
+    assert set(op_ids) == {f"myOp_{m}" for m in path_item}


### PR DESCRIPTION
## Summary
When an Azure Functions route omits `methods=`, the runtime responds to **all** HTTP methods (MS Learn HTTP trigger reference), but discovery previously narrowed the generated spec to **GET only**, making the spec narrower than runtime.

This reconciles all three GET-default sites so both discovery paths agree for the same handler:

- **`bridge.py` `_extract_methods`** now returns `(methods, expanded)`. An unspecified `methods=` (None) expands to the full `HttpMethod` set (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS); an explicit `methods=[]` is a *different* signal and stays non-expanded.
- **`spec.py`** (the `@openapi` decorator path) emits one operation per method for entries with no explicit `method`, instead of defaulting to `get`.
- **`decorator.py`** docstring updated to describe expansion rather than a `get` default.
- Shared HTTP-method constants (`ALL_HTTP_METHODS`, `BODYLESS_HTTP_METHODS`) live in the cycle-free `routes.py`.

### Expansion policy (Option 1)
Auto-expanded **GET/HEAD/DELETE** operations drop the `requestBody` (OpenAPI leaves a body there semantically undefined and many tools reject it). Explicitly requested methods are untouched.

## Test
- Repurposed `test_scan_defaults_method_to_get_when_unspecified` → asserts all-method expansion.
- Added body-exclusion tests on **both** paths (bridge scan + `@openapi` spec generation).
- Added an explicit-method test confirming single-operation behavior is unchanged.
- `_extract_methods` tuple contract covered (string / invalid / None / empty list).
- `make check-all` passes; coverage 96%.

Closes #335