### PR TITLE
fix(cli): move --fail-on-warnings gate after empty-paths hint

### DIFF
--- a/src/azure_functions_openapi/cli.py
+++ b/src/azure_functions_openapi/cli.py
@@ -243,11 +243,6 @@ def handle_generate(args: argparse.Namespace) -> int:
                     _json.dumps(warning.to_dict(), ensure_ascii=False),
                     file=sys.stderr,
                 )
-        # --fail-on-warnings gate: short-circuit BEFORE writing any artifact,
-        # so a wrong-but-plausible spec is never emitted (warnings were already
-        # surfaced to stderr above for CI to parse).
-        if getattr(args, "fail_on_warnings", False) is True and warnings:
-            return 2
         # Check for empty paths before serialising — gives a clear signal
         # instead of silently producing a spec with no routes.
         if not spec.get("paths"):
@@ -260,6 +255,14 @@ def handle_generate(args: argparse.Namespace) -> int:
             )
             if getattr(args, "fail_on_empty_paths", False) is True:
                 return 1
+
+        # --fail-on-warnings gate: short-circuit BEFORE writing any artifact,
+        # so a wrong-but-plausible spec is never emitted (warnings were already
+        # surfaced to stderr above for CI to parse). Placed AFTER the empty-paths
+        # block so its diagnostic hint still prints and --fail-on-empty-paths
+        # (exit 1) stays reachable when warnings and empty paths coincide.
+        if getattr(args, "fail_on_warnings", False) is True and warnings:
+            return 2
 
         if args.format == "json":
             import json

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -381,3 +381,24 @@ class TestCliFailOnWarnings:
         rc = handle_generate(_args(fail_on_warnings=False, output=str(out)))
         assert rc == 0
         assert out.exists()
+
+    def test_empty_paths_hint_survives_and_priority_preserved(
+        self, tmp_path: Any, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # #353: when warnings AND empty paths coincide, the --fail-on-warnings
+        # gate must not pre-empt the empty-paths diagnostic. The hint must still
+        # print, --fail-on-empty-paths must remain reachable (exit 1), and no
+        # artifact may be written.
+        app = MockApp([_UnbuildableBuilder("orphan")])
+        scan_endpoint_metadata(app)
+        out = tmp_path / "openapi.json"
+        rc = handle_generate(
+            _args(
+                fail_on_warnings=True,
+                fail_on_empty_paths=True,
+                output=str(out),
+            )
+        )
+        assert rc == 1
+        assert not out.exists()
+        assert "Hint: use --app" in capsys.readouterr().err


### PR DESCRIPTION
## Context

Follow-up to #345 (shipped in #349). The `--fail-on-warnings` exit-code gate landed one step too early — it short-circuited **before** the empty-paths diagnostic block in `cli.py::handle_generate`, causing two unintended effects:

1. The `Hint: use --app function_app:app` message — most useful to first-time users — disappeared whenever any warning was present.
2. Exit-code priority changed silently: with warnings + empty paths, `2` beat `1`, making `--fail-on-empty-paths` unreachable.

The empty-paths block only prints and returns (writes no artifact), so moving the warnings gate one step down preserves the "never write a suspect artifact" goal while restoring the hint and priority.

## Changes

- Move the `--fail-on-warnings` gate to after the empty-paths block, before serialization/write.

## Acceptance Checklist

- [x] Gate moved after empty-paths block, before serialization.
- [x] No artifact written when warnings are present.
- [x] Empty-paths hint still prints; `--fail-on-empty-paths` returns 1 in the combined case.
- [x] Regression test covers warnings + empty paths (no file, hint printed, exit 1).
- [x] `make check-all` passes (599 passed).

## References

- Shipped in #349 (issue #345).

Closes #353
