### PR TITLE
refactor(bridge): binding-first invariant resolution model for discovery

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -110,82 +110,6 @@ def _extract_methods(binding: Any) -> tuple[list[str], bool]:
     return ["get"], False
 
 
-def _reconcile_openapi_binding(
-    function: Any, handler: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX
-) -> None:
-    """Reconcile a plain ``@openapi`` entry with the HTTP binding the decorator
-    could not see (#354/#358/#360/#361).
-
-    A plain ``@openapi`` handler (no endpoint/validation metadata) is skipped by
-    the main scan loop, so any binding evidence must be reconciled here.
-    Whichever decorator order is used, ``@openapi`` decorates the function before
-    the HTTP-trigger binding is observable, so the entry is registered with
-    ``method=None`` and ``route=None``. This is easiest to hit in the
-    README-recommended order (``@openapi`` above ``@app.route``), where
-    ``@openapi`` wraps the ``@app.route`` result but still cannot read the
-    binding. The scan, however, sees the fully wrapped builder.
-
-    For a ``method=None`` entry we therefore explode it into one operation per
-    bound method and set the raw binding route (prefix NOT applied; spec.py
-    re-applies the prefix), mirroring the metadata-carrying scan path so the
-    ``@openapi``-only user gets the correct route and method(s) instead of a lone
-    ``get`` at the function name (#361). The entry is located by canonical
-    function id; note that after #359 explosion multiple entries can share one
-    ``_function_id``, so this path resolves the ``method=None`` canonical entry
-    (the pre-explosion original) rather than assuming a unique id.
-
-    An explicit ``@openapi(method=...)`` is authoritative and never overridden;
-    in that case we only stamp the binding's method set on the entry so spec.py
-    can flag a method/binding mismatch (#362). An explicit ``@openapi(route=...)``
-    is likewise preserved.
-    """
-    binding = _extract_http_binding(function)
-    if binding is None:
-        return
-    canonical_id = canonical_function_id(handler)
-    methods, methods_expanded = _extract_methods(binding)
-    raw_route = getattr(binding, "route", None)
-    # Unspecified binding methods (expanded to every verb) are not stamped:
-    # the runtime answers every method, so no explicit method can contradict it.
-    binding_methods = None if methods_expanded else list(methods)
-    with registry.lock:
-        target = registry.find_by_function_id(canonical_id)
-        if target is None:
-            return
-        if target.get("method") is not None:
-            # Explicit @openapi(method=...) wins; do not explode. Stamp the
-            # binding method set so spec.py can surface a mismatch (#362).
-            if binding_methods is not None:
-                target["_binding_methods"] = binding_methods
-            return
-        # method=None @openapi entry: infer route + method(s) from the binding.
-        route_for_key = target.get("route") or raw_route
-        function_name = target.get("function_name") or adapters.get_function_name(function)
-        path = _normalize_path(route_for_key, function_name, route_prefix)
-        # Locate the original method=None entry by identity (find_by_function_id
-        # returns the live entry but not its registry key) so it can be dropped
-        # after exploding, avoiding a stray bare-GET duplicate.
-        original_key = None
-        for key, entry in registry.entries.items():
-            if entry is target:
-                original_key = key
-                break
-        for method in methods:
-            clone = copy.deepcopy(target)
-            clone["method"] = method
-            # Preserve the binding route when @openapi registered route=None; an
-            # explicit @openapi(route=...) stays truthy and is never overwritten.
-            if clone.get("route") is None and raw_route:
-                clone["route"] = raw_route
-            # Drop the body from GET/HEAD/DELETE when methods= was unspecified
-            # (auto-expanded): OpenAPI leaves such a body semantically undefined.
-            if methods_expanded and method in BODYLESS_HTTP_METHODS:
-                clone["request_body"] = None
-            registry.set(f"{method}::{path}", clone)
-        if original_key is not None and registry.entries.get(original_key) is target:
-            del registry.entries[original_key]
-
-
 def _merge_parameters(
     existing: list[dict[str, Any]],
     discovered: list[dict[str, Any]],
@@ -551,15 +475,31 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
         handler = adapters.get_user_handler(function)
         if handler is None:
             continue
+
         endpoint_hints = _read_endpoint_hints(handler)
         metadata = None if endpoint_hints is not None else _read_validation_hints(handler)
-        if endpoint_hints is None and metadata is None:
-            # Plain @openapi route (no endpoint/validation metadata): the main
-            # scan below does not revisit it, so reconcile route + method(s)
-            # from binding evidence the decorator could not see (#354/#361).
-            _reconcile_openapi_binding(function, handler, route_prefix)
+        has_enrichment = endpoint_hints is not None or metadata is not None
+
+        # Binding-first (#364): the Azure @app.route binding is the source of
+        # truth for route + method. Resolve it before anything else -- a handler
+        # without an HTTP binding has no concrete operations to register.
+        binding = _extract_http_binding(function)
+        if binding is None:
+            if has_enrichment:
+                logger.debug(
+                    "Function '%s' has validation metadata but is not HTTP triggered",
+                    function_name,
+                )
             continue
 
+        methods, methods_expanded = _extract_methods(binding)
+        # Raw binding route (prefix NOT applied): spec.py re-applies the route
+        # prefix to meta["route"] via apply_route_prefix, so storing the already
+        # normalized ``path`` (which includes the prefix) would double-prefix.
+        raw_route = getattr(binding, "route", None)
+
+        # Namespace-fallback skew: only when validation metadata is consumed
+        # because the self-contained endpoint namespace was malformed.
         handler_skew: set[WarningCode] = set()
         if endpoint_hints is None and metadata is not None and _has_endpoint_namespace(handler):
             logger.warning(
@@ -573,26 +513,12 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
 
         canonical_id = canonical_function_id(handler)
 
-        binding = _extract_http_binding(function)
-        if binding is None:
-            logger.debug(
-                "Function '%s' has validation metadata but is not HTTP triggered", function_name
-            )
-            continue
-
-        path = _normalize_path(getattr(binding, "route", None), function_name, route_prefix)
-        methods, methods_expanded = _extract_methods(binding)
-        # Raw binding route (prefix NOT applied): spec.py re-applies the route
-        # prefix to meta["route"] via apply_route_prefix, so storing the already
-        # normalized ``path`` (which includes the prefix) would double-prefix.
-        raw_route = getattr(binding, "route", None)
-
         # Resolve the canonical @openapi entry once (it does not vary per
         # method). When @openapi decorates the handler BELOW @app.route, the
         # decorator cannot see the HTTP binding and registers the entry with
-        # method=None. We must then explode that entry into one operation per
-        # bound method instead of merging every method into it, which would
-        # otherwise collapse the generated spec to a single GET (#358).
+        # method=None; we then explode that entry into one operation per bound
+        # method instead of merging every method into it, which would otherwise
+        # collapse the generated spec to a single GET (#358).
         with registry.lock:
             canonical_target = registry.find_by_function_id(canonical_id)
             explode_canonical = (
@@ -600,11 +526,9 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
             )
             # An explicit @openapi(method=...) that the binding does not serve is
             # a mismatch: stamp the binding's specified method set on the entry so
-            # spec.py can flag the unreachable operation (#362/#368). This mirrors
-            # the plain-@openapi path in _reconcile_openapi_binding; without it the
-            # warning only ever surfaced for handlers WITHOUT validation/endpoint
-            # metadata. Unspecified (auto-expanded) bindings serve every verb, so
-            # they are never stamped and never contradict the authored method.
+            # spec.py can flag the unreachable operation (#362/#368). Unspecified
+            # (auto-expanded) bindings serve every verb, so they are never stamped
+            # and never contradict the authored method.
             if (
                 not explode_canonical
                 and canonical_target is not None
@@ -613,49 +537,70 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
             ):
                 canonical_target["_binding_methods"] = list(methods)
 
+        # Path key. Enrichment handlers key off the binding route (the runtime
+        # truth). A plain @openapi entry may carry an explicit route= override
+        # registered before the binding was visible, so honour it when present
+        # (mirrors the pre-#364 plain-reconcile path).
+        if has_enrichment:
+            path = _normalize_path(raw_route, function_name, route_prefix)
+        else:
+            entry_route = canonical_target.get("route") if canonical_target is not None else None
+            entry_name = (
+                canonical_target.get("function_name") if canonical_target is not None else None
+            ) or function_name
+            path = _normalize_path(entry_route or raw_route, entry_name, route_prefix)
+
         for method in methods:
+            endpoint_key = f"{method}::{path}"
+            entry_skew = set(handler_skew)
+
+            # Build the enrichment payload for this concrete operation. Plain
+            # @openapi handlers have no metadata to merge, so ``discovered`` is
+            # None and the binding alone materializes the operation.
+            discovered: dict[str, Any] | None = None
             if endpoint_hints is not None:
                 discovered = _discovered_operation_from_endpoint(
                     function_name, endpoint_hints, path, method
                 )
             elif metadata is not None:
                 discovered = _discovered_operation(function_name, metadata, path, method)
-            else:  # pragma: no cover - guarded above (endpoint or metadata is set)
-                continue
 
             # When methods= was unspecified and we auto-expanded to every HTTP
             # method, drop the request body from GET/HEAD/DELETE operations:
             # OpenAPI leaves a body there semantically undefined and many tools
             # reject it. Explicitly requested methods are left untouched.
-            if methods_expanded and method in BODYLESS_HTTP_METHODS:
+            if discovered is not None and methods_expanded and method in BODYLESS_HTTP_METHODS:
                 discovered["request_body"] = None
-            endpoint_key = f"{method}::{path}"
-            entry_skew = set(handler_skew)
 
             with registry.lock:
                 if explode_canonical:
-                    # @openapi was applied BELOW @app.route, so its entry was
-                    # registered with method=None. Collapsing every bound
-                    # method into that single entry would make spec.py emit a
-                    # lone GET (#358). Instead, seed one per-method entry from
-                    # the @openapi metadata and merge the discovered operation
-                    # into it.
-                    seed = cast("dict[str, Any]", canonical_target)
-                    clone = copy.deepcopy(seed)
+                    # Seed one per-method entry from the method=None @openapi
+                    # entry, then merge any enrichment into it. Collapsing every
+                    # bound method into the single method=None entry would make
+                    # spec.py emit a lone GET (#358).
+                    clone = copy.deepcopy(cast("dict[str, Any]", canonical_target))
                     clone["method"] = method
-                    # Preserve the binding route on the clone. The decorator
-                    # could not see the binding, so @openapi registered
-                    # route=None; without this, spec.py falls back to the
-                    # function name and emits the wrong path (#360). An explicit
-                    # @openapi(route=...) stays truthy and is never overwritten.
+                    # Preserve the binding route on the clone. The decorator could
+                    # not see the binding, so @openapi registered route=None;
+                    # without this, spec.py falls back to the function name and
+                    # emits the wrong path (#360). An explicit @openapi(route=...)
+                    # stays truthy and is never overwritten.
                     if clone.get("route") is None and raw_route:
                         clone["route"] = raw_route
-                    _merge_into_existing(clone, discovered)
+                    if discovered is not None:
+                        _merge_into_existing(clone, discovered)
                     if methods_expanded and method in BODYLESS_HTTP_METHODS:
                         clone["request_body"] = None
                     _tag_skew(clone, entry_skew)
                     registry.set(endpoint_key, clone)
                     continue
+
+                if discovered is None:
+                    # Plain @openapi with an explicit method and no enrichment:
+                    # the existing @openapi entry stands as-is (its binding methods
+                    # were already stamped above for mismatch detection).
+                    continue
+
                 # Resolve the target entry by, in order of trust:
                 #   1. the exact OpenAPI endpoint key (method::path),
                 #   2. canonical callable identity, method-aware,
@@ -667,9 +612,7 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
                 # id alone would let every method iteration merge into whichever
                 # sibling comes first, corrupting per-method operations on a
                 # re-scan. The exact ``method::path`` key pins each method to its
-                # own entry; the id lookup is then method-aware as a backstop
-                # (e.g. an explicit @openapi(method=) registered under a short
-                # name whose binding route differs from the entry key).
+                # own entry; the id lookup is then method-aware as a backstop.
                 target = registry.get(endpoint_key)
                 match_kind = "OpenAPI endpoint"
 


### PR DESCRIPTION
## Context

`scan_endpoint_metadata` previously ran two parallel discovery paths: a plain-`@openapi` reconciliation helper (`_reconcile_openapi_binding`) and the metadata enrichment loop. The duplication caused the class of divergence bugs fixed in #366/#368/#369, where one path stamped/resolved state the other didn't. This unifies them into a single binding-first pipeline so the invariant (binding extracted and canonical-target resolved before enrichment branching) holds for every function.

Closes #364.

## Approach

- Hoist binding extraction ahead of enrichment classification; compute a `has_enrichment` flag once.
- Resolve `canonical_target` + method/binding mismatch stamping in a single lock block for both paths.
- Branch **only** path computation on `has_enrichment` — this preserves the real, intentional divergence between the two former paths (enrichment uses the binding raw_route; plain uses `entry_route or raw_route` with an entry_name fallback).
- Per-method loop handles the plain case inline via `discovered=None` (explicit-method plain → no-op preserving the existing entry), replacing the old dead `else # pragma: no cover` branch.
- Delete the now-unreachable `_reconcile_openapi_binding` helper.

## Risks reviewed

- **Re-scan idempotency** — multi-method explode + per-method body preservation still covered (#369 regression tests green).
- **Lock scope** — mismatch stamp now written inside the unified lock block only when explicit-method & not method-expanded; `_collect_binding_mismatch_warnings` reads it unchanged (#368 tests green).
- **Path divergence preservation** — verified the enrichment vs plain route computation is retained, not collapsed.

## Verification

- `make check-all` passes: 645 tests, coverage 96.32%, ruff/mypy/bandit clean.
- Net behavior unchanged (pure refactor); diff is +68/-125 in `bridge.py`.

## Note

Please review before merge — no auto-merge.