### PR TITLE
fix(spec): scope all-method expansion to routes with binding evidence

### DIFF
--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -43,17 +43,22 @@ def _resolve_metadata_target(func: Any) -> tuple[Any, Callable[..., Any]]:
     return func, cast(Callable[..., Any], func)
 
 
-def _extract_binding_hints(func: Any) -> tuple[str | None, str | None, bool]:
+def _extract_binding_hints(func: Any) -> tuple[str | None, str | None, bool, bool]:
     """Extract route and method from a FunctionBuilder's HTTP trigger binding.
 
-    Returns ``(route, method, multiple_methods)`` where:
+    Returns ``(route, method, multiple_methods, methods_unspecified)`` where:
     - ``route`` and ``method`` may each be ``None`` if not available.
     - ``multiple_methods`` is ``True`` when the binding declares more than one
       HTTP method; in that case ``method`` is ``None`` and the caller must
       require an explicit ``method=`` argument from the user.
+    - ``methods_unspecified`` is ``True`` only when an ``httptrigger`` binding
+      is present but omits ``methods=`` entirely. This is the sole evidence
+      that the Azure runtime will answer *every* HTTP method, so it gates the
+      all-method expansion in the spec generator (a bare ``@openapi`` with no
+      binding must NOT expand).
     """
     if not adapters.is_function_builder(func):
-        return None, None, False
+        return None, None, False, False
 
     function = adapters.build_function(func)
     bindings = adapters.get_bindings(function)
@@ -70,14 +75,15 @@ def _extract_binding_hints(func: Any) -> tuple[str | None, str | None, bool]:
             binding_method = methods_attr.lower()
         elif isinstance(methods_attr, (list, tuple)):
             if len(methods_attr) > 1:
-                return binding_route, None, True  # ambiguous — caller must require explicit method
+                # ambiguous — caller must require an explicit method=
+                return binding_route, None, True, False
             if methods_attr:
                 val = methods_attr[0]
                 binding_method = str(getattr(val, "value", val)).lower()
 
-        return binding_route, binding_method, False
+        return binding_route, binding_method, False, binding_method is None
 
-    return None, None, False
+    return None, None, False, False
 
 
 def openapi(
@@ -168,7 +174,11 @@ def openapi(
     route:
         Override for the HTTP route path (e.g. "/items/{id}").
     method:
-        Explicit HTTP method if not inferrable.
+        Explicit HTTP method for this operation. When omitted, the method is
+        inferred from the ``@app.route`` binding: a single ``methods=`` value is
+        used directly, and a binding that omits ``methods=`` expands to every
+        HTTP method (matching the Azure runtime). A bare ``@openapi`` with no
+        route binding and no ``method=`` emits a single ``get`` operation.
     parameters:
         List of param objects (query/path/header/cookie).
     security:
@@ -222,7 +232,9 @@ def openapi(
             # not explicitly provided by the caller.
             effective_route = route
             effective_method = method
-            binding_route, binding_method, binding_multi = _extract_binding_hints(func)
+            binding_route, binding_method, binding_multi, binding_methods_unspecified = (
+                _extract_binding_hints(func)
+            )
             if effective_route is None and binding_route is not None:
                 effective_route = binding_route
             if effective_method is None:
@@ -235,6 +247,12 @@ def openapi(
                         "Pass method=... explicitly to @openapi, "
                         "or create a separate @openapi-decorated function per method."
                     )
+
+            # All-method expansion (see spec generator) is only justified when a
+            # real httptrigger binding is present but omits ``methods=``; a bare
+            # @openapi with no binding leaves the method unresolved and must emit
+            # a single operation instead of fanning out to every HTTP verb (#347).
+            expand_all_methods = effective_method is None and binding_methods_unspecified
 
             # Enhanced input validation and sanitization
             validated_route = _validate_and_sanitize_route(effective_route, metadata_func.__name__)
@@ -333,6 +351,11 @@ def openapi(
                     # ── routing info ─────────────────────────────────────────
                     "route": validated_route,
                     "method": validated_method,
+                    # Evidence that the runtime answers every HTTP method
+                    # (binding present, ``methods=`` omitted). Gates all-method
+                    # expansion in the spec generator; a bare @openapi stays
+                    # single-operation (#347).
+                    "_expand_all_methods": expand_all_methods,
                     "parameters": validated_parameters,
                     "security": validated_security,
                     "security_scheme": validated_security_scheme,

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -302,14 +302,21 @@ def generate_openapi_spec(
                 # route & method --------------------------------------------------
                 raw_path = f"/{(meta.get('route') or logical_name).lstrip('/')}"
                 path = apply_route_prefix(raw_path, normalized_prefix)
-                # An unspecified method (``None``) means the Azure runtime
-                # responds to every HTTP method, so expand to the full set to
-                # match the endpoint-metadata scan path. An explicit method is
-                # emitted as a single operation, unchanged.
+                # An unspecified method (``None``) expands to the full HTTP set
+                # ONLY when there is binding evidence that the Azure runtime
+                # answers every method (an ``@app.route`` binding that omits
+                # ``methods=``), recorded as ``_expand_all_methods`` at
+                # registration. A bare ``@openapi`` with no binding leaves the
+                # method unresolved and emits a single ``get`` operation, and an
+                # explicit method is emitted as a single operation, unchanged.
                 raw_method = meta.get("method")
                 if raw_method is None:
-                    methods_to_emit = list(ALL_HTTP_METHODS)
-                    methods_expanded = True
+                    if meta.get("_expand_all_methods"):
+                        methods_to_emit = list(ALL_HTTP_METHODS)
+                        methods_expanded = True
+                    else:
+                        methods_to_emit = ["get"]
+                        methods_expanded = False
                 else:
                     methods_to_emit = [str(raw_method).lower()]
                     methods_expanded = False

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -353,9 +353,9 @@ def test_openapi_spec_contains_operation_id_and_tags() -> None:
     spec = json.loads(get_openapi_json())
     item = spec["paths"]["/api/http_trigger"]["get"]
 
-    # method= is unspecified, so #335 expands to all HTTP methods and suffixes
-    # the explicit operation_id per method to keep operationIds unique.
-    assert item["operationId"] == "greetUser_get"
+    # #347: bare @openapi (no route binding) emits a single GET operation, so
+    # the explicit operation_id is used verbatim without a method suffix.
+    assert item["operationId"] == "greetUser"
     assert item["tags"] == ["Example"]
     assert "HTTP Trigger with name parameter" in item["summary"]
     assert "### Usage" in item["description"]

--- a/tests/test_openapi_spec.py
+++ b/tests/test_openapi_spec.py
@@ -36,9 +36,11 @@ def test_openapi_spec_http_trigger_metadata() -> None:
     http_get = spec["paths"]["/api/http_trigger"]["get"]
 
     # Basic metadata
-    # method= unspecified -> #335 expands to all methods with per-method-unique
-    # operationIds (explicit operation_id suffixed by method).
-    assert http_get["operationId"] == "greetUser_get"
+    # #347: bare @openapi (no route binding, no method=) emits a single GET
+    # operation, so the explicit operation_id is used verbatim (no method suffix).
+    assert http_get["operationId"] == "greetUser"
+    # Only the single GET operation is emitted (no all-method expansion).
+    assert set(spec["paths"]["/api/http_trigger"]) == {"get"}
     assert http_get["tags"] == ["Example"]
     assert http_get["summary"] == "HTTP Trigger with name parameter"
 

--- a/tests/test_register_metadata.py
+++ b/tests/test_register_metadata.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
+import azure.functions as func
 from pydantic import BaseModel
 import pytest
 
@@ -331,17 +332,31 @@ def test_register_request_model_and_request_body_raises() -> None:
         )
 
 
-def test_spec_expands_unspecified_method_to_all_http_methods() -> None:
-    # #335: @openapi without method= must produce one operation per HTTP method
-    # (the Azure runtime responds to all methods when methods= is omitted),
-    # not a single GET operation.
+def test_spec_bare_openapi_without_binding_stays_single_get() -> None:
+    # #347: a bare @openapi with no @app.route binding and no method= has no
+    # evidence that the runtime answers every method, so it must emit a single
+    # GET operation rather than fanning out to all seven HTTP verbs.
     @openapi(route="/api/hello", summary="Hello")
     def hello() -> None:  # pragma: no cover - registration only
         ...
 
     spec = generate_openapi_spec()
-    path_item = spec["paths"]["/api/hello"]
-    assert set(path_item) == {
+    assert set(spec["paths"]["/api/hello"]) == {"get"}
+
+
+def test_spec_expands_unspecified_method_with_route_binding() -> None:
+    # #335/#347: @openapi over an @app.route that omits methods= DOES carry
+    # binding evidence that the runtime answers every method, so it expands to
+    # one operation per HTTP method.
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    @openapi(route="/api/hello", summary="Hello")
+    @app.route(route="hello")
+    def hello(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("OK", status_code=200)
+
+    spec = generate_openapi_spec()
+    assert set(spec["paths"]["/api/hello"]) == {
         "get",
         "post",
         "put",
@@ -353,11 +368,14 @@ def test_spec_expands_unspecified_method_to_all_http_methods() -> None:
 
 
 def test_spec_expanded_methods_omit_body_on_get_head_delete() -> None:
-    # #335 policy 1: a body-carrying @openapi with unspecified method expands to
-    # all methods but must not attach requestBody to GET/HEAD/DELETE.
+    # #335 policy 1: a body-carrying route whose binding omits methods= expands
+    # to all methods but must not attach requestBody to GET/HEAD/DELETE.
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
     @openapi(route="/api/thing", request_model=DemoRequestModel)
-    def thing() -> None:  # pragma: no cover - registration only
-        ...
+    @app.route(route="thing")
+    def thing(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("OK", status_code=200)
 
     spec = generate_openapi_spec()
     path_item = spec["paths"]["/api/thing"]
@@ -377,12 +395,15 @@ def test_spec_explicit_method_stays_single_operation() -> None:
 
 def test_spec_expanded_methods_keep_unique_operation_ids() -> None:
     # #335 regression: an explicit operation_id on an unspecified-method route
-    # must not be reused verbatim across every expanded operation (duplicate
-    # operationIds are invalid and error under strict=True). Each emitted
-    # operation is suffixed with its method to stay unique.
+    # (binding present, methods= omitted) must not be reused verbatim across
+    # every expanded operation (duplicate operationIds are invalid and error
+    # under strict=True). Each emitted operation is suffixed with its method.
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
     @openapi(route="/api/dup", operation_id="myOp")
-    def dup() -> None:  # pragma: no cover - registration only
-        ...
+    @app.route(route="dup")
+    def dup(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("OK", status_code=200)
 
     spec = generate_openapi_spec()
     path_item = spec["paths"]["/api/dup"]

--- a/tests/test_sdk_compat.py
+++ b/tests/test_sdk_compat.py
@@ -94,7 +94,7 @@ def test_resolve_metadata_target_returns_original_and_callable() -> None:
 
 def test_extract_binding_hints_reads_route_and_method_from_real_binding() -> None:
     """``_extract_binding_hints`` must read the httptrigger binding produced
-    by the current SDK and return ``(route, method, multiple_methods)``.
+    by the current SDK and return ``(route, method, multiple_methods, methods_unspecified)``.
 
     This exercises the full integration between the SDK's binding shape
     (``binding.type``, ``binding.route``, ``binding.methods``) and our
@@ -106,10 +106,11 @@ def test_extract_binding_hints_reads_route_and_method_from_real_binding() -> Non
     def update_item(req: func.HttpRequest) -> func.HttpResponse:
         return func.HttpResponse("OK", status_code=200)
 
-    route, method, multi = _extract_binding_hints(update_item)
+    route, method, multi, unspecified = _extract_binding_hints(update_item)
     assert route == "items/{id}"
     assert method == "put"
     assert multi is False
+    assert unspecified is False
 
 
 def test_extract_binding_hints_signals_multiple_methods_from_real_binding() -> None:
@@ -126,7 +127,25 @@ def test_extract_binding_hints_signals_multiple_methods_from_real_binding() -> N
     def collection(req: func.HttpRequest) -> func.HttpResponse:
         return func.HttpResponse("OK", status_code=200)
 
-    route, method, multi = _extract_binding_hints(collection)
+    route, method, multi, unspecified = _extract_binding_hints(collection)
     assert route == "collection"
     assert method is None
     assert multi is True
+    assert unspecified is False
+
+
+def test_extract_binding_hints_flags_unspecified_methods_from_real_binding() -> None:
+    """``_extract_binding_hints`` must set ``methods_unspecified`` when an
+    httptrigger binding omits ``methods=`` entirely — the sole evidence that
+    justifies all-method expansion in the spec generator (#347)."""
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    @app.route(route="anymethod")
+    def anymethod(req: func.HttpRequest) -> func.HttpResponse:
+        return func.HttpResponse("OK", status_code=200)
+
+    route, method, multi, unspecified = _extract_binding_hints(anymethod)
+    assert route == "anymethod"
+    assert method is None
+    assert multi is False
+    assert unspecified is True


### PR DESCRIPTION
## Context
#339 expanded an unspecified method to the full HTTP set whenever
`meta["method"]` was `None`. But the condition had **no binding-evidence check**,
so a bare `@openapi(route=...)` with no `@app.route` binding expanded from
**1 operation to 7** (`get/post/put/delete/patch/head/options`). The
"runtime answers every method" justification only holds when an `@app.route`
binding omits `methods=` — with no binding there is no such evidence; the user
merely omitted `method=`.

## Change (preferred direction — scope to binding evidence)
- `_extract_binding_hints` now returns a 4th flag `methods_unspecified`, `True`
  only when an httptrigger binding is present **and** omits `methods=`.
- The `@openapi` decorator records `_expand_all_methods` on the registry entry,
  set only when the method is unresolved **and** that binding evidence exists.
- `spec.py` expands to `ALL_HTTP_METHODS` only when `_expand_all_methods` is set;
  a bare `@openapi` with no binding emits a single `get`; explicit methods are
  unchanged.
- Refreshed the stale `method` parameter docstring (was "Explicit HTTP method if
  not inferrable").

## Tests
- `test_spec_bare_openapi_without_binding_stays_single_get` — no binding → `{get}`.
- `test_spec_expands_unspecified_method_with_route_binding` — `@app.route` w/o
  `methods=` → all 7 verbs (exercises `head`/`options` in-repo).
- Body-omission and unique-operationId expansion tests re-pointed to real
  bindings; `_extract_binding_hints` gains a `methods_unspecified` assertion.
- `make check-all`: 593 passed, 28 skipped; bandit clean.

Closes #347