### PR TITLE
feat(warnings): surface skipped unbuildable functions as a discovery warning

### DIFF
--- a/src/azure_functions_openapi/_warnings.py
+++ b/src/azure_functions_openapi/_warnings.py
@@ -31,6 +31,7 @@ class WarningCode(str, Enum):
     AMBIGUOUS_NAMESPACE = "ambiguous-namespace"
     DUPLICATE_OPERATION = "duplicate-operation"
     SPEC_VALIDATION = "spec-validation"
+    DISCOVERY_SKIPPED = "discovery-skipped"
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return self.value

--- a/src/azure_functions_openapi/adapters/azure_functions.py
+++ b/src/azure_functions_openapi/adapters/azure_functions.py
@@ -37,6 +37,7 @@ See issue #325 for the full rationale and empirical reproduction.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import logging
 from typing import Any, cast
 
@@ -79,7 +80,9 @@ def build_function(builder: Any, auth_level: Any = None) -> Function:
         ) from exc
 
 
-def iter_functions(app: Any) -> list[Function]:
+def iter_functions(
+    app: Any, on_skip: Callable[[str | None, str], None] | None = None
+) -> list[Function]:
     """Enumerate the built ``Function`` objects registered on *app*.
 
     Enumerates via the SDK-private ``_function_builders`` list (the only
@@ -95,6 +98,11 @@ def iter_functions(app: Any) -> list[Function]:
     logged at debug and omitted rather than aborting the whole scan. Returns an
     empty list when *app* exposes no builders (e.g. an app with no registered
     functions), matching the previous "skip quietly" behaviour.
+
+    When *on_skip* is provided it is invoked as ``on_skip(function_name, reason)``
+    for each skipped builder (name is best-effort and may be ``None`` when the
+    pre-build name is unavailable), letting callers record the omission as a
+    structured warning instead of losing it to a debug log.
     """
     builders = getattr(app, "_function_builders", None)
     if not builders:
@@ -106,7 +114,32 @@ def iter_functions(app: Any) -> list[Function]:
             functions.append(build_function(builder, auth_level))
         except ValueError as exc:  # no trigger / trigger not in bindings
             _logger.debug("Skipping unbuildable function during discovery: %s", exc)
+            if on_skip is not None:
+                on_skip(_best_effort_builder_name(builder), str(exc))
     return functions
+
+
+def _best_effort_builder_name(builder: Any) -> str | None:
+    """Best-effort function name for a builder that failed to build.
+
+    A builder whose ``build()`` raises never produces a ``Function``, so the
+    public per-function accessors are unavailable. The name a user assigned via
+    ``@function_name`` still lives on the builder's ``_function``; this reads it
+    defensively for the sole purpose of attributing a ``discovery-skipped``
+    warning. It is the one place besides ``_function_builders`` enumeration that
+    reaches for a private token, and only for an already-skipped builder — every
+    lookup is guarded and falls back to ``None`` so a shape change never breaks
+    discovery; the skip is still recorded, just without a name.
+    """
+    function = getattr(builder, "_function", None)
+    getter = getattr(function, "get_function_name", None)
+    if not callable(getter):
+        return None
+    try:
+        name = getter()
+    except Exception:  # pragma: no cover - defensive; name is best-effort only
+        return None
+    return str(name) if name is not None else None
 
 
 def get_function_name(function: Any) -> str:

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -457,7 +457,9 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
     (default ``"/api"``). Pass ``""`` for hosts that disable the prefix or
     a custom value such as ``"/v1"`` to match a non-default deployment.
     """
-    functions = adapters.iter_functions(app)
+    functions = adapters.iter_functions(
+        app, on_skip=lambda name, reason: registry.add_discovery_warning(name, reason)
+    )
     if not functions:
         logger.debug("No function builders found on app; skipping validation scan")
         return

--- a/src/azure_functions_openapi/registry.py
+++ b/src/azure_functions_openapi/registry.py
@@ -29,6 +29,7 @@ class OpenAPIRegistry:
 
     def __init__(self) -> None:
         self._entries: dict[str, dict[str, Any]] = {}
+        self._discovery_warnings: list[tuple[str | None, str]] = []
         self._lock = threading.RLock()
 
     @property
@@ -93,6 +94,7 @@ class OpenAPIRegistry:
         """Remove all entries, under :attr:`lock`."""
         with self._lock:
             self._entries.clear()
+            self._discovery_warnings.clear()
 
     def find_by_function_id(self, function_id: str) -> dict[str, Any] | None:
         """Return the entry whose ``_function_id`` equals *function_id*.
@@ -122,6 +124,25 @@ class OpenAPIRegistry:
                 for entry in self._entries.values()
                 if entry.get("function_name") == function_name
             )
+
+    def add_discovery_warning(self, function_name: str | None, reason: str) -> None:
+        """Record that a function builder was skipped during discovery.
+
+        The adapter enumeration path (:func:`iter_functions`) skips any builder
+        whose ``build()`` raises ``ValueError`` (a user-app state such as a
+        trigger missing from its bindings). Historically that skip was only
+        logged at debug and vanished; recording it here lets the spec generator
+        surface a structured ``discovery-skipped`` warning so CI can notice that
+        an endpoint silently fell out of the spec.
+        """
+        with self._lock:
+            self._discovery_warnings.append((function_name, reason))
+
+    @property
+    def discovery_warnings(self) -> list[tuple[str | None, str]]:
+        """Return a copy of the recorded ``(function_name, reason)`` skips."""
+        with self._lock:
+            return list(self._discovery_warnings)
 
 
 # Process-wide singleton. The ``@openapi`` decorator records metadata at import

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -762,6 +762,10 @@ _SKEW_MESSAGES: dict[WarningCode, str] = {
         "Validation metadata could not be merged: the short function name is "
         "shared across modules. Registered a standalone endpoint instead."
     ),
+    WarningCode.DISCOVERY_SKIPPED: (
+        "A function builder could not be built during discovery and was omitted "
+        "from the spec; its trigger may be missing from its bindings."
+    ),
 }
 
 
@@ -804,6 +808,29 @@ def _collect_skew_warnings(registry: OpenAPIRegistry | None = None) -> list[Spec
                 )
             )
     return collected
+
+
+def _collect_discovery_warnings(
+    registry: OpenAPIRegistry | None = None,
+) -> list[SpecWarning]:
+    """Derive discovery-skipped warnings from the registry's recorded skips.
+
+    The scan adapter records every function builder it could not build (see
+    :meth:`OpenAPIRegistry.add_discovery_warning`); this turns each recorded
+    ``(function_name, reason)`` into a structured :class:`SpecWarning` so a
+    silently omitted endpoint is observable to CI. When ``registry`` is provided
+    its skips are used, keeping warnings isolated to the same registry the spec
+    was built from; otherwise the process-wide global registry is consulted.
+    """
+    reg = registry if registry is not None else _default_registry
+    return [
+        SpecWarning(
+            code=WarningCode.DISCOVERY_SKIPPED,
+            message=_SKEW_MESSAGES[WarningCode.DISCOVERY_SKIPPED],
+            function_name=function_name,
+        )
+        for function_name, _reason in reg.discovery_warnings
+    ]
 
 
 def generate_openapi_report(
@@ -863,6 +890,7 @@ def collect_spec_warnings(
         A deterministic tuple of :class:`SpecWarning`.
     """
     warnings_list: list[SpecWarning] = _collect_skew_warnings(registry)
+    warnings_list.extend(_collect_discovery_warnings(registry))
     for message in _validate_spec(spec):
         warnings_list.append(SpecWarning(code=WarningCode.SPEC_VALIDATION, message=message))
     return tuple(warnings_list)

--- a/tests/test_sdk_compat_adapter.py
+++ b/tests/test_sdk_compat_adapter.py
@@ -269,6 +269,37 @@ def test_iter_functions_skips_builder_that_fails_to_build() -> None:
     assert names == ["healthy"]
 
 
+def test_iter_functions_reports_skipped_builder_via_on_skip() -> None:
+    """A skipped builder is surfaced through the ``on_skip`` callback (#346).
+
+    Skipping keeps the scan alive (regression #337), but the omission must not
+    vanish silently: ``iter_functions`` invokes ``on_skip(name, reason)`` for
+    each unbuildable builder so callers can record a structured warning. The
+    best-effort name comes from the public ``function_name`` decorator.
+    """
+    app = func.FunctionApp(http_auth_level=func.AuthLevel.ANONYMOUS)
+
+    @app.route(route="healthy", methods=["GET"])
+    def healthy(req: func.HttpRequest) -> func.HttpResponse:
+        return func.HttpResponse("OK", status_code=200)
+
+    @app.function_name(name="orphan")  # builder with no trigger decorator
+    def orphan(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("nope")
+
+    skipped: list[tuple[str | None, str]] = []
+    functions = adapters.iter_functions(app, on_skip=lambda n, r: skipped.append((n, r)))
+
+    assert [adapters.get_function_name(fn) for fn in functions] == ["healthy"]
+    assert len(skipped) == 1
+    name, reason = skipped[0]
+    assert name == "orphan"
+    assert reason
+
+    names = [adapters.get_function_name(fn) for fn in functions]
+    assert names == ["healthy"]
+
+
 @pytest.mark.parametrize("bad_type", ["queueTrigger", "timerTrigger", ""])
 def test_extract_http_binding_ignores_non_http_triggers(bad_type: str) -> None:
     """Only httpTrigger bindings are returned; other trigger types yield None."""

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -72,7 +72,7 @@ class MockBuilder:
 
 
 class MockApp:
-    def __init__(self, builders: list[MockBuilder]) -> None:
+    def __init__(self, builders: list[Any]) -> None:
         self._function_builders = builders
 
 
@@ -227,6 +227,64 @@ class TestReportRegistryIsolation:
         # Without injection, the same spec still reflects the global skew.
         assert any(
             w.code == WarningCode.VERSION_SKEW for w in collect_spec_warnings(spec)
+        )
+
+
+# ---------------------------------------------------------------------------
+# #346: discovery-skipped warnings for unbuildable function builders
+# ---------------------------------------------------------------------------
+
+
+class _UnbuildableBuilder:
+    """Mimics a FunctionBuilder whose build() raises (e.g. a trigger-less
+    function) so the adapter skips it during discovery."""
+
+    def __init__(self, name: str) -> None:
+        # Mirror the real FunctionBuilder, which holds the pre-build name on a
+        # private ``_function`` (the only place a failed builder's name lives).
+        self._function = MockFunction(name=name, func=lambda req: req, bindings=[])
+
+    def build(self, auth_level: Any = None) -> Any:
+        raise ValueError(
+            f"Function {self._function.get_function_name()} does not have a trigger"
+        )
+
+
+class TestDiscoverySkippedWarnings:
+    """An unbuildable builder must surface a structured discovery-skipped
+    warning without aborting the scan (#346)."""
+
+    def test_skipped_builder_surfaces_discovery_warning(self) -> None:
+        app = _make_app(_clean_namespaces())
+        # Append a trigger-less builder alongside the valid one.
+        app._function_builders.append(_UnbuildableBuilder("orphan"))
+
+        scan_endpoint_metadata(app)
+        report = generate_openapi_report()
+
+        skipped = [
+            w for w in report.warnings if w.code == WarningCode.DISCOVERY_SKIPPED
+        ]
+        assert len(skipped) == 1
+        assert skipped[0].function_name == "orphan"
+        # The valid endpoint is still present in the spec (scan not aborted).
+        assert report.spec["paths"]
+
+    def test_discovery_warning_honors_injected_registry(self) -> None:
+        app = _make_app(_clean_namespaces())
+        app._function_builders.append(_UnbuildableBuilder("orphan"))
+        scan_endpoint_metadata(app)
+        # An injected clean registry has recorded no skips of its own.
+        isolated = OpenAPIRegistry()
+        spec = generate_openapi_spec(registry=isolated)
+        isolated_codes = {
+            w.code for w in collect_spec_warnings(spec, registry=isolated)
+        }
+        assert WarningCode.DISCOVERY_SKIPPED not in isolated_codes
+        # The global path still reports the skip.
+        assert any(
+            w.code == WarningCode.DISCOVERY_SKIPPED
+            for w in collect_spec_warnings(spec)
         )
 
 


### PR DESCRIPTION
## Summary

- Adds `WarningCode.DISCOVERY_SKIPPED` so a function silently dropped during discovery becomes an observable, structured warning.
- The discovery adapter still skips a builder whose `build()` raises `ValueError` (keeps #338's scan-don't-crash behavior), but now reports each skip via a new `on_skip(function_name, reason)` callback instead of only a debug log.
- The bridge scan wires `on_skip` to record the skip on the **scanned registry** (`OpenAPIRegistry.add_discovery_warning`), so injected-registry callers only ever see their own discovery warnings — consistent with #344's registry-scoped warnings.
- `collect_spec_warnings` / `generate_openapi_report` now surface these as `DISCOVERY_SKIPPED` warnings, so `--fail-on-warnings` can gate a build on an incomplete spec.

## Notes

- Best-effort function name for a *failed* builder is read defensively from the builder's private `_function` (the only place a pre-build name lives); every lookup is guarded and falls back to `None`, so an SDK shape change never breaks discovery.

## Testing

- `make check-all` (596 passed, coverage 96%+, ruff + mypy + bandit clean)
- New adapter test: `on_skip` fires with name + reason for a trigger-less builder.
- New end-to-end tests: unbuildable builder yields a `DISCOVERY_SKIPPED` warning without aborting the scan, and the warning honors an injected registry.

Closes #346