### PR TITLE
fix(discovery): reconcile HTTP method for @openapi below @app.route

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 import copy
 import logging
-from typing import Any, get_origin
+from typing import Any, cast, get_origin
 import warnings
 
 from pydantic import BaseModel
@@ -114,15 +114,18 @@ def _reconcile_all_methods_expansion(function: Any, handler: Any) -> None:
     """Set ``_expand_all_methods`` on an already-registered ``@openapi`` entry
     when the SDK scan finds binding evidence the decorator lacked (#354).
 
-    In the README-recommended decorator order (``@app.route`` above
-    ``@openapi``), ``@openapi`` decorates the *raw* function before ``@app.route``
-    wraps it, so no HTTP-trigger binding is visible at decoration time and the
-    entry is registered without the all-method expansion flag (emitting only a
-    single ``get``). The scan, however, sees the fully wrapped builder: when it
-    carries an ``httptrigger`` binding that omits ``methods=`` we set the flag on
-    the matching entry here, restoring parity with the reverse order (which
-    records the flag at decoration time, #347/#350). Matching is by collision-
-    free canonical function id, and an explicit ``method=`` is never overridden.
+    Whichever decorator order is used, ``@openapi`` decorates the function
+    before the HTTP-trigger binding is observable, so the entry is registered
+    with ``method=None`` and without the all-method expansion flag (emitting
+    only a single ``get``). This is easiest to hit in the README-recommended
+    order (``@openapi`` above ``@app.route``), where ``@openapi`` wraps the
+    ``@app.route`` result but still cannot read the binding's ``methods=``. The
+    scan, however, sees the fully wrapped builder: when it carries an
+    ``httptrigger`` binding that omits ``methods=`` we set the flag on the
+    matching entry here, restoring parity with the entry the decorator would
+    have recorded had the binding been visible (#347/#350). Matching is by
+    collision-free canonical function id, and an explicit ``method=`` is never
+    overridden.
     """
     binding = _extract_http_binding(function)
     if binding is None:
@@ -538,6 +541,18 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
         path = _normalize_path(getattr(binding, "route", None), function_name, route_prefix)
         methods, methods_expanded = _extract_methods(binding)
 
+        # Resolve the canonical @openapi entry once (it does not vary per
+        # method). When @openapi decorates the handler BELOW @app.route, the
+        # decorator cannot see the HTTP binding and registers the entry with
+        # method=None. We must then explode that entry into one operation per
+        # bound method instead of merging every method into it, which would
+        # otherwise collapse the generated spec to a single GET (#358).
+        with registry.lock:
+            canonical_target = registry.find_by_function_id(canonical_id)
+        explode_canonical = (
+            canonical_target is not None and canonical_target.get("method") is None
+        )
+
         for method in methods:
             if endpoint_hints is not None:
                 discovered = _discovered_operation_from_endpoint(
@@ -558,6 +573,22 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
             entry_skew = set(handler_skew)
 
             with registry.lock:
+                if explode_canonical:
+                    # @openapi was applied BELOW @app.route, so its entry was
+                    # registered with method=None. Collapsing every bound
+                    # method into that single entry would make spec.py emit a
+                    # lone GET (#358). Instead, seed one per-method entry from
+                    # the @openapi metadata and merge the discovered operation
+                    # into it.
+                    seed = cast("dict[str, Any]", canonical_target)
+                    clone = copy.deepcopy(seed)
+                    clone["method"] = method
+                    _merge_into_existing(clone, discovered)
+                    if methods_expanded and method in BODYLESS_HTTP_METHODS:
+                        clone["request_body"] = None
+                    _tag_skew(clone, entry_skew)
+                    registry.set(endpoint_key, clone)
+                    continue
                 # Resolve the target entry by, in order of trust:
                 #   1. canonical callable identity (collision-free),
                 #   2. the OpenAPI endpoint key (method::path),
@@ -623,6 +654,17 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
                 registered = registry.get(endpoint_key)
                 if registered is not None:
                     _tag_skew(registered, entry_skew)
+
+        # After exploding a method=None @openapi entry into per-method entries,
+        # drop the original so spec.py does not additionally emit it as a bare
+        # GET duplicate (#358). Match by identity: find_by_function_id returns
+        # the live entry but not its registry key.
+        if explode_canonical:
+            with registry.lock:
+                for key, entry in list(registry.entries.items()):
+                    if entry is canonical_target:
+                        del registry.entries[key]
+                        break
 
 
 def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -> None:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -274,12 +274,13 @@ def test_scan_omits_request_body_from_expanded_bodyless_methods() -> None:
 
 
 def test_scan_reconciles_plain_openapi_recommended_order_expansion() -> None:
-    # #354: in the README-recommended order (@app.route above @openapi), @openapi
-    # decorates the raw function before @app.route wraps it, so no binding is
-    # visible at decoration time and the entry emits GET only. The scan sees the
+    # #354: whichever decorator order is used, @openapi decorates the function
+    # before the HTTP-trigger binding is observable, so the entry is registered
+    # with method=None and emits GET only. This is easiest to hit in the
+    # README-recommended order (@openapi above @app.route). The scan sees the
     # wrapped builder with an httptrigger binding that omits methods=, and must
-    # reconcile the entry to expand to every HTTP method — matching the reverse
-    # order — even though the handler carries no endpoint/validation metadata.
+    # reconcile the entry to expand to every HTTP method — even though the
+    # handler carries no endpoint/validation metadata.
     from azure_functions_openapi.decorator import openapi
     from azure_functions_openapi.spec import generate_openapi_spec
 
@@ -324,6 +325,138 @@ def test_scan_does_not_expand_plain_openapi_with_explicit_method() -> None:
     spec = generate_openapi_spec("T", "1.0.0")
 
     assert set(spec["paths"]["/api/things"].keys()) == {"post"}
+
+
+def test_scan_reconciles_method_for_openapi_below_route_post() -> None:
+    # #358: when @openapi sits BELOW @app.route, it decorates the raw function
+    # and registers with method=None (no binding visible). The scan sees the
+    # POST binding and must explode the method=None entry into a per-method
+    # entry — otherwise every method collapses into a lone GET.
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="create thing", route="things")
+    def make_thing(req: Any) -> Any:
+        return req
+
+    setattr(make_thing, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="things", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="make_thing", _func=make_thing, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    registry = get_openapi_registry()
+    # The original method=None short-name entry must be gone; only the
+    # per-method entry remains.
+    assert "make_thing" not in registry
+    assert "post::/api/things" in registry
+    entry = registry["post::/api/things"]
+    assert entry["method"] == "post"
+    assert entry["summary"] == "create thing"
+    assert entry["request_body"] is not None
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"]["/api/things"].keys()) == {"post"}
+
+
+def test_scan_reconciles_method_for_openapi_below_route_unspecified_expands() -> None:
+    # #358: an unspecified-methods binding below @openapi expands to every HTTP
+    # method, with GET/HEAD/DELETE stripped of the request body.
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="any thing", route="things")
+    def any_thing(req: Any) -> Any:
+        return req
+
+    setattr(any_thing, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="things", methods=None, type="httpTrigger")
+    fn = MockFunction(_name="any_thing", _func=any_thing, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    registry = get_openapi_registry()
+    assert "any_thing" not in registry
+    for method in ("get", "head", "delete"):
+        assert registry[f"{method}::/api/things"]["request_body"] is None
+    for method in ("post", "put", "patch"):
+        assert registry[f"{method}::/api/things"]["request_body"] is not None
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"]["/api/things"].keys()) == {
+        "get",
+        "post",
+        "put",
+        "delete",
+        "patch",
+        "head",
+        "options",
+    }
+
+
+def test_scan_reconciles_method_for_openapi_below_route_multi_method() -> None:
+    # #358: an explicit multi-method binding below @openapi produces one entry
+    # per method (not a single collapsed GET).
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="rw thing", route="things")
+    def rw_thing(req: Any) -> Any:
+        return req
+
+    setattr(rw_thing, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="things", methods=["GET", "POST"], type="httpTrigger")
+    fn = MockFunction(_name="rw_thing", _func=rw_thing, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"]["/api/things"].keys()) == {"get", "post"}
+
+
+def test_scan_below_route_is_idempotent_across_repeated_scans() -> None:
+    # #358: re-running the scan must not duplicate or drop per-method entries.
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="idem thing", route="things")
+    def idem_thing(req: Any) -> Any:
+        return req
+
+    setattr(idem_thing, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="things", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="idem_thing", _func=idem_thing, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    scan_endpoint_metadata(app)
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"]["/api/things"].keys()) == {"post"}
+
+
+def test_scan_below_route_does_not_override_explicit_openapi_method() -> None:
+    # #358 guard: an explicit method= on @openapi must never be exploded or
+    # overridden by the binding — the entry keeps its declared method.
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="explicit thing", route="things", method="put")
+    def explicit_thing(req: Any) -> Any:
+        return req
+
+    setattr(explicit_thing, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="things", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="explicit_thing", _func=explicit_thing, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"]["/api/things"].keys()) == {"put"}
 
 
 def test_scan_merges_explicit_function_name_entry() -> None:


### PR DESCRIPTION
## Summary
- When `@openapi` is applied **below** `@app.route`, the decorator cannot see the HTTP binding and registers the entry with `method=None`. The scan then merged **every** bound method into that single entry, collapsing the generated spec to a lone `GET` — dropping `POST` request bodies, `422` responses, and multi-method paths. Adding `@openapi` actually made the spec *worse* than the validation-only baseline.
- Fix: explode the `method=None` `@openapi` entry into one per-method entry (seeded from the `@openapi` metadata, merged with the discovered operation), then remove the original short-name entry so `spec.py` does not additionally emit a bare `GET` duplicate.
- Explicit `method=` is never overridden; unspecified `methods=` still expands to all HTTP verbs with `GET`/`HEAD`/`DELETE` bodies stripped.
- Also corrected a reversed comment that labeled `@app.route` above `@openapi` as the "README-recommended order" — the README consistently shows `@openapi` **above** `@app.route`.

## Behavior (before → after)
| Decorator order (top→bottom) | binding methods | before | after |
|---|---|---|---|
| `@app.route(POST)` / `@validate_http` / `@openapi` | `["POST"]` | get only, no body | **post + requestBody + 422** |
| `@app.route()` (unspecified) / `@validate_http` / `@openapi` | `None` | get only | **all 7 verbs, GET/HEAD/DELETE bodyless** |
| `@app.route(GET,POST)` / `@validate_http` / `@openapi` | `["GET","POST"]` | get only | **get + post** |
| `@openapi` / `@app.route(POST)` (README order) | `["POST"]` | post | post (unchanged) |

## Tests
- Added regression tests for POST-below-route, unspecified expansion (bodyless GET/HEAD/DELETE), multi-method, scan idempotency, and the explicit-`method=` guard.
- `make check-all` passes (ruff + mypy + bandit + pytest, coverage 96%).

Closes #358