### PR TITLE
fix(bridge): infer route+method for plain @openapi and flag binding mismatch

### DIFF
--- a/src/azure_functions_openapi/_warnings.py
+++ b/src/azure_functions_openapi/_warnings.py
@@ -32,6 +32,7 @@ class WarningCode(str, Enum):
     DUPLICATE_OPERATION = "duplicate-operation"
     SPEC_VALIDATION = "spec-validation"
     DISCOVERY_SKIPPED = "discovery-skipped"
+    METHOD_BINDING_MISMATCH = "method-binding-mismatch"
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return self.value

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -110,38 +110,78 @@ def _extract_methods(binding: Any) -> tuple[list[str], bool]:
     return ["get"], False
 
 
-def _reconcile_all_methods_expansion(function: Any, handler: Any) -> None:
-    """Set ``_expand_all_methods`` on an already-registered ``@openapi`` entry
-    when the SDK scan finds binding evidence the decorator lacked (#354).
+def _reconcile_openapi_binding(
+    function: Any, handler: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX
+) -> None:
+    """Reconcile a plain ``@openapi`` entry with the HTTP binding the decorator
+    could not see (#354/#358/#360/#361).
 
-    Whichever decorator order is used, ``@openapi`` decorates the function
-    before the HTTP-trigger binding is observable, so the entry is registered
-    with ``method=None`` and without the all-method expansion flag (emitting
-    only a single ``get``). This is easiest to hit in the README-recommended
-    order (``@openapi`` above ``@app.route``), where ``@openapi`` wraps the
-    ``@app.route`` result but still cannot read the binding's ``methods=``. The
-    scan, however, sees the fully wrapped builder: when it carries an
-    ``httptrigger`` binding that omits ``methods=`` we set the flag on the
-    matching entry here, restoring parity with the entry the decorator would
-    have recorded had the binding been visible (#347/#350). Matching is by
-    collision-free canonical function id, and an explicit ``method=`` is never
-    overridden.
+    A plain ``@openapi`` handler (no endpoint/validation metadata) is skipped by
+    the main scan loop, so any binding evidence must be reconciled here.
+    Whichever decorator order is used, ``@openapi`` decorates the function before
+    the HTTP-trigger binding is observable, so the entry is registered with
+    ``method=None`` and ``route=None``. This is easiest to hit in the
+    README-recommended order (``@openapi`` above ``@app.route``), where
+    ``@openapi`` wraps the ``@app.route`` result but still cannot read the
+    binding. The scan, however, sees the fully wrapped builder.
+
+    For a ``method=None`` entry we therefore explode it into one operation per
+    bound method and set the raw binding route (prefix NOT applied; spec.py
+    re-applies the prefix), mirroring the metadata-carrying scan path so the
+    ``@openapi``-only user gets the correct route and method(s) instead of a lone
+    ``get`` at the function name (#361). Matching is by collision-free canonical
+    function id.
+
+    An explicit ``@openapi(method=...)`` is authoritative and never overridden;
+    in that case we only stamp the binding's method set on the entry so spec.py
+    can flag a method/binding mismatch (#362). An explicit ``@openapi(route=...)``
+    is likewise preserved.
     """
     binding = _extract_http_binding(function)
     if binding is None:
         return
-    _methods, methods_expanded = _extract_methods(binding)
-    if not methods_expanded:
-        return
     canonical_id = canonical_function_id(handler)
+    methods, methods_expanded = _extract_methods(binding)
+    raw_route = getattr(binding, "route", None)
+    # Unspecified binding methods (expanded to every verb) are not stamped:
+    # the runtime answers every method, so no explicit method can contradict it.
+    binding_methods = None if methods_expanded else list(methods)
     with registry.lock:
         target = registry.find_by_function_id(canonical_id)
-        if (
-            target is not None
-            and target.get("method") is None
-            and not target.get("_expand_all_methods")
-        ):
-            target["_expand_all_methods"] = True
+        if target is None:
+            return
+        if target.get("method") is not None:
+            # Explicit @openapi(method=...) wins; do not explode. Stamp the
+            # binding method set so spec.py can surface a mismatch (#362).
+            if binding_methods is not None:
+                target["_binding_methods"] = binding_methods
+            return
+        # method=None @openapi entry: infer route + method(s) from the binding.
+        route_for_key = target.get("route") or raw_route
+        function_name = target.get("function_name") or adapters.get_function_name(function)
+        path = _normalize_path(route_for_key, function_name, route_prefix)
+        # Locate the original method=None entry by identity (find_by_function_id
+        # returns the live entry but not its registry key) so it can be dropped
+        # after exploding, avoiding a stray bare-GET duplicate.
+        original_key = None
+        for key, entry in registry.entries.items():
+            if entry is target:
+                original_key = key
+                break
+        for method in methods:
+            clone = copy.deepcopy(target)
+            clone["method"] = method
+            # Preserve the binding route when @openapi registered route=None; an
+            # explicit @openapi(route=...) stays truthy and is never overwritten.
+            if clone.get("route") is None and raw_route:
+                clone["route"] = raw_route
+            # Drop the body from GET/HEAD/DELETE when methods= was unspecified
+            # (auto-expanded): OpenAPI leaves such a body semantically undefined.
+            if methods_expanded and method in BODYLESS_HTTP_METHODS:
+                clone["request_body"] = None
+            registry.set(f"{method}::{path}", clone)
+        if original_key is not None and registry.entries.get(original_key) is target:
+            del registry.entries[original_key]
 
 
 def _merge_parameters(
@@ -513,9 +553,9 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
         metadata = None if endpoint_hints is not None else _read_validation_hints(handler)
         if endpoint_hints is None and metadata is None:
             # Plain @openapi route (no endpoint/validation metadata): the main
-            # scan below does not revisit it, so reconcile all-method expansion
-            # from binding evidence the decorator could not see (#354).
-            _reconcile_all_methods_expansion(function, handler)
+            # scan below does not revisit it, so reconcile route + method(s)
+            # from binding evidence the decorator could not see (#354/#361).
+            _reconcile_openapi_binding(function, handler, route_prefix)
             continue
 
         handler_skew: set[WarningCode] = set()

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -768,8 +768,16 @@ _SKEW_MESSAGES: dict[WarningCode, str] = {
 # ``_SKEW_MESSAGES``. The recorded SDK ``reason`` (which itself names the
 # function) is appended by :func:`_collect_discovery_warnings` for attribution.
 _DISCOVERY_SKIPPED_MESSAGE = (
-    "A function builder could not be built during discovery and was omitted "
-    "from the spec"
+"A function builder could not be built during discovery and was omitted "
+"from the spec"
+)
+
+# Method/binding mismatch is authored disagreement, not a skew signal: an
+# explicit ``@openapi(method=...)`` names a verb the HTTP binding does not serve,
+# so the generated operation cannot be reached at runtime.
+_METHOD_BINDING_MISMATCH_MESSAGE = (
+    "The explicit @openapi(method=...) is not served by the function's HTTP "
+    "binding; the generated operation cannot be reached at runtime"
 )
 
 
@@ -837,6 +845,40 @@ def _collect_discovery_warnings(
     ]
 
 
+def _collect_binding_mismatch_warnings(
+    registry: OpenAPIRegistry | None = None,
+) -> list[SpecWarning]:
+    """Derive method/binding mismatch warnings from stamped registry entries.
+
+    The bridge scanner stamps ``_binding_methods`` (the binding's method set) on
+    entries whose method was set by an explicit ``@openapi(method=...)`` rather
+    than inferred from the binding. When that explicit method is absent from the
+    binding's served verbs the generated operation is unreachable at runtime, so
+    a :class:`WarningCode.METHOD_BINDING_MISMATCH` is surfaced. Entries with an
+    unspecified binding (no ``_binding_methods`` stamp) are never flagged: the
+    runtime answers every verb, so nothing can contradict the authored method.
+    Ordering is deterministic (entries sorted by registry key).
+    """
+    collected: list[SpecWarning] = []
+    snapshot = registry.snapshot() if registry is not None else get_openapi_registry()
+    for key, entry in sorted(snapshot.items()):
+        binding_methods = entry.get("_binding_methods")
+        if not binding_methods:
+            continue
+        method = entry.get("method")
+        if method is None:
+            continue
+        if str(method).lower() in {str(m).lower() for m in binding_methods}:
+            continue
+        collected.append(
+            SpecWarning(
+                code=WarningCode.METHOD_BINDING_MISMATCH,
+                message=_METHOD_BINDING_MISMATCH_MESSAGE,
+                function_name=entry.get("function_name") or key,
+            )
+        )
+    return collected
+
 def generate_openapi_report(
     title: str = "API",
     version: str = "1.0.0",
@@ -895,6 +937,7 @@ def collect_spec_warnings(
     """
     warnings_list: list[SpecWarning] = _collect_skew_warnings(registry)
     warnings_list.extend(_collect_discovery_warnings(registry))
+    warnings_list.extend(_collect_binding_mismatch_warnings(registry))
     for message in _validate_spec(spec):
         warnings_list.append(SpecWarning(code=WarningCode.SPEC_VALIDATION, message=message))
     return tuple(warnings_list)

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -506,6 +506,212 @@ def test_scan_below_route_preserves_explicit_openapi_route_override() -> None:
     spec = generate_openapi_spec("T", "1.0.0")
     assert set(spec["paths"].keys()) == {"/api/custom/path"}
 
+def test_scan_reconciles_plain_openapi_below_route_explicit_method() -> None:
+    # #361: a plain @openapi (no validation/endpoint metadata) below @app.route
+    # must infer BOTH the binding method and route. The decorator registered
+    # method=None, route=None; the scan sees a POST binding at a route that can
+    # never equal the function name (real-world case).
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="create user")
+    def handler_p1(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="users/create", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_p1", _func=handler_p1, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    registry = get_openapi_registry()
+    assert "handler_p1" not in registry
+    assert registry["post::/api/users/create"]["route"] == "users/create"
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"].keys()) == {"/api/users/create"}
+    assert set(spec["paths"]["/api/users/create"].keys()) == {"post"}
+
+
+def test_scan_reconciles_plain_openapi_below_route_multi_method() -> None:
+    # #361: a plain @openapi with an explicit multi-method binding produces one
+    # operation per method at the binding route (not a collapsed lone GET).
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="rw thing")
+    def handler_p2(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="things/rw", methods=["GET", "POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_p2", _func=handler_p2, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"].keys()) == {"/api/things/rw"}
+    assert set(spec["paths"]["/api/things/rw"].keys()) == {"get", "post"}
+
+
+def test_scan_reconciles_plain_openapi_below_route_unspecified_preserves_route() -> None:
+    # #361: an unspecified-methods binding expands to every HTTP method AND keeps
+    # the binding route (previously the route fell back to the function name).
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="any thing")
+    def handler_p3(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="things/any", methods=None, type="httpTrigger")
+    fn = MockFunction(_name="handler_p3", _func=handler_p3, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    registry = get_openapi_registry()
+    assert "handler_p3" not in registry
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"].keys()) == {"/api/things/any"}
+    assert set(spec["paths"]["/api/things/any"].keys()) == {
+        "get",
+        "post",
+        "put",
+        "delete",
+        "patch",
+        "head",
+        "options",
+    }
+
+
+def test_scan_plain_openapi_preserves_explicit_route_override() -> None:
+    # #361: an explicit @openapi(route=...) on a plain handler must win over the
+    # binding route.
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="create user", route="custom/path")
+    def handler_p4(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="users/create", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_p4", _func=handler_p4, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"].keys()) == {"/api/custom/path"}
+    assert set(spec["paths"]["/api/custom/path"].keys()) == {"post"}
+
+
+def test_scan_plain_openapi_preserves_explicit_method() -> None:
+    # #361 guard: an explicit @openapi(method=...) on a plain handler is never
+    # exploded or overridden by the binding.
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import generate_openapi_spec
+
+    @openapi(summary="explicit", route="things", method="put")
+    def handler_p5(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="things", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_p5", _func=handler_p5, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+
+    spec = generate_openapi_spec("T", "1.0.0")
+    assert set(spec["paths"]["/api/things"].keys()) == {"put"}
+
+
+def test_collect_spec_warnings_flags_method_binding_mismatch() -> None:
+    # #362: an explicit @openapi(method=...) naming a verb the binding does not
+    # serve yields an unreachable operation; surface METHOD_BINDING_MISMATCH.
+    from azure_functions_openapi._warnings import WarningCode
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import collect_spec_warnings, generate_openapi_spec
+
+    @openapi(summary="mismatch", route="things", method="put")
+    def handler_m1(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="things", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_m1", _func=handler_m1, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    spec = generate_openapi_spec("T", "1.0.0")
+    warnings = collect_spec_warnings(spec)
+
+    codes = [w.code for w in warnings]
+    assert WarningCode.METHOD_BINDING_MISMATCH in codes
+    mismatch = next(w for w in warnings if w.code == WarningCode.METHOD_BINDING_MISMATCH)
+    assert mismatch.function_name == "handler_m1"
+
+
+def test_collect_spec_warnings_no_mismatch_for_subset_method() -> None:
+    # #362: documenting a subset of a multi-method binding is legitimate and must
+    # NOT warn.
+    from azure_functions_openapi._warnings import WarningCode
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import collect_spec_warnings, generate_openapi_spec
+
+    @openapi(summary="subset", route="things", method="get")
+    def handler_m2(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="things", methods=["GET", "POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_m2", _func=handler_m2, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    spec = generate_openapi_spec("T", "1.0.0")
+    codes = [w.code for w in collect_spec_warnings(spec)]
+    assert WarningCode.METHOD_BINDING_MISMATCH not in codes
+
+
+def test_collect_spec_warnings_no_mismatch_for_unspecified_binding() -> None:
+    # #362: an unspecified-methods binding serves every verb, so no explicit
+    # method can contradict it.
+    from azure_functions_openapi._warnings import WarningCode
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import collect_spec_warnings, generate_openapi_spec
+
+    @openapi(summary="unspecified", route="things", method="put")
+    def handler_m3(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="things", methods=None, type="httpTrigger")
+    fn = MockFunction(_name="handler_m3", _func=handler_m3, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    spec = generate_openapi_spec("T", "1.0.0")
+    codes = [w.code for w in collect_spec_warnings(spec)]
+    assert WarningCode.METHOD_BINDING_MISMATCH not in codes
+
+
+def test_collect_spec_warnings_no_mismatch_for_inferred_method() -> None:
+    # #362: a method inferred from the binding (plain @openapi, method=None) is
+    # never a mismatch, even though the resulting entry carries a method.
+    from azure_functions_openapi._warnings import WarningCode
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import collect_spec_warnings, generate_openapi_spec
+
+    @openapi(summary="inferred")
+    def handler_m4(req: Any) -> Any:
+        return req
+
+    binding = MockBinding(route="things", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_m4", _func=handler_m4, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    spec = generate_openapi_spec("T", "1.0.0")
+    codes = [w.code for w in collect_spec_warnings(spec)]
+    assert WarningCode.METHOD_BINDING_MISMATCH not in codes
 
 def test_scan_merges_explicit_function_name_entry() -> None:
     with _registry_lock:


### PR DESCRIPTION
## Summary

Follow-up to #358/#359/#360. Two fixes for the `azure-functions-openapi`-only user (no validation dependency).

- **#361 — plain `@openapi` route+method inference.** A plain `@openapi` handler (no endpoint/validation metadata) decorated below `@app.route` previously hit a branch that only set `_expand_all_methods` for the unspecified-`methods=` case: it never inferred an explicit method, and the route fell back to the **function name**. `_reconcile_all_methods_expansion` is generalized into `_reconcile_openapi_binding`, which explodes a `method=None` entry into one operation per bound method and sets the raw binding route (prefix NOT applied; `spec.py` re-applies it). Explicit `@openapi(method=)` / `@openapi(route=)` are never overridden. This fulfills the README promise that "@openapi infers the route and method from the @app.route below".

- **#362 — `METHOD_BINDING_MISMATCH` warning.** When an explicit `@openapi(method="put")` names a verb the HTTP binding does not serve, the generated operation is unreachable at runtime. The scan now stamps the binding's method set (`_binding_methods`) on entries whose method was set explicitly, and `collect_spec_warnings()` surfaces a structured `WarningCode.METHOD_BINDING_MISMATCH`. Inferred methods and unspecified bindings (runtime answers every verb) never warn; documenting a subset of a multi-method binding is legitimate and does not warn.

## Behavior

| binding | `@openapi` | before | after |
|---|---|---|---|
| `methods=["POST"]` route `users/create` | plain | `POST /api/handler_name` ❌ | `POST /api/users/create` ✅ |
| `methods=["GET","POST"]` | plain | lone `GET` at func name ❌ | both verbs at binding route ✅ |
| unspecified | plain | all verbs, wrong route ⚠️ | all verbs at binding route ✅ |
| `methods=["POST"]` | `@openapi(method="put")` | silent unreachable `PUT` | `METHOD_BINDING_MISMATCH` warning |

## Tests

Added 9 regression tests (route != function name): plain explicit/multi/unspecified inference, explicit route/method preservation, and mismatch positive + 3 negative cases (subset, unspecified binding, inferred method). `make check-all` green; coverage 96.27% (>= 95%).

## Out of scope (tracked separately)

- `function_id` one-to-many re-scan resolution — #363
- Binding-first invariant refactor — #364

Closes #361
Closes #362