### PR TITLE
fix(warnings): carry reason, dedupe, and harden discovery-skipped warning

### DIFF
--- a/src/azure_functions_openapi/adapters/azure_functions.py
+++ b/src/azure_functions_openapi/adapters/azure_functions.py
@@ -22,15 +22,19 @@ Two SDK facts shape this module:
    calling the *public*, idempotent :meth:`FunctionBuilder.build`. ``build`` runs
    the guarded, apply-once ``_validate_function`` and returns the *same*
    ``Function`` instance on every call, without touching ``functions_bindings``.
-   ``_function_builders`` is thus the one — and only — SDK-private token we keep,
-   and it lives exclusively in this module. ``Blueprint`` is a ``DecoratorApi``
-   and exposes ``_function_builders`` identically, so raw Blueprints, registered
-   Blueprints, and ``FunctionApp`` instances all enumerate through this one path.
+   ``_function_builders`` is the primary SDK-private token we keep, and it lives
+   exclusively in this module. ``Blueprint`` is a ``DecoratorApi`` and exposes
+   ``_function_builders`` identically, so raw Blueprints, registered Blueprints,
+   and ``FunctionApp`` instances all enumerate through this one path.
 
 2. **Per-function reads are entirely public.** Once a builder is built into a
    ``Function``, the name, user handler, bindings, HTTP-ness, and trigger are all
    available through documented public accessors — no ``_function`` / ``_func`` /
-   ``_bindings`` access is required anywhere.
+   ``_bindings`` access is required for a built function. The **one** exception is
+   :func:`_best_effort_builder_name`, which reads a *failed* builder's
+   ``_function`` solely to attribute a ``discovery-skipped`` warning (a builder
+   that never built exposes no public name); that read is guarded and falls back
+   to ``None``. See its docstring for the rationale.
 
 See issue #325 for the full rationale and empirical reproduction.
 """

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -457,6 +457,12 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
     (default ``"/api"``). Pass ``""`` for hosts that disable the prefix or
     a custom value such as ``"/v1"`` to match a non-default deployment.
     """
+    # Discovery skips are recorded on the *global* ``registry`` because this scan
+    # registers entries there too (see ``register_openapi_metadata`` below), so
+    # the skips and entries stay in the same registry. NOTE: if this function
+    # ever gains a ``registry`` parameter, route ``on_skip`` to that registry as
+    # well — otherwise discovery warnings would leak to / be read from the wrong
+    # registry, the exact mirror of the bug #344 fixed for skew warnings.
     functions = adapters.iter_functions(
         app, on_skip=lambda name, reason: registry.add_discovery_warning(name, reason)
     )

--- a/src/azure_functions_openapi/registry.py
+++ b/src/azure_functions_openapi/registry.py
@@ -134,16 +134,29 @@ class OpenAPIRegistry:
         logged at debug and vanished; recording it here lets the spec generator
         surface a structured ``discovery-skipped`` warning so CI can notice that
         an endpoint silently fell out of the spec.
+
+        Identical ``(function_name, reason)`` skips are deduplicated so repeated
+        scans (e.g. an app and its Blueprint, or a module re-import) do not spam
+        the same warning line — mirroring the idempotent merge of :attr:`entries`.
         """
         with self._lock:
-            self._discovery_warnings.append((function_name, reason))
+            record = (function_name, reason)
+            if record not in self._discovery_warnings:
+                self._discovery_warnings.append(record)
 
     @property
     def discovery_warnings(self) -> list[tuple[str | None, str]]:
-        """Return a copy of the recorded ``(function_name, reason)`` skips."""
-        with self._lock:
-            return list(self._discovery_warnings)
+        """Return the recorded ``(function_name, reason)`` skips, deduplicated.
 
+        The result is sorted deterministically (unnamed skips first, then by
+        name and reason) so downstream warning collection is reproducible, the
+        same guarantee :func:`_collect_skew_warnings` gives skew warnings.
+        """
+        with self._lock:
+            return sorted(
+                self._discovery_warnings,
+                key=lambda record: (record[0] is not None, record[0] or "", record[1]),
+            )
 
 # Process-wide singleton. The ``@openapi`` decorator records metadata at import
 # time — before any application object exists — so a shared instance is required.

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -762,11 +762,15 @@ _SKEW_MESSAGES: dict[WarningCode, str] = {
         "Validation metadata could not be merged: the short function name is "
         "shared across modules. Registered a standalone endpoint instead."
     ),
-    WarningCode.DISCOVERY_SKIPPED: (
-        "A function builder could not be built during discovery and was omitted "
-        "from the spec; its trigger may be missing from its bindings."
-    ),
 }
+
+# Discovery-skipped is not a skew signal, so its message lives outside
+# ``_SKEW_MESSAGES``. The recorded SDK ``reason`` (which itself names the
+# function) is appended by :func:`_collect_discovery_warnings` for attribution.
+_DISCOVERY_SKIPPED_MESSAGE = (
+    "A function builder could not be built during discovery and was omitted "
+    "from the spec"
+)
 
 
 @dataclass(frozen=True)
@@ -826,10 +830,10 @@ def _collect_discovery_warnings(
     return [
         SpecWarning(
             code=WarningCode.DISCOVERY_SKIPPED,
-            message=_SKEW_MESSAGES[WarningCode.DISCOVERY_SKIPPED],
+            message=f"{_DISCOVERY_SKIPPED_MESSAGE}: {reason}",
             function_name=function_name,
         )
-        for function_name, _reason in reg.discovery_warnings
+        for function_name, reason in reg.discovery_warnings
     ]
 
 

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -287,6 +287,36 @@ class TestDiscoverySkippedWarnings:
             for w in collect_spec_warnings(spec)
         )
 
+    def test_repeated_scans_do_not_duplicate_discovery_warning(self) -> None:
+        # Re-scanning the same app (idempotent like entry registration) must
+        # not accumulate duplicate discovery-skipped warnings (#352).
+        app = _make_app(_clean_namespaces())
+        app._function_builders.append(_UnbuildableBuilder("orphan"))
+
+        scan_endpoint_metadata(app)
+        scan_endpoint_metadata(app)
+        scan_endpoint_metadata(app)
+        report = generate_openapi_report()
+
+        skipped = [
+            w for w in report.warnings if w.code == WarningCode.DISCOVERY_SKIPPED
+        ]
+        assert len(skipped) == 1
+
+    def test_discovery_warning_message_carries_sdk_reason(self) -> None:
+        # The build() failure reason must be surfaced in the warning message so
+        # operators can act on it, not just a fixed generic string (#352).
+        app = _make_app(_clean_namespaces())
+        app._function_builders.append(_UnbuildableBuilder("orphan"))
+        scan_endpoint_metadata(app)
+        report = generate_openapi_report()
+
+        skipped = [
+            w for w in report.warnings if w.code == WarningCode.DISCOVERY_SKIPPED
+        ]
+        assert len(skipped) == 1
+        assert "does not have a trigger" in skipped[0].message
+
 
 # ---------------------------------------------------------------------------
 # CLI --fail-on-warnings exit-code gate


### PR DESCRIPTION
## Context

Follow-up hardening for the discovery-skipped warning shipped in #346 (PR #351). A 4th-round review surfaced three valid defects, all reproduced against the merged code:

1. `spec._collect_discovery_warnings` discarded the SDK build-failure reason and emitted only a fixed generic string, failing #346's acceptance ("with function name and reason").
2. `registry.add_discovery_warning` did a plain append, so repeated scans accumulated duplicate warnings (unlike function-id entry merging, which is idempotent).
3. The adapter module docstring claimed `_function_builders` was the "one and only" private SDK token read, but `_best_effort_builder_name` also reads `_function` — stale.

## Changes

- `registry`: dedupe on insert; `discovery_warnings` returns a stable sorted list.
- `spec`: split `DISCOVERY_SKIPPED` out of `_SKEW_MESSAGES` into a dedicated `_DISCOVERY_SKIPPED_MESSAGE`; `_collect_discovery_warnings` now carries the reason (`"<message>: <reason>"`) and iterates `(function_name, reason)`.
- `adapters/azure_functions`: docstring corrected re: private-token access in `_best_effort_builder_name`.
- `bridge.scan_endpoint_metadata`: documents the global-registry coupling as the mirror of the #344 skew-warning fix.

## Acceptance Checklist

- [x] Repeated scans yield exactly one warning per unique skip.
- [x] Warning message includes the SDK build-failure reason.
- [x] `make check-all` passes (598 passed, coverage gate met, bandit clean).

## References

- Closes #352
- Follows #346 / PR #351
- Mirrors #344

Closes #352
