### PR TITLE
docs(bridge): drop canonical/shared-contract framing in endpoint terminology

### DIFF
--- a/src/azure_functions_openapi/_endpoint_contract.py
+++ b/src/azure_functions_openapi/_endpoint_contract.py
@@ -1,4 +1,4 @@
-"""Read-side contract for the shared ``endpoint`` namespace metadata.
+"""Read-side model for the ``endpoint`` namespace metadata convention.
 
 Producer packages (``azure-functions-validation``, ``azure-functions-langgraph``,
 ...) write a self-contained, OpenAPI-ready payload onto handlers under the
@@ -7,11 +7,13 @@ Unlike the ``validation`` namespace (which carries user-defined Pydantic model
 *classes*), the ``endpoint`` payload is entirely JSON Schema, so this consumer
 needs **no** import of the producing package and no access to the user's models.
 
-This module mirrors the *shape the bridge reads* as a ``TypedDict`` so the
-consumed contract is explicit and type-checked. The producer's canonical schema
-lives in ``azure-functions-validation`` (``schemas/endpoint.schema.json``); the
-two packages release independently, so this read-side mirror keeps the
-consumer's expectations pinned even as producers evolve.
+This module mirrors the *shape the bridge reads* as a ``TypedDict`` so this
+package's local read model is explicit and type-checked. The ``endpoint``
+namespace is a **versioned plain-dict convention**, not a shared or hosted
+schema owned by any single package: each package keeps its own local
+read/write model of the same convention and they release independently. This
+read-side mirror pins the versioned dict this package accepts
+(``SUPPORTED_ENDPOINT_VERSIONS``) even as producers evolve.
 """
 
 from __future__ import annotations
@@ -21,7 +23,7 @@ from typing import Any, TypedDict
 # Convention attribute name shared across every Azure Functions toolkit package.
 HANDLER_METADATA_ATTR = "_azure_functions_metadata"
 
-# Namespace owned by the shared endpoint contract.
+# Namespace name for the versioned endpoint metadata convention.
 ENDPOINT_NAMESPACE = "endpoint"
 
 # Payload ``version`` values this consumer understands.


### PR DESCRIPTION
## Summary
Per the converged design (validation #288, umbrella #270), the `endpoint` namespace is a **versioned plain-dict convention** — there is no shared/hosted/canonical schema and no single package "owns" a cross-repo contract; each package keeps its own local read/write model.

Rewords the consumer-side comments in `_endpoint_contract.py` that still used the old ownership framing:
- module docstring: "shared endpoint namespace" → "endpoint namespace metadata convention" / local read model.
- `:11` "The producer's canonical schema lives in ..." → describes this package's local read model of a versioned convention.
- `:24` "Namespace owned by the shared endpoint contract" → "Namespace name for the versioned endpoint metadata convention."

Comment/wording-only; no behavior change. Verified no user-facing docs echo the old framing. `_validation_contract.py:22` left as-is (that namespace genuinely is validation's).

## Test
- `make lint` + `make typecheck` pass (no code change).

Closes #336