### PR TITLE
fix(spec): isolate report warnings to injected registry

### DIFF
--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -773,15 +773,17 @@ class SpecReport:
     warnings: tuple[SpecWarning, ...] = field(default_factory=tuple)
 
 
-def _collect_skew_warnings() -> list[SpecWarning]:
+def _collect_skew_warnings(registry: OpenAPIRegistry | None = None) -> list[SpecWarning]:
     """Derive skew warnings from ``_skew_flags`` recorded on registry entries.
 
     The bridge scanner tags entries at scan time; this re-derives structured
     warnings from a registry snapshot deterministically (entries sorted by key,
-    codes already stored in sorted order) with no global accumulator.
+    codes already stored in sorted order) with no global accumulator. When
+    ``registry`` is provided its snapshot is used instead of the global one, so
+    warnings stay isolated to the same registry the spec was built from.
     """
     collected: list[SpecWarning] = []
-    snapshot = get_openapi_registry()
+    snapshot = registry.snapshot() if registry is not None else get_openapi_registry()
     for key, entry in sorted(snapshot.items()):
         flags = entry.get("_skew_flags") or []
         function_name = entry.get("function_name") or key
@@ -805,6 +807,7 @@ def generate_openapi_report(
     security_schemes: dict[str, dict[str, Any]] | None = None,
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
     strict: bool = False,
+    registry: OpenAPIRegistry | None = None,
 ) -> SpecReport:
     """Generate the spec together with structured, machine-readable warnings.
 
@@ -827,12 +830,15 @@ def generate_openapi_report(
         security_schemes=security_schemes,
         route_prefix=route_prefix,
         strict=strict,
+        registry=registry,
     )
-    warnings_list = collect_spec_warnings(spec)
+    warnings_list = collect_spec_warnings(spec, registry=registry)
     return SpecReport(spec=spec, warnings=warnings_list)
 
 
-def collect_spec_warnings(spec: dict[str, Any]) -> tuple[SpecWarning, ...]:
+def collect_spec_warnings(
+    spec: dict[str, Any], registry: OpenAPIRegistry | None = None
+) -> tuple[SpecWarning, ...]:
     """Derive the deterministic warning tuple for an already-generated spec.
 
     Combines scan-time skew signals (version skew, namespace fallback, ambiguous
@@ -842,11 +848,14 @@ def collect_spec_warnings(spec: dict[str, Any]) -> tuple[SpecWarning, ...]:
 
     Parameters:
         spec: The generated OpenAPI document to validate.
+        registry: Optional injected registry whose snapshot the skew warnings
+            are derived from. Defaults to the process-wide global registry so
+            the warnings match the spec built from that same registry.
 
     Returns:
         A deterministic tuple of :class:`SpecWarning`.
     """
-    warnings_list: list[SpecWarning] = _collect_skew_warnings()
+    warnings_list: list[SpecWarning] = _collect_skew_warnings(registry)
     for message in _validate_spec(spec):
         warnings_list.append(SpecWarning(code=WarningCode.SPEC_VALIDATION, message=message))
     return tuple(warnings_list)

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -19,7 +19,9 @@ from azure_functions_openapi._warnings import SpecWarning, WarningCode
 from azure_functions_openapi.bridge import scan_endpoint_metadata
 from azure_functions_openapi.cli import handle_generate
 from azure_functions_openapi.decorator import clear_openapi_registry
+from azure_functions_openapi.registry import OpenAPIRegistry
 from azure_functions_openapi.spec import (
+    collect_spec_warnings,
     generate_openapi_report,
     generate_openapi_spec,
 )
@@ -178,6 +180,54 @@ class TestGenerateReport:
         first = generate_openapi_report().warnings
         second = generate_openapi_report().warnings
         assert first == second
+
+
+# ---------------------------------------------------------------------------
+# #344: injected-registry isolation for report/warnings
+# ---------------------------------------------------------------------------
+
+
+class TestReportRegistryIsolation:
+    """Report/warnings must honor an injected registry and never leak skew
+    warnings from a polluted global registry (#344)."""
+
+    @staticmethod
+    def _clean_registry() -> OpenAPIRegistry:
+        isolated = OpenAPIRegistry()
+        isolated.set(
+            "get::/api/isolated",
+            {
+                "function_name": "isolated",
+                "route": "isolated",
+                "method": "get",
+                "response": {"200": {"description": "OK"}},
+            },
+        )
+        return isolated
+
+    def test_report_ignores_global_skew_when_registry_injected(self) -> None:
+        # Pollute the global registry with version-skew + namespace fallback.
+        scan_endpoint_metadata(_make_app(_skewed_namespaces()))
+        # Sanity: the default (global) path surfaces the skew.
+        global_codes = {w.code for w in generate_openapi_report().warnings}
+        assert WarningCode.VERSION_SKEW in global_codes
+        # An injected clean registry must not inherit the global skew.
+        report = generate_openapi_report(registry=self._clean_registry())
+        isolated_codes = {w.code for w in report.warnings}
+        assert WarningCode.VERSION_SKEW not in isolated_codes
+        assert WarningCode.NAMESPACE_FALLBACK not in isolated_codes
+
+    def test_collect_spec_warnings_honors_injected_registry(self) -> None:
+        scan_endpoint_metadata(_make_app(_skewed_namespaces()))
+        isolated = self._clean_registry()
+        spec = generate_openapi_spec(registry=isolated)
+        isolated_codes = {w.code for w in collect_spec_warnings(spec, registry=isolated)}
+        assert WarningCode.VERSION_SKEW not in isolated_codes
+        assert WarningCode.NAMESPACE_FALLBACK not in isolated_codes
+        # Without injection, the same spec still reflects the global skew.
+        assert any(
+            w.code == WarningCode.VERSION_SKEW for w in collect_spec_warnings(spec)
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context
`generate_openapi_report` accepted no registry and its internal warning
collectors (`collect_spec_warnings` / `_collect_skew_warnings`) always read
the process-wide global registry via `get_openapi_registry()`. When a spec
was built from an explicitly injected registry, the surfaced warnings still
came from the polluted global registry, so warnings could disagree with the
spec they were meant to describe.

## Changes
- `_collect_skew_warnings(registry=None)` derives skew warnings from
  `registry.snapshot()` when a registry is injected, else the global one.
- `collect_spec_warnings(spec, registry=None)` threads the registry through.
- `generate_openapi_report(..., registry=None)` passes the registry to both
  `generate_openapi_spec` and `collect_spec_warnings`.

## Tests
- New `TestReportRegistryIsolation` (2 tests): an injected clean registry
  does not inherit global version-skew / namespace-fallback warnings, while
  the default global path still surfaces them.
- `make check-all`: 589 passed, 28 skipped; bandit clean.

Closes #344