### PR TITLE
docs(readme): sync translated READMEs with CLI --app discovery and SDK Compatibility

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -11,8 +11,6 @@
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> **翻訳保留:** CLI の `--app module:variable` エンドポイントメタデータ検出セクション（#331）および **SDK 互換性** セクション（#332）は英語版 [README.md](README.md) に追加されましたが、まだ翻訳されていません。追跡: [#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334)。
-
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
 **Azure Functions Python v2 プログラミング モデル**向けの OpenAPI（Swagger）ドキュメント生成と Swagger UI を提供します。
@@ -95,6 +93,32 @@ def create_user(req):
 - セキュアなデフォルトを備えた Swagger UI helper
 - 生成および検証ワークフローのための CLI ツール
 
+## CLI Quick Start
+
+デコレーターを適用した関数アプリから OpenAPI スペックを生成します。
+
+```bash
+# インストール
+pip install azure-functions-openapi
+
+# 関数アプリモジュールからスペックを生成（@openapi ルートを登録）
+azure-functions-openapi generate --app function_app --title "My API" --format json
+
+# 整形してファイルに出力
+azure-functions-openapi generate --app function_app --title "My API" --pretty --output openapi.json
+
+# YAML 出力
+azure-functions-openapi generate --app function_app --format yaml --output openapi.yaml
+```
+
+`module:variable` 形式を渡すと、`FunctionApp` インスタンスを解決し、`@validate_http` や `azure-functions-langgraph` などのプロデューサーが登録したエンドポイントメタデータのルートも検出して、`@openapi` ルートと 1 つのスペックにマージします。`module` のみを渡すと、CLI はモジュールをインポートし（`@openapi` デコレーターを実行）スペックを生成しますが、エンドポイントメタデータは検出しません。
+
+```bash
+azure-functions-openapi generate --app function_app:app --title "My API"
+```
+
+すべてのオプションと CI 統合の例は [CLI ガイド](docs/cli.md)を参照してください。
+
 ## Installation
 
 ```bash
@@ -107,6 +131,18 @@ Function App の依存関係には次を含めてください。
 azure-functions
 azure-functions-openapi
 ```
+
+## SDK Compatibility
+
+このパッケージは、`azure-functions` SDK からルート、メソッド、ハンドラーを 1 つの分離されたアダプター（`azure_functions_openapi.adapters`）を介して検出します。検出は **公開 API 優先** で、公開された冪等な `FunctionBuilder.build()` で列挙し、その他はすべて公開 `Function` アクセサー（`get_function_name` / `get_user_function` / `get_bindings` / `is_http_function`）を介して読み取ります。アダプターは冪等でない `FunctionApp.get_functions()` を決して呼び出しません。列挙に公開の代替手段がない **唯一** の非公開トークン `app._function_builders` のみがアダプター内部に分離され、必須のガードテストで保護されます。CI で明示的なマトリックスで検証します。経緯は [イシュー #258](https://github.com/yeongseon/azure-functions-openapi-python/issues/258) と [イシュー #327](https://github.com/yeongseon/azure-functions-openapi-python/issues/327) を参照してください。
+
+| `azure-functions` | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 | Python 3.14 |
+| ----------------- | :---------: | :---------: | :---------: | :---------: | :---------: |
+| `1.21.0`（下限）  | ✅ 検証済 |             |             |             |             |
+| `1.24.0`          | ✅ 検証済 |             |             |             |             |
+| `latest` (`<2.0`) | ✅ 検証済 | ✅ 検証済 | ✅ 検証済 | ✅ 検証済 | ✅ 検証済 |
+
+`pyproject.toml` のバージョンピンは `azure-functions>=1.21.0,<2.0.0` です。下限が `1.21.0` なのは、それ以前のリリースが `FunctionBuilder.__call__` から `None` を返すためです（テストと CLI 抽出でデコレートされたハンドラーの直接呼び出しが壊れる）。より新しい SDK が必要な場合はイシューを開いてください。上限を設けているのは、`azure-functions` 2.x が Python < 3.13 のサポートを廃止し、まだ `@openapi` で検証されていないためです。
 
 ## Quick Start
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -11,8 +11,6 @@
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> **Translation pending:** The CLI `--app module:variable` endpoint-metadata discovery section (#331) and the **SDK Compatibility** section (#332), added to the English [README.md](README.md), are not yet translated here. Tracking: [#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334).
-
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
 **Azure Functions Python v2 프로그래밍 모델**을 위한 OpenAPI(Swagger) 문서화와 Swagger UI를 제공합니다.
@@ -95,6 +93,32 @@ def create_user(req):
 - 보안 기본값이 포함된 Swagger UI helper
 - 생성 및 검증 워크플로를 위한 CLI 도구
 
+## CLI Quick Start
+
+데코레이터가 적용된 함수 앱에서 OpenAPI 스펙을 생성합니다.
+
+```bash
+# 설치
+pip install azure-functions-openapi
+
+# 함수 앱 모듈에서 스펙 생성 (@openapi 라우트 등록)
+azure-functions-openapi generate --app function_app --title "My API" --format json
+
+# 예쁘게 출력하여 파일로 저장
+azure-functions-openapi generate --app function_app --title "My API" --pretty --output openapi.json
+
+# YAML 출력
+azure-functions-openapi generate --app function_app --format yaml --output openapi.yaml
+```
+
+`module:variable` 형식을 전달하면 `FunctionApp` 인스턴스를 확인하고, `@validate_http`나 `azure-functions-langgraph` 같은 프로듀서가 등록한 엔드포인트 메타데이터 라우트까지 함께 검색하여 `@openapi` 라우트와 하나의 스펙으로 병합합니다. `module`만 전달하면 CLI가 모듈을 임포트하여(`@openapi` 데코레이터 실행) 스펙을 생성하지만 엔드포인트 메타데이터는 검색하지 않습니다.
+
+```bash
+azure-functions-openapi generate --app function_app:app --title "My API"
+```
+
+모든 옵션과 CI 통합 예제는 [CLI 가이드](docs/cli.md)를 참고하세요.
+
 ## Installation
 
 ```bash
@@ -107,6 +131,18 @@ Function App 의존성에는 다음이 포함되어야 합니다.
 azure-functions
 azure-functions-openapi
 ```
+
+## SDK Compatibility
+
+이 패키지는 `azure-functions` SDK에서 라우트, 메서드, 핸들러를 하나의 격리된 어댑터(`azure_functions_openapi.adapters`)를 통해 검색합니다. 검색은 **공개 API 우선**으로, 공개적이고 멱등한 `FunctionBuilder.build()`로 열거하며 나머지는 모두 공개 `Function` 접근자(`get_function_name` / `get_user_function` / `get_bindings` / `is_http_function`)를 통해 읽습니다. 어댑터는 멱등하지 않은 `FunctionApp.get_functions()`를 절대 호출하지 않습니다. 열거에 공개 대체 수단이 없는 **유일한** 비공개 토큰 `app._function_builders`만 어댑터 내부에 격리되어 있으며 필수 가드 테스트로 보호됩니다. CI에서 명시적 매트릭스로 검증합니다. 배경은 [이슈 #258](https://github.com/yeongseon/azure-functions-openapi-python/issues/258)과 [이슈 #327](https://github.com/yeongseon/azure-functions-openapi-python/issues/327)을 참고하세요.
+
+| `azure-functions` | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 | Python 3.14 |
+| ----------------- | :---------: | :---------: | :---------: | :---------: | :---------: |
+| `1.21.0` (최소)   | ✅ 테스트됨 |             |             |             |             |
+| `1.24.0`          | ✅ 테스트됨 |             |             |             |             |
+| `latest` (`<2.0`) | ✅ 테스트됨 | ✅ 테스트됨 | ✅ 테스트됨 | ✅ 테스트됨 | ✅ 테스트됨 |
+
+`pyproject.toml`의 버전 핀은 `azure-functions>=1.21.0,<2.0.0`입니다. 최소 버전이 `1.21.0`인 이유는 그 이전 릴리스가 `FunctionBuilder.__call__`에서 `None`을 반환하기 때문입니다(테스트와 CLI 추출에서 데코레이트된 핸들러의 직접 호출이 깨짐). 더 새로운 SDK가 필요하면 이슈를 열어 주세요. 상한을 둔 이유는 `azure-functions` 2.x가 Python < 3.13 지원을 중단하며 아직 `@openapi`로 검증되지 않았기 때문입니다.
 
 ## Quick Start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,8 +11,6 @@
 [![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> **翻译待处理：** CLI 的 `--app module:variable` 端点元数据发现部分（#331）和 **SDK 兼容性** 部分（#332）已添加到英文 [README.md](README.md)，但尚未翻译。跟踪：[#334](https://github.com/yeongseon/azure-functions-openapi-python/issues/334)。
-
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
 
 为 **Azure Functions Python v2 编程模型**提供 OpenAPI（Swagger）文档生成和 Swagger UI。
@@ -95,6 +93,32 @@ def create_user(req):
 - 带有安全默认值的 Swagger UI helper
 - 用于生成和校验工作流的 CLI 工具
 
+## CLI Quick Start
+
+从应用了装饰器的函数应用生成 OpenAPI 规范：
+
+```bash
+# 安装
+pip install azure-functions-openapi
+
+# 从函数应用模块生成规范（注册 @openapi 路由）
+azure-functions-openapi generate --app function_app --title "My API" --format json
+
+# 美化输出并写入文件
+azure-functions-openapi generate --app function_app --title "My API" --pretty --output openapi.json
+
+# YAML 输出
+azure-functions-openapi generate --app function_app --format yaml --output openapi.yaml
+```
+
+传入 `module:variable` 会解析 `FunctionApp` 实例，并同时发现由 `@validate_http` 或 `azure-functions-langgraph` 等生产者注册的端点元数据路由，将它们与你的 `@openapi` 路由合并为单一规范。仅传入 `module` 时，CLI 会导入模块（触发 `@openapi` 装饰器）生成规范，但不会扫描端点元数据。
+
+```bash
+azure-functions-openapi generate --app function_app:app --title "My API"
+```
+
+有关所有选项和 CI 集成示例，请参阅 [CLI 指南](docs/cli.md)。
+
 ## Installation
 
 ```bash
@@ -107,6 +131,18 @@ pip install azure-functions-openapi
 azure-functions
 azure-functions-openapi
 ```
+
+## SDK Compatibility
+
+本包通过单一隔离适配器（`azure_functions_openapi.adapters`）从 `azure-functions` SDK 发现路由、方法和处理器。发现采用 **公共 API 优先** 策略：通过公共、幂等的 `FunctionBuilder.build()` 枚举，其余内容均通过公共 `Function` 访问器（`get_function_name` / `get_user_function` / `get_bindings` / `is_http_function`）读取。适配器绝不调用非幂等的 `FunctionApp.get_functions()`。枚举时没有公共替代方案的 **唯一** 非公开令牌 `app._function_builders` 仅驻留在适配器内部，并由强制守卫测试覆盖。我们在 CI 中使用明确的矩阵进行验证。背景请参阅 [问题 #258](https://github.com/yeongseon/azure-functions-openapi-python/issues/258) 和 [问题 #327](https://github.com/yeongseon/azure-functions-openapi-python/issues/327)。
+
+| `azure-functions` | Python 3.10 | Python 3.11 | Python 3.12 | Python 3.13 | Python 3.14 |
+| ----------------- | :---------: | :---------: | :---------: | :---------: | :---------: |
+| `1.21.0`（下限）  | ✅ 已测试 |             |             |             |             |
+| `1.24.0`          | ✅ 已测试 |             |             |             |             |
+| `latest` (`<2.0`) | ✅ 已测试 | ✅ 已测试 | ✅ 已测试 | ✅ 已测试 | ✅ 已测试 |
+
+`pyproject.toml` 中的版本锁定为 `azure-functions>=1.21.0,<2.0.0`。下限为 `1.21.0` 是因为更早的版本会从 `FunctionBuilder.__call__` 返回 `None`（会破坏测试和 CLI 提取中对装饰处理器的直接调用）。如果你需要更新的 SDK，请提交问题；设置上限是有意为之，因为 `azure-functions` 2.x 放弃了对 Python < 3.13 的支持，且尚未针对 `@openapi` 进行验证。
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Syncs the three translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) with the English `README.md`:

- Adds the **CLI Quick Start** section covering `generate --app module:variable` endpoint-metadata discovery (from #331 / #326).
- Adds the **SDK Compatibility** section (adapter/public-API-first discovery notes and the version matrix, from #332).
- Removes the now-resolved "translation pending" notes that pointed here.

## Verification

- `make lint` passes (ruff + mypy clean).
- Section headings mirror the English source; version matrix and issue links preserved verbatim.

Closes #334