### PR TITLE
fix(bridge): resolve one-to-many _function_id per method on re-scan

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -129,8 +129,10 @@ def _reconcile_openapi_binding(
     bound method and set the raw binding route (prefix NOT applied; spec.py
     re-applies the prefix), mirroring the metadata-carrying scan path so the
     ``@openapi``-only user gets the correct route and method(s) instead of a lone
-    ``get`` at the function name (#361). Matching is by collision-free canonical
-    function id.
+    ``get`` at the function name (#361). The entry is located by canonical
+    function id; note that after #359 explosion multiple entries can share one
+    ``_function_id``, so this path resolves the ``method=None`` canonical entry
+    (the pre-explosion original) rather than assuming a unique id.
 
     An explicit ``@openapi(method=...)`` is authoritative and never overridden;
     in that case we only stamp the binding's method set on the entry so spec.py
@@ -641,15 +643,25 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
                     registry.set(endpoint_key, clone)
                     continue
                 # Resolve the target entry by, in order of trust:
-                #   1. canonical callable identity (collision-free),
-                #   2. the OpenAPI endpoint key (method::path),
+                #   1. the exact OpenAPI endpoint key (method::path),
+                #   2. canonical callable identity, method-aware,
                 #   3. the short function name (backward-compatible fallback).
-                target = registry.find_by_function_id(canonical_id)
-                match_kind = "canonical @openapi id"
+                #
+                # The endpoint key is tried FIRST because #359 made
+                # ``_function_id`` one-to-many: an exploded multi-method handler
+                # has several entries sharing one ``_function_id``. Resolving by
+                # id alone would let every method iteration merge into whichever
+                # sibling comes first, corrupting per-method operations on a
+                # re-scan. The exact ``method::path`` key pins each method to its
+                # own entry; the id lookup is then method-aware as a backstop
+                # (e.g. an explicit @openapi(method=) registered under a short
+                # name whose binding route differs from the entry key).
+                target = registry.get(endpoint_key)
+                match_kind = "OpenAPI endpoint"
 
                 if target is None:
-                    target = registry.get(endpoint_key)
-                    match_kind = "OpenAPI endpoint"
+                    target = registry.find_by_function_id(canonical_id, method=method)
+                    match_kind = "canonical @openapi id"
 
                 if target is None:
                     # Short-name fallback: refuse to merge when the name is

--- a/src/azure_functions_openapi/registry.py
+++ b/src/azure_functions_openapi/registry.py
@@ -96,21 +96,42 @@ class OpenAPIRegistry:
             self._entries.clear()
             self._discovery_warnings.clear()
 
-    def find_by_function_id(self, function_id: str) -> dict[str, Any] | None:
-        """Return the entry whose ``_function_id`` equals *function_id*.
+    def find_by_function_id(
+        self, function_id: str, method: str | None = None
+    ) -> dict[str, Any] | None:
+        """Return an entry whose ``_function_id`` equals *function_id*.
 
-        This is the collision-free lookup path: ``@openapi`` records a
-        canonical ``_function_id`` (see :func:`canonical_function_id`) for every
-        entry, so a handler can be resolved by identity regardless of how its
-        short name collides with other modules. Returns ``None`` if no entry
-        matches. Caller should hold :attr:`lock` when the result is used for a
-        read-modify-write transaction.
+        ``@openapi`` records a canonical ``_function_id`` (see
+        :func:`canonical_function_id`) for every entry, so a handler can be
+        resolved by identity regardless of how its short name collides with
+        other modules.
+
+        Historically this was a *collision-free* one-to-one lookup, but the
+        per-method explode introduced in #359 makes ``_function_id`` **one to
+        many**: a single handler bound to several HTTP methods produces one
+        ``{method}::{path}`` entry per method, all sharing the same
+        ``_function_id``. Passing *method* disambiguates that case: an entry
+        whose ``method`` equals *method* is preferred, falling back to a
+        ``method=None`` (un-exploded canonical) entry when no exact match
+        exists. With *method* left ``None`` the first matching entry is returned
+        (used only to detect the un-exploded canonical before exploding).
+
+        Returns ``None`` if no entry matches. Caller should hold :attr:`lock`
+        when the result is used for a read-modify-write transaction.
         """
         with self._lock:
+            method_none_fallback: dict[str, Any] | None = None
             for entry in self._entries.values():
-                if entry.get("_function_id") == function_id:
+                if entry.get("_function_id") != function_id:
+                    continue
+                if method is None:
                     return entry
-        return None
+                entry_method = entry.get("method")
+                if entry_method is not None and str(entry_method).lower() == method.lower():
+                    return entry
+                if entry_method is None and method_none_fallback is None:
+                    method_none_fallback = entry
+            return method_none_fallback
 
     def count_by_function_name(self, function_name: str) -> int:
         """Return how many entries carry ``function_name`` as their name.

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -768,8 +768,8 @@ _SKEW_MESSAGES: dict[WarningCode, str] = {
 # ``_SKEW_MESSAGES``. The recorded SDK ``reason`` (which itself names the
 # function) is appended by :func:`_collect_discovery_warnings` for attribution.
 _DISCOVERY_SKIPPED_MESSAGE = (
-"A function builder could not be built during discovery and was omitted "
-"from the spec"
+    "A function builder could not be built during discovery and was omitted "
+    "from the spec"
 )
 
 # Method/binding mismatch is authored disagreement, not a skew signal: an

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -438,6 +438,62 @@ def test_scan_below_route_is_idempotent_across_repeated_scans() -> None:
     assert set(spec["paths"]["/api/things"].keys()) == {"post"}
 
 
+def test_rescan_expanded_handler_preserves_per_method_bodies() -> None:
+    # #363: after #359 made _function_id one-to-many (one entry per exploded
+    # method), resolving by function id alone would let every method iteration
+    # merge into whichever sibling comes first. On a re-scan of an unspecified-
+    # methods handler the POST body would leak into the bodyless GET/HEAD/DELETE
+    # entries. Pinning resolution to the exact method::path key keeps each
+    # method's operation intact across repeated scans.
+    from azure_functions_openapi.decorator import openapi
+
+    @openapi(summary="any thing", route="things")
+    def any_thing(req: Any) -> Any:
+        return req
+
+    setattr(any_thing, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="things", methods=None, type="httpTrigger")
+    fn = MockFunction(_name="any_thing", _func=any_thing, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    scan_endpoint_metadata(app)  # re-scan must not corrupt per-method bodies
+
+    registry = get_openapi_registry()
+    for method in ("get", "head", "delete"):
+        assert registry[f"{method}::/api/things"]["request_body"] is None
+    for method in ("post", "put", "patch"):
+        assert registry[f"{method}::/api/things"]["request_body"] is not None
+
+
+def test_rescan_multi_method_resolves_each_method_to_own_entry() -> None:
+    # #363: an explicit multi-method handler explodes into distinct entries that
+    # share one _function_id. A re-scan must resolve each method iteration to
+    # its own method::path entry, not the first id match.
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.registry import canonical_function_id, registry
+
+    @openapi(summary="rw thing", route="things")
+    def rw_thing(req: Any) -> Any:
+        return req
+
+    setattr(rw_thing, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="things", methods=["GET", "POST"], type="httpTrigger")
+    fn = MockFunction(_name="rw_thing", _func=rw_thing, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    scan_endpoint_metadata(app)
+
+    fid = canonical_function_id(rw_thing)
+    # Each method resolves to its own live entry (method-aware id lookup).
+    for method in ("get", "post"):
+        entry = registry.find_by_function_id(fid, method=method)
+        assert entry is not None
+        assert entry is registry.get(f"{method}::/api/things")
+        assert entry["method"] == method
+
+
 def test_scan_below_route_does_not_override_explicit_openapi_method() -> None:
     # #358 guard: an explicit method= on @openapi must never be exploded or
     # overridden by the binding — the entry keeps its declared method.


### PR DESCRIPTION
## Context
After #359 exploded a single handler into one registry entry per HTTP method, those entries share one `_function_id`. `find_by_function_id` returned only the first match, so `scan_endpoint_metadata`'s non-explode resolution order (function_id → endpoint_key → short-name) made every method iteration resolve to the same first entry on a **re-scan**, leaking the POST body into bodyless GET/HEAD/DELETE entries.

## Changes
- `registry.find_by_function_id(function_id, method=None)` is now method-aware: exact method match → `method=None` canonical fallback → first match.
- `bridge.py` non-explode resolution reordered to `endpoint_key` (method::path) → method-aware id → short-name.
- Corrected the misleading "collision-free" docstring in `_reconcile_openapi_binding` and a continuation-indent nit in `spec._DISCOVERY_SKIPPED_MESSAGE` (PR #366 review comments).

## Tests
- `test_rescan_expanded_handler_preserves_per_method_bodies`
- `test_rescan_multi_method_resolves_each_method_to_own_entry`
- `make check-all` green (coverage 96%+, bandit clean).

## Out of scope
- #364 (binding-first invariant refactor).
- #368 tracks the `METHOD_BINDING_MISMATCH` coverage gap for validation-carrying handlers.

Closes #363