### PR TITLE
fix(bridge): flag method/binding mismatch for validation-carrying handlers

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -595,9 +595,23 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
         # otherwise collapse the generated spec to a single GET (#358).
         with registry.lock:
             canonical_target = registry.find_by_function_id(canonical_id)
-        explode_canonical = (
-            canonical_target is not None and canonical_target.get("method") is None
-        )
+            explode_canonical = (
+                canonical_target is not None and canonical_target.get("method") is None
+            )
+            # An explicit @openapi(method=...) that the binding does not serve is
+            # a mismatch: stamp the binding's specified method set on the entry so
+            # spec.py can flag the unreachable operation (#362/#368). This mirrors
+            # the plain-@openapi path in _reconcile_openapi_binding; without it the
+            # warning only ever surfaced for handlers WITHOUT validation/endpoint
+            # metadata. Unspecified (auto-expanded) bindings serve every verb, so
+            # they are never stamped and never contradict the authored method.
+            if (
+                not explode_canonical
+                and canonical_target is not None
+                and canonical_target.get("method") is not None
+                and not methods_expanded
+            ):
+                canonical_target["_binding_methods"] = list(methods)
 
         for method in methods:
             if endpoint_hints is not None:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -769,6 +769,78 @@ def test_collect_spec_warnings_no_mismatch_for_inferred_method() -> None:
     codes = [w.code for w in collect_spec_warnings(spec)]
     assert WarningCode.METHOD_BINDING_MISMATCH not in codes
 
+def test_mismatch_flagged_for_validation_carrying_handler() -> None:
+    # #368: METHOD_BINDING_MISMATCH must also fire when the explicit
+    # @openapi(method=...) handler carries validation/endpoint metadata. Such a
+    # handler takes the metadata-merge path (not _reconcile_openapi_binding), so
+    # the binding method set has to be stamped there too.
+    from azure_functions_openapi._warnings import WarningCode
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import collect_spec_warnings, generate_openapi_spec
+
+    @openapi(summary="mismatch", route="things", method="put")
+    def handler_v1(req: Any) -> Any:
+        return req
+
+    setattr(handler_v1, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="things", methods=["POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_v1", _func=handler_v1, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    spec = generate_openapi_spec("T", "1.0.0")
+    warnings = collect_spec_warnings(spec)
+
+    codes = [w.code for w in warnings]
+    assert WarningCode.METHOD_BINDING_MISMATCH in codes
+    mismatch = next(w for w in warnings if w.code == WarningCode.METHOD_BINDING_MISMATCH)
+    assert mismatch.function_name == "handler_v1"
+
+
+def test_no_mismatch_for_validation_handler_with_subset_method() -> None:
+    # #368: a validation-carrying handler documenting a subset of a multi-method
+    # binding is legitimate and must NOT warn.
+    from azure_functions_openapi._warnings import WarningCode
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import collect_spec_warnings, generate_openapi_spec
+
+    @openapi(summary="subset", route="things", method="post")
+    def handler_v2(req: Any) -> Any:
+        return req
+
+    setattr(handler_v2, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="things", methods=["GET", "POST"], type="httpTrigger")
+    fn = MockFunction(_name="handler_v2", _func=handler_v2, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    spec = generate_openapi_spec("T", "1.0.0")
+    codes = [w.code for w in collect_spec_warnings(spec)]
+    assert WarningCode.METHOD_BINDING_MISMATCH not in codes
+
+
+def test_no_mismatch_for_validation_handler_with_unspecified_binding() -> None:
+    # #368: an unspecified-methods binding serves every verb, so a validation-
+    # carrying explicit-method handler still cannot be a mismatch.
+    from azure_functions_openapi._warnings import WarningCode
+    from azure_functions_openapi.decorator import openapi
+    from azure_functions_openapi.spec import collect_spec_warnings, generate_openapi_spec
+
+    @openapi(summary="unspecified", route="things", method="put")
+    def handler_v3(req: Any) -> Any:
+        return req
+
+    setattr(handler_v3, _HANDLER_METADATA_ATTR, {"validation": {"body": CreateBody}})
+    binding = MockBinding(route="things", methods=None, type="httpTrigger")
+    fn = MockFunction(_name="handler_v3", _func=handler_v3, _bindings=[binding])
+    app = MockApp(_function_builders=[MockBuilder(_function=fn)])
+
+    scan_endpoint_metadata(app)
+    spec = generate_openapi_spec("T", "1.0.0")
+    codes = [w.code for w in collect_spec_warnings(spec)]
+    assert WarningCode.METHOD_BINDING_MISMATCH not in codes
+
+
 def test_scan_merges_explicit_function_name_entry() -> None:
     with _registry_lock:
         _openapi_registry["create_user"] = {


### PR DESCRIPTION
## Context
`WarningCode.METHOD_BINDING_MISMATCH` (#362) only fired for **plain** `@openapi` handlers, because `_binding_methods` was stamped solely in `_reconcile_openapi_binding()` (reached only via the plain-`@openapi` early-continue). A handler carrying validation/endpoint metadata **plus** an explicit `@openapi(method=X)` that the HTTP binding does not serve took the metadata-merge path and was never stamped, so its unreachable operation went unwarned — the common real-world case. Surfaced by the Copilot review on PR #366.

Reproduced empirically: a validation-carrying `@openapi(method="put")` handler on a `methods=["POST"]` binding produced no `METHOD_BINDING_MISMATCH` before this change.

## Changes
- In `scan_endpoint_metadata`'s metadata path, stamp `_binding_methods = list(methods)` on the explicit-method canonical entry when the binding methods are specified (not auto-expanded), mirroring `_reconcile_openapi_binding`.

## Tests
- `test_mismatch_flagged_for_validation_carrying_handler` — positive case now warns.
- `test_no_mismatch_for_validation_handler_with_subset_method` — subset of a multi-method binding does not warn.
- `test_no_mismatch_for_validation_handler_with_unspecified_binding` — unspecified binding never warns.
- `make check-all` green (645 passed, coverage 96%+, bandit clean).

## Out of scope
- #364 (binding-first invariant refactor).

Closes #368