### PR TITLE
fix(discovery): unwrap FunctionApp-wrapping containers and warn on empty scans

### DIFF
--- a/src/azure_functions_openapi/adapters/azure_functions.py
+++ b/src/azure_functions_openapi/adapters/azure_functions.py
@@ -84,6 +84,29 @@ def build_function(builder: Any, auth_level: Any = None) -> Function:
         ) from exc
 
 
+_WRAPPED_APP_ATTRS = ("function_app", "_function_app", "app", "_app")
+
+
+def _unwrap_function_app(app: Any) -> Any | None:
+    """Return an inner ``FunctionApp``-like object wrapped by *app*, or ``None``.
+
+    Some container apps do **not** subclass ``FunctionApp``; they hold the real
+    app and expose it through a property (e.g. ``LangGraphApp.function_app``).
+    When the outer object exposes no builders of its own, look for a wrapped
+    inner app that does — without importing the wrapper type. Only an inner
+    object that actually carries a non-empty ``_function_builders`` list is
+    accepted, and the outer object itself is never returned, so this can never
+    loop or mistake an unrelated attribute for the app.
+    """
+    for attr in _WRAPPED_APP_ATTRS:
+        inner = getattr(app, attr, None)
+        if inner is None or inner is app:
+            continue
+        if getattr(inner, "_function_builders", None):
+            return inner
+    return None
+
+
 def iter_functions(
     app: Any, on_skip: Callable[[str | None, str], None] | None = None
 ) -> list[Function]:
@@ -99,9 +122,11 @@ def iter_functions(
     Skips any builder whose :meth:`FunctionBuilder.build` raises ``ValueError``
     (e.g. a function with no trigger, or a trigger not present in its bindings).
     Such a function is a *user app state*, not an SDK incompatibility, so it is
-    logged at debug and omitted rather than aborting the whole scan. Returns an
     empty list when *app* exposes no builders (e.g. an app with no registered
-    functions), matching the previous "skip quietly" behaviour.
+    functions). When the app itself carries no builders but wraps a real
+    ``FunctionApp`` via a property (e.g. ``LangGraphApp.function_app``), the
+    inner app is unwrapped and enumerated (#374); a truly empty app still
+    returns an empty list, matching the previous "skip quietly" behaviour.
 
     When *on_skip* is provided it is invoked as ``on_skip(function_name, reason)``
     for each skipped builder (name is best-effort and may be ``None`` when the
@@ -109,6 +134,14 @@ def iter_functions(
     structured warning instead of losing it to a debug log.
     """
     builders = getattr(app, "_function_builders", None)
+    if not builders:
+        # #374: the object may be a container that wraps a real FunctionApp
+        # (e.g. LangGraphApp exposes it via a ``.function_app`` property) rather
+        # than subclassing it. Unwrap to the inner app before giving up.
+        inner = _unwrap_function_app(app)
+        if inner is not None:
+            app = inner
+            builders = getattr(app, "_function_builders", None)
     if not builders:
         return []
     auth_level = getattr(app, "auth_level", None)

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -468,6 +468,15 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
     )
     if not functions:
         logger.debug("No function builders found on app; skipping validation scan")
+        # #373: an app that exposes no discoverable functions produces an empty
+        # ``paths`` object. Record a structured discovery-skipped warning (in
+        # addition to the debug log) so ``--fail-on-warnings`` can catch a
+        # silently-empty spec instead of the skip vanishing.
+        registry.add_discovery_warning(
+            None,
+            "no functions were discovered on the application object "
+            f"({type(app).__name__}); the generated spec will have empty paths",
+        )
         return
 
     for function in functions:

--- a/src/azure_functions_openapi/cli.py
+++ b/src/azure_functions_openapi/cli.py
@@ -246,11 +246,18 @@ def handle_generate(args: argparse.Namespace) -> int:
         # Check for empty paths before serialising — gives a clear signal
         # instead of silently producing a spec with no routes.
         if not spec.get("paths"):
+            hint = (
+                "Hint: your function app imported cleanly but exposes no "
+                "@openapi-decorated routes, so there is nothing to document."
+                if getattr(args, "app", None)
+                else (
+                    "Hint: use --app <module> to import your function app before "
+                    "generating (e.g. --app function_app or --app function_app:app)."
+                )
+            )
             print(
                 "Warning: No routes found in the OpenAPI registry. "
-                "The generated spec contains no paths.\n"
-                "Hint: use --app <module> to import your function app before generating "
-                "(e.g. --app function_app or --app function_app:app).",
+                "The generated spec contains no paths.\n" + hint,
                 file=sys.stderr,
             )
             if getattr(args, "fail_on_empty_paths", False) is True:

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -282,6 +282,20 @@ def test_scan_endpoint_request_body_not_required() -> None:
     assert entry["request_body_required"] is False
 
 
+def test_scan_empty_app_records_discovery_warning() -> None:
+    # Regression (#373): an app exposing no discoverable functions must record a
+    # structured discovery-skipped warning (not just a debug log) so
+    # ``--fail-on-warnings`` can catch a silently-empty spec.
+    from azure_functions_openapi.registry import registry
+
+    app = MockApp([])
+    scan_endpoint_metadata(app)
+
+    warnings = registry.discovery_warnings
+    assert warnings, "expected a discovery-skipped warning for an empty app"
+    assert any(name is None and "empty paths" in reason for name, reason in warnings)
+
+
 # ---------------------------------------------------------------------------
 # Version-skew: endpoint preferred, validation fallback
 # ---------------------------------------------------------------------------

--- a/tests/test_sdk_compat_adapter.py
+++ b/tests/test_sdk_compat_adapter.py
@@ -244,6 +244,42 @@ def test_iter_functions_returns_empty_for_app_without_builders() -> None:
     assert adapters.iter_functions(_EmptyApp()) == []
 
 
+def test_iter_functions_unwraps_wrapping_container_app() -> None:
+    """Regression (#374): a container that wraps a FunctionApp is unwrapped.
+
+    ``LangGraphApp`` does not subclass ``FunctionApp``; it holds the real app
+    lazily and exposes it via a ``.function_app`` property. The outer object has
+    no ``_function_builders`` of its own, so discovery must unwrap to the inner
+    app and enumerate its builders.
+    """
+
+    class _WrapperApp:
+        def __init__(self) -> None:
+            self._inner = _FakeApp()
+
+        @property
+        def function_app(self) -> _FakeApp:
+            return self._inner
+
+    functions = adapters.iter_functions(_WrapperApp())
+
+    assert len(functions) == 1
+    assert adapters.get_function_name(functions[0]) == "ping"
+
+
+def test_iter_functions_returns_empty_when_wrapped_app_also_empty() -> None:
+    """A wrapper whose inner app has no builders still enumerates to empty."""
+
+    class _EmptyInner:
+        _function_builders: list[Any] = []
+        auth_level = None
+
+    class _WrapperApp:
+        function_app = _EmptyInner()
+
+    assert adapters.iter_functions(_WrapperApp()) == []
+
+
 def test_iter_functions_skips_builder_that_fails_to_build() -> None:
     """Regression (#337): a trigger-less builder is skipped, not fatal.
 

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -402,3 +402,20 @@ class TestCliFailOnWarnings:
         assert rc == 1
         assert not out.exists()
         assert "Hint: use --app" in capsys.readouterr().err
+
+    def test_empty_paths_hint_adapts_when_app_was_provided(
+        self, tmp_path: Any, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # When the user already passed --app, the circular "use --app" hint is
+        # misleading; the diagnostic should instead explain that the app
+        # imported cleanly but exposes no @openapi-decorated routes.
+        # Use a real importable module with no ':variable' so the import
+        # succeeds (discovery is skipped) and the registry stays empty.
+        out = tmp_path / "openapi.json"
+        rc = handle_generate(
+            _args(app="os", fail_on_empty_paths=True, output=str(out))
+        )
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Hint: use --app" not in err
+        assert "no" in err and "@openapi-decorated routes" in err


### PR DESCRIPTION
## Summary
- **#374**: `iter_functions` read `_function_builders` only off the object passed in, so a container that wraps a real `FunctionApp` without subclassing it (e.g. `LangGraphApp`, exposing the inner app via a `.function_app` property) discovered zero functions and produced an empty spec. It now unwraps such containers to the inner app before enumerating, via generic duck-typing (`function_app` / `_function_app` / `app` / `_app`) without importing the wrapper type.
- **#373**: when a scan discovers no functions, it now records a structured `discovery-skipped` warning (in addition to the debug log) so `--fail-on-warnings` can catch a silently-empty `paths` object.

## Tests
- `test_iter_functions_unwraps_wrapping_container_app` + empty-wrapper case.
- `test_scan_empty_app_records_discovery_warning`.
- `make check-all` passes (650 passed; coverage >= 95%; type + security scan clean).

Closes #373
Closes #374