### PR TITLE
fix(bridge): preserve binding route when exploding @openapi below @app.route

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -540,6 +540,10 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
 
         path = _normalize_path(getattr(binding, "route", None), function_name, route_prefix)
         methods, methods_expanded = _extract_methods(binding)
+        # Raw binding route (prefix NOT applied): spec.py re-applies the route
+        # prefix to meta["route"] via apply_route_prefix, so storing the already
+        # normalized ``path`` (which includes the prefix) would double-prefix.
+        raw_route = getattr(binding, "route", None)
 
         # Resolve the canonical @openapi entry once (it does not vary per
         # method). When @openapi decorates the handler BELOW @app.route, the
@@ -583,6 +587,13 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
                     seed = cast("dict[str, Any]", canonical_target)
                     clone = copy.deepcopy(seed)
                     clone["method"] = method
+                    # Preserve the binding route on the clone. The decorator
+                    # could not see the binding, so @openapi registered
+                    # route=None; without this, spec.py falls back to the
+                    # function name and emits the wrong path (#360). An explicit
+                    # @openapi(route=...) stays truthy and is never overwritten.
+                    if clone.get("route") is None and raw_route:
+                        clone["route"] = raw_route
                     _merge_into_existing(clone, discovered)
                     if methods_expanded and method in BODYLESS_HTTP_METHODS:
                         clone["request_body"] = None

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -459,6 +459,54 @@ def test_scan_below_route_does_not_override_explicit_openapi_method() -> None:
     assert set(spec["paths"]["/api/things"].keys()) == {"put"}
 
 
+def test_scan_below_route_preserves_binding_route_when_name_differs() -> None:
+    # #360: the explode branch must carry the binding route onto each clone.
+    # @openapi below @app.route registers route=None; without preservation the
+    # spec falls back to the function name and emits the wrong path. Uses a
+    # route that can never equal the function name (real-world case).
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="create user")
+    def handler_one(req: Any) -> Any:
+        return req
+
+    setattr(handler_one, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="users/create", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_one", _func=handler_one, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    registry = get_openapi_registry()
+    assert registry["post::/api/users/create"]["route"] == "users/create"
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    # Correct binding-derived path, NOT /api/handler_one, and not double-prefixed.
+    assert set(spec["paths"].keys()) == {"/api/users/create"}
+    assert set(spec["paths"]["/api/users/create"].keys()) == {"post"}
+
+
+def test_scan_below_route_preserves_explicit_openapi_route_override() -> None:
+    # #360: an explicit @openapi(route=...) must win over the binding route.
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="create user", route="custom/path")
+    def handler_three(req: Any) -> Any:
+        return req
+
+    setattr(handler_three, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="users/create", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_three", _func=handler_three, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"].keys()) == {"/api/custom/path"}
+
+
 def test_scan_merges_explicit_function_name_entry() -> None:
     with _registry_lock:
         _openapi_registry["create_user"] = {


### PR DESCRIPTION
## Summary
- The per-method explode from #358/#359 deep-copied the `@openapi` decorator's `route=None` and only overwrote `method`. The correctly computed path reached the registry **key** (`post::/api/users/create`) but never the entry, so `spec.py` fell back to the **function name** — emitting `/api/handler_one` instead of `/api/users/create` whenever the binding route differs from the function name (the common case: `users/create`, `orders/{id}`).
- Fix: carry the **raw** binding route onto each clone when the entry `route` is `None`. Raw (unprefixed) is stored deliberately because `spec.py` re-applies the prefix via `apply_route_prefix`; storing the already-normalized `path` would double-prefix. Explicit `@openapi(route=...)` stays truthy and is never overwritten.

## Why #359 tests missed it
Those tests set `@openapi(route="things")` explicitly, so `route` was never `None`. Real routes can't equal the function name, so the defect is the common case. New regression tests use **route != function name**.

## Tests
- `test_scan_below_route_preserves_binding_route_when_name_differs` — `@app.route(route="users/create")` + `def handler_one` → spec `/api/users/create` (not `/api/handler_one`, not double-prefixed).
- `test_scan_below_route_preserves_explicit_openapi_route_override` — explicit `@openapi(route="custom/path")` wins over the binding.
- `make check-all` green (ruff + mypy + bandit + pytest, coverage >= 95%).

Closes #360