### PR TITLE
fix(cli): fail --fail-on-warnings before writing output

### DIFF
--- a/src/azure_functions_openapi/cli.py
+++ b/src/azure_functions_openapi/cli.py
@@ -243,6 +243,11 @@ def handle_generate(args: argparse.Namespace) -> int:
                     _json.dumps(warning.to_dict(), ensure_ascii=False),
                     file=sys.stderr,
                 )
+        # --fail-on-warnings gate: short-circuit BEFORE writing any artifact,
+        # so a wrong-but-plausible spec is never emitted (warnings were already
+        # surfaced to stderr above for CI to parse).
+        if getattr(args, "fail_on_warnings", False) is True and warnings:
+            return 2
         # Check for empty paths before serialising — gives a clear signal
         # instead of silently producing a spec with no routes.
         if not spec.get("paths"):
@@ -273,8 +278,6 @@ def handle_generate(args: argparse.Namespace) -> int:
         else:
             print(content)
 
-        if getattr(args, "fail_on_warnings", False) is True and warnings:
-            return 2
         return 0
     except OpenAPISpecConfigError as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -276,3 +276,20 @@ class TestCliFailOnWarnings:
     def test_returns_zero_without_warnings_even_with_flag(self) -> None:
         scan_endpoint_metadata(_make_app(_clean_namespaces()))
         assert handle_generate(_args(fail_on_warnings=True)) == 0
+
+    def test_fail_on_warnings_does_not_write_output(self, tmp_path: Any) -> None:
+        # The gate must short-circuit BEFORE the artifact is written, so a
+        # wrong-but-plausible spec is never emitted (#345).
+        scan_endpoint_metadata(_make_app(_skewed_namespaces()))
+        out = tmp_path / "openapi.json"
+        rc = handle_generate(_args(fail_on_warnings=True, output=str(out)))
+        assert rc == 2
+        assert not out.exists()
+
+    def test_output_written_when_flag_absent(self, tmp_path: Any) -> None:
+        # Without the gate, warnings do not block the artifact.
+        scan_endpoint_metadata(_make_app(_skewed_namespaces()))
+        out = tmp_path / "openapi.json"
+        rc = handle_generate(_args(fail_on_warnings=False, output=str(out)))
+        assert rc == 0
+        assert out.exists()


### PR DESCRIPTION
## Context
`--fail-on-warnings` is a CI gate meant to stop a wrong-but-plausible spec from
being published. But the CLI wrote the `--output` artifact **before** evaluating
the gate, so `generate --fail-on-warnings -o openapi.json` with warnings present
still created `openapi.json` **and** exited `2`.

## Change
Move the gate to short-circuit immediately after warnings are surfaced to stderr
(before the empty-paths check, serialization, and output write):

```
generate → collect + print warnings → (warnings && --fail-on-warnings ? exit 2 : write output)
```

## Tests
- `test_fail_on_warnings_does_not_write_output`: exit `2` **and** output file not created.
- `test_output_written_when_flag_absent`: warnings present, no flag → exit `0`, file written.
- `make check-all`: all passed; bandit clean.

Closes #345