### PR TITLE
fix(spec): expand all-methods for @openapi below @app.route in recommended order

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -110,6 +110,37 @@ def _extract_methods(binding: Any) -> tuple[list[str], bool]:
     return ["get"], False
 
 
+def _reconcile_all_methods_expansion(function: Any, handler: Any) -> None:
+    """Set ``_expand_all_methods`` on an already-registered ``@openapi`` entry
+    when the SDK scan finds binding evidence the decorator lacked (#354).
+
+    In the README-recommended decorator order (``@app.route`` above
+    ``@openapi``), ``@openapi`` decorates the *raw* function before ``@app.route``
+    wraps it, so no HTTP-trigger binding is visible at decoration time and the
+    entry is registered without the all-method expansion flag (emitting only a
+    single ``get``). The scan, however, sees the fully wrapped builder: when it
+    carries an ``httptrigger`` binding that omits ``methods=`` we set the flag on
+    the matching entry here, restoring parity with the reverse order (which
+    records the flag at decoration time, #347/#350). Matching is by collision-
+    free canonical function id, and an explicit ``method=`` is never overridden.
+    """
+    binding = _extract_http_binding(function)
+    if binding is None:
+        return
+    _methods, methods_expanded = _extract_methods(binding)
+    if not methods_expanded:
+        return
+    canonical_id = canonical_function_id(handler)
+    with registry.lock:
+        target = registry.find_by_function_id(canonical_id)
+        if (
+            target is not None
+            and target.get("method") is None
+            and not target.get("_expand_all_methods")
+        ):
+            target["_expand_all_methods"] = True
+
+
 def _merge_parameters(
     existing: list[dict[str, Any]],
     discovered: list[dict[str, Any]],
@@ -478,6 +509,10 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
         endpoint_hints = _read_endpoint_hints(handler)
         metadata = None if endpoint_hints is not None else _read_validation_hints(handler)
         if endpoint_hints is None and metadata is None:
+            # Plain @openapi route (no endpoint/validation metadata): the main
+            # scan below does not revisit it, so reconcile all-method expansion
+            # from binding evidence the decorator could not see (#354).
+            _reconcile_all_methods_expansion(function, handler)
             continue
 
         handler_skew: set[WarningCode] = set()

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -273,6 +273,59 @@ def test_scan_omits_request_body_from_expanded_bodyless_methods() -> None:
         assert f"{method}::/api/users" in registry_keys
 
 
+def test_scan_reconciles_plain_openapi_recommended_order_expansion() -> None:
+    # #354: in the README-recommended order (@app.route above @openapi), @openapi
+    # decorates the raw function before @app.route wraps it, so no binding is
+    # visible at decoration time and the entry emits GET only. The scan sees the
+    # wrapped builder with an httptrigger binding that omits methods=, and must
+    # reconcile the entry to expand to every HTTP method — matching the reverse
+    # order — even though the handler carries no endpoint/validation metadata.
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="list things", route="things")
+    def things(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="things", methods=None, type="httpTrigger")
+    fn = MockFunction(_name="things", _func=things, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    spec = generate_openapi_spec("T", "1.0.0")
+
+    assert set(spec["paths"]["/api/things"].keys()) == {
+        "get",
+        "post",
+        "put",
+        "delete",
+        "patch",
+        "head",
+        "options",
+    }
+
+
+def test_scan_does_not_expand_plain_openapi_with_explicit_method() -> None:
+    # #354 guard: reconciliation must never override an explicit method. When the
+    # @openapi entry declares a method, an unspecified-methods binding does not
+    # trigger all-method expansion.
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="make thing", route="things", method="post")
+    def make_thing(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="things", methods=None, type="httpTrigger")
+    fn = MockFunction(_name="make_thing", _func=make_thing, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    spec = generate_openapi_spec("T", "1.0.0")
+
+    assert set(spec["paths"]["/api/things"].keys()) == {"post"}
+
+
 def test_scan_merges_explicit_function_name_entry() -> None:
     with _registry_lock:
         _openapi_registry["create_user"] = {


### PR DESCRIPTION
## Context

Follow-up to #347 (shipped #350), which correctly scoped all-method expansion to routes with binding evidence. That left the original narrowing bug (#339) intact for the **README-recommended** decorator order:

| Form | Before | After |
| --- | --- | --- |
| `@openapi` alone | `get` | `get` |
| `@openapi` above `@app.route` | 7 methods | 7 methods |
| `@app.route` above `@openapi`, `methods=` unspecified | **`get` only** | **7 methods** |
| `@app.route` + `@validate_http` | 7 methods | 7 methods |

In the recommended order, `@openapi` decorates the raw function before `@app.route` wraps it, so there is genuinely no binding evidence at decoration time and the spec emitted `get` only while the runtime served every method. The bridge scan skipped these routes because they carry no `endpoint`/`validation` metadata.

## Changes

- `bridge.scan_endpoint_metadata`: for a plain `@openapi` route (no endpoint/validation metadata), reconcile the already-registered entry from binding evidence — when an `httptrigger` binding omits `methods=` and the entry has no explicit method, set `_expand_all_methods`. Matching is by collision-free canonical function id; an explicit `method=` is never overridden.

## Acceptance Checklist

- [x] Recommended order + unspecified `methods=` now expands to all HTTP methods.
- [x] Explicit `method=` on the `@openapi` entry is never overridden (guard test).
- [x] Reverse-order binding-evidence gate from #350 unchanged.
- [x] Regression tests added; `make check-all` passes (601 passed).

## Out of scope

- #350's binding-evidence gate for the reverse order (correct as-is).

## References

- Original narrowing #339; binding-evidence scope #347 (shipped #350).

Closes #354
