### PR TITLE
feat(spec): opt-in hoisting of flat schemas into components (#375)

### DIFF
--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -70,6 +70,7 @@ def _ensure_default_response(
         "content": {"application/json": {"schema": resolved_schema}},
     }
 
+
 def _operation_id_for(
     provided_id: str | None,
     method: str,
@@ -257,6 +258,7 @@ def generate_openapi_spec(
     route_prefix: str = DEFAULT_ROUTE_PREFIX,
     strict: bool = False,
     registry: OpenAPIRegistry | None = None,
+    hoist_flat_schemas: bool = False,
 ) -> dict[str, Any]:
     """
     Compile an OpenAPI specification from the registry.
@@ -276,6 +278,11 @@ def generate_openapi_spec(
         strict: When ``True``, raise on any registry entry processing failure
             instead of logging and skipping. Useful for CI/build-time
             validation where a missing path should fail the build.
+        hoist_flat_schemas: When ``True`` (opt-in, #375), structured flat
+            schemas (objects/arrays with no inline ``$defs``) are promoted into
+            ``components.schemas`` under their ``title`` and replaced with a
+            ``$ref``, deduplicating schemas reused across endpoints. Defaults to
+            ``False`` to preserve the verbatim inline-schema behaviour.
 
     Returns:
         OpenAPI specification dictionary
@@ -333,7 +340,11 @@ def generate_openapi_spec(
                             if isinstance(media_obj, dict) and "schema" in media_obj:
                                 media_obj = {
                                     **media_obj,
-                                    "schema": hoist_inline_defs(media_obj["schema"], components),
+                                    "schema": hoist_inline_defs(
+                                        media_obj["schema"],
+                                        components,
+                                        hoist_flat=hoist_flat_schemas,
+                                    ),
                                 }
                             hoisted_content[media] = media_obj
                         resp["content"] = hoisted_content
@@ -382,7 +393,14 @@ def generate_openapi_spec(
                 op_parameters: list[dict[str, Any]] | None = None
                 if parameters:
                     op_parameters = [
-                        {**param, "schema": hoist_inline_defs(param["schema"], components)}
+                        {
+                            **param,
+                            "schema": hoist_inline_defs(
+                                param["schema"],
+                                components,
+                                hoist_flat=hoist_flat_schemas,
+                            ),
+                        }
                         if isinstance(param, dict) and "schema" in param
                         else param
                         for param in parameters
@@ -400,7 +418,9 @@ def generate_openapi_spec(
                         "content": {
                             "application/json": {
                                 "schema": hoist_inline_defs(
-                                    meta["request_body"], components
+                                    meta["request_body"],
+                                    components,
+                                    hoist_flat=hoist_flat_schemas,
                                 )
                             }
                         },
@@ -768,8 +788,7 @@ _SKEW_MESSAGES: dict[WarningCode, str] = {
 # ``_SKEW_MESSAGES``. The recorded SDK ``reason`` (which itself names the
 # function) is appended by :func:`_collect_discovery_warnings` for attribution.
 _DISCOVERY_SKIPPED_MESSAGE = (
-    "A function builder could not be built during discovery and was omitted "
-    "from the spec"
+    "A function builder could not be built during discovery and was omitted from the spec"
 )
 
 # Method/binding mismatch is authored disagreement, not a skew signal: an
@@ -878,6 +897,7 @@ def _collect_binding_mismatch_warnings(
             )
         )
     return collected
+
 
 def generate_openapi_report(
     title: str = "API",

--- a/src/azure_functions_openapi/utils.py
+++ b/src/azure_functions_openapi/utils.py
@@ -1,6 +1,8 @@
 # src/azure_functions_openapi/utils.py
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
 import re
 from typing import Any, cast, get_origin
@@ -134,7 +136,62 @@ def _needs_hoisting(obj: Any) -> bool:
     return False
 
 
-def hoist_inline_defs(schema: Any, components: dict[str, Any]) -> Any:
+_FLAT_COMPOSITION_KEYS = ("properties", "items", "anyOf", "oneOf", "allOf")
+
+
+def _schema_short_hash(schema: dict[str, Any]) -> str:
+    """Return a stable 8-char hash of a schema's canonical JSON form."""
+    canonical = json.dumps(schema, sort_keys=True, default=str)
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8]
+
+
+def _is_hoistable_flat_schema(schema: Any) -> bool:
+    """Return ``True`` for a flat schema worth promoting to ``components``.
+
+    Only structured schemas (objects with ``properties`` or a schema using a
+    composition keyword such as ``items``/``anyOf``) are hoisted; trivial
+    scalars like ``{"type": "string"}`` are left inline to avoid noisy,
+    single-use component entries.
+    """
+    if not isinstance(schema, dict):
+        return False
+    if _needs_hoisting(schema):  # nested $defs are handled by the main path
+        return False
+    if "$ref" in schema:
+        return False
+    return any(key in schema for key in _FLAT_COMPOSITION_KEYS)
+
+
+def _flat_schema_name(schema: dict[str, Any]) -> str:
+    """Derive a component name for a flat schema.
+
+    Prefers the schema's ``title`` (the natural name Pydantic emits); falls back
+    to a deterministic ``InlineSchema_<hash>`` for anonymous schemas so identical
+    schemas dedupe to the same component.
+    """
+    title = schema.get("title")
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    return f"InlineSchema_{_schema_short_hash(schema)}"
+
+
+def _hoist_flat_schema(schema: dict[str, Any], components: dict[str, Any]) -> dict[str, Any]:
+    """Promote a flat schema into ``components.schemas`` and return a ``$ref``.
+
+    Reuses :func:`_resolve_name_collision` so a name reused with differing
+    content gets a deterministic alias, exactly like the ``$defs`` and model
+    paths. Identical schemas registered under the same name dedupe to one entry.
+    """
+    schemas = components.setdefault("schemas", {})
+    normalized = cast(dict[str, Any], _rewrite_refs(schema))
+    name = _flat_schema_name(normalized)
+    resolved = _resolve_name_collision(name, normalized, schemas)
+    if resolved not in schemas:
+        schemas[resolved] = normalized
+    return {"$ref": f"#/components/schemas/{resolved}"}
+
+
+def hoist_inline_defs(schema: Any, components: dict[str, Any], *, hoist_flat: bool = False) -> Any:
     """Hoist inline ``$defs`` from a raw JSON Schema into ``components['schemas']``.
 
     Producer-authored ``endpoint`` schemas embed nested-model definitions inline
@@ -146,12 +203,19 @@ def hoist_inline_defs(schema: Any, components: dict[str, Any]) -> Any:
     point at renamed definitions are rewritten.
 
     Flat schemas -- those with no ``$defs`` and no local ``#/$defs/`` refs -- are
-    returned unchanged, preserving the verbatim behaviour from #311.
+    returned unchanged by default, preserving the verbatim behaviour from #311.
+    When *hoist_flat* is ``True`` (opt-in, #375), a structured flat schema is also
+    promoted into ``components.schemas`` under its ``title`` (or a deterministic
+    ``InlineSchema_<hash>`` when anonymous) and replaced with a ``$ref``, so the
+    same flat schema reused across endpoints is deduplicated the way model-class
+    schemas already are. Trivial scalar schemas are always left inline.
 
     The input *schema* is never mutated; :func:`_collect_schemas` rebuilds every
     nested structure via :func:`_rewrite_refs` before any in-place ``pop``.
     """
     if not isinstance(schema, dict) or not _needs_hoisting(schema):
+        if hoist_flat and _is_hoistable_flat_schema(schema):
+            return _hoist_flat_schema(cast(dict[str, Any], schema), components)
         return schema
 
     normalized_root, definitions = _collect_schemas(schema)
@@ -173,9 +237,7 @@ def hoist_inline_defs(schema: Any, components: dict[str, Any]) -> Any:
             )
             for name, definition in definitions.items()
         }
-        normalized_root = cast(
-            dict[str, Any], _rewrite_refs_with_map(normalized_root, name_map)
-        )
+        normalized_root = cast(dict[str, Any], _rewrite_refs_with_map(normalized_root, name_map))
 
     for name, definition in definitions.items():
         if name not in schemas or schemas[name] != definition:

--- a/src/azure_functions_openapi/utils.py
+++ b/src/azure_functions_openapi/utils.py
@@ -148,18 +148,23 @@ def _schema_short_hash(schema: dict[str, Any]) -> str:
 def _is_hoistable_flat_schema(schema: Any) -> bool:
     """Return ``True`` for a flat schema worth promoting to ``components``.
 
-    Only structured schemas (objects with ``properties`` or a schema using a
-    composition keyword such as ``items``/``anyOf``) are hoisted; trivial
-    scalars like ``{"type": "string"}`` are left inline to avoid noisy,
-    single-use component entries.
+    Precondition: the caller has already established the schema is *flat* --
+    ``_needs_hoisting(schema) is False`` -- so this only classifies whether a
+    flat schema is *structured* enough to hoist (and never re-walks the tree).
+    Structured means an object with ``properties``, a dict/map object using a
+    schema-valued ``additionalProperties``, or a schema using a composition
+    keyword such as ``items``/``anyOf``. Trivial scalars like
+    ``{"type": "string"}`` (and ``additionalProperties: true``) are left inline
+    to avoid noisy, single-use component entries.
     """
     if not isinstance(schema, dict):
         return False
-    if _needs_hoisting(schema):  # nested $defs are handled by the main path
-        return False
     if "$ref" in schema:
         return False
-    return any(key in schema for key in _FLAT_COMPOSITION_KEYS)
+    if any(key in schema for key in _FLAT_COMPOSITION_KEYS):
+        return True
+    # dict/map schemas emit a schema-valued ``additionalProperties`` (not a bool).
+    return isinstance(schema.get("additionalProperties"), dict)
 
 
 def _flat_schema_name(schema: dict[str, Any]) -> str:

--- a/tests/test_hoist_flat.py
+++ b/tests/test_hoist_flat.py
@@ -107,6 +107,30 @@ def test_trivial_scalar_schema_left_inline_even_when_opted_in() -> None:
     assert components["schemas"] == {}
 
 
+def test_dict_map_schema_via_additional_properties_is_hoisted() -> None:
+    schema = {
+        "title": "WidgetMap",
+        "type": "object",
+        "additionalProperties": {"type": "integer"},
+    }
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components, hoist_flat=True)
+
+    assert result == {"$ref": "#/components/schemas/WidgetMap"}
+    assert components["schemas"]["WidgetMap"]["additionalProperties"] == {"type": "integer"}
+
+
+def test_open_object_with_bool_additional_properties_left_inline() -> None:
+    schema = {"type": "object", "additionalProperties": True}
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components, hoist_flat=True)
+
+    assert result == schema
+    assert components["schemas"] == {}
+
+
 def test_schema_with_defs_uses_main_path_regardless_of_flag() -> None:
     schema = {
         "type": "object",

--- a/tests/test_hoist_flat.py
+++ b/tests/test_hoist_flat.py
@@ -1,0 +1,238 @@
+"""Opt-in flat-schema hoisting (issue #375).
+
+``hoist_inline_defs(..., hoist_flat=True)`` promotes structured *flat* schemas
+(objects/arrays with no inline ``$defs`` and no local ``#/$defs`` refs) into
+``components.schemas`` and replaces them with a ``$ref``. This deduplicates a
+flat schema reused across endpoints exactly like model-class schemas already
+are. The default (``hoist_flat=False``) preserves the verbatim inline behaviour
+from #311, and trivial scalar schemas are always left inline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from azure_functions_openapi.bridge import _HANDLER_METADATA_ATTR, scan_endpoint_metadata
+from azure_functions_openapi.decorator import clear_openapi_registry, get_openapi_registry
+from azure_functions_openapi.spec import generate_openapi_spec
+from azure_functions_openapi.utils import hoist_inline_defs
+
+
+def _make_components() -> dict[str, Any]:
+    return {"schemas": {}}
+
+
+def test_flat_schema_left_inline_by_default() -> None:
+    schema = {"title": "Widget", "type": "object", "properties": {"id": {"type": "integer"}}}
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components)
+
+    assert result == schema
+    assert components["schemas"] == {}
+
+
+def test_flat_schema_promoted_when_opted_in() -> None:
+    schema = {"title": "Widget", "type": "object", "properties": {"id": {"type": "integer"}}}
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components, hoist_flat=True)
+
+    assert result == {"$ref": "#/components/schemas/Widget"}
+    assert components["schemas"]["Widget"]["properties"] == {"id": {"type": "integer"}}
+
+
+def test_identical_flat_schemas_dedupe_to_one_component() -> None:
+    schema_a = {"title": "Widget", "type": "object", "properties": {"id": {"type": "integer"}}}
+    schema_b = {"title": "Widget", "type": "object", "properties": {"id": {"type": "integer"}}}
+    components = _make_components()
+
+    ref_a = hoist_inline_defs(schema_a, components, hoist_flat=True)
+    ref_b = hoist_inline_defs(schema_b, components, hoist_flat=True)
+
+    assert ref_a == ref_b == {"$ref": "#/components/schemas/Widget"}
+    assert list(components["schemas"]) == ["Widget"]
+
+
+def test_same_name_different_content_gets_alias() -> None:
+    schema_a = {"title": "Widget", "type": "object", "properties": {"id": {"type": "integer"}}}
+    schema_b = {"title": "Widget", "type": "object", "properties": {"id": {"type": "string"}}}
+    components = _make_components()
+
+    ref_a = hoist_inline_defs(schema_a, components, hoist_flat=True)
+    ref_b = hoist_inline_defs(schema_b, components, hoist_flat=True)
+
+    assert ref_a == {"$ref": "#/components/schemas/Widget"}
+    assert ref_b != ref_a
+    assert ref_b["$ref"].startswith("#/components/schemas/Widget")
+    assert len(components["schemas"]) == 2
+
+
+def test_anonymous_flat_schema_gets_deterministic_hash_name() -> None:
+    schema = {"type": "object", "properties": {"id": {"type": "integer"}}}
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components, hoist_flat=True)
+
+    ref = result["$ref"]
+    assert ref.startswith("#/components/schemas/InlineSchema_")
+    name = ref.rsplit("/", 1)[-1]
+    assert name in components["schemas"]
+
+    # A second identical anonymous schema dedupes to the same hash-based name.
+    result2 = hoist_inline_defs(dict(schema), components, hoist_flat=True)
+    assert result2 == result
+    assert list(components["schemas"]) == [name]
+
+
+def test_array_flat_schema_is_hoisted() -> None:
+    schema = {"title": "WidgetList", "type": "array", "items": {"type": "string"}}
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components, hoist_flat=True)
+
+    assert result == {"$ref": "#/components/schemas/WidgetList"}
+    assert components["schemas"]["WidgetList"]["items"] == {"type": "string"}
+
+
+def test_trivial_scalar_schema_left_inline_even_when_opted_in() -> None:
+    schema = {"type": "string"}
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components, hoist_flat=True)
+
+    assert result == schema
+    assert components["schemas"] == {}
+
+
+def test_schema_with_defs_uses_main_path_regardless_of_flag() -> None:
+    schema = {
+        "type": "object",
+        "properties": {"child": {"$ref": "#/$defs/Child"}},
+        "$defs": {"Child": {"type": "object", "properties": {"n": {"type": "integer"}}}},
+    }
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components, hoist_flat=True)
+
+    # $defs are lifted to components; root stays inline with rewritten refs.
+    assert "$defs" not in result
+    assert components["schemas"]["Child"]["properties"] == {"n": {"type": "integer"}}
+    assert result["properties"]["child"] == {"$ref": "#/components/schemas/Child"}
+
+
+def test_input_schema_is_not_mutated() -> None:
+    schema = {"title": "Widget", "type": "object", "properties": {"id": {"type": "integer"}}}
+    original = {"title": "Widget", "type": "object", "properties": {"id": {"type": "integer"}}}
+    components = _make_components()
+
+    hoist_inline_defs(schema, components, hoist_flat=True)
+
+    assert schema == original
+
+
+# ---------------------------------------------------------------------------
+# Spec-level integration: hoist_flat_schemas plumbs through generate_openapi_spec
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+class _MockBinding:
+    def __init__(self, route: str, methods: list[str] | None, type: str = "httpTrigger") -> None:
+        self.route = route
+        self.methods = methods
+        self.type = type
+
+
+class _MockFunction:
+    def __init__(self, name: str, func: Any, bindings: list[Any]) -> None:
+        self._name = name
+        self._func = func
+        self._bindings = bindings
+
+    def get_function_name(self) -> str:
+        return self._name
+
+    def get_user_function(self) -> Any:
+        return self._func
+
+    def get_bindings(self) -> list[Any]:
+        return self._bindings
+
+    def is_http_function(self) -> bool:
+        return any(str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings)
+
+
+class _MockBuilder:
+    def __init__(self, function: _MockFunction) -> None:
+        self._function = function
+
+    def build(self, auth_level: Any = None) -> _MockFunction:
+        return self._function
+
+
+class _MockApp:
+    def __init__(self, builders: list[_MockBuilder]) -> None:
+        self._function_builders = builders
+
+
+_FLAT_BODY: dict[str, Any] = {
+    "title": "CreateUser",
+    "type": "object",
+    "properties": {"name": {"type": "string"}},
+}
+
+
+def _make_flat_app() -> _MockApp:
+    def handler(req: Any) -> Any:
+        return req
+
+    setattr(
+        handler,
+        _HANDLER_METADATA_ATTR,
+        {
+            "endpoint": {
+                "version": 1,
+                "request_body": _FLAT_BODY,
+                "request_body_required": True,
+                "responses": {"200": {"schema": {"type": "object"}}},
+            }
+        },
+    )
+    binding = _MockBinding(route="users", methods=["POST"])
+    fn = _MockFunction(name="create_user", func=handler, bindings=[binding])
+    return _MockApp([_MockBuilder(fn)])
+
+
+def _request_schema(spec: dict[str, Any]) -> dict[str, Any]:
+    op = spec["paths"]["/api/users"]["post"]
+    schema: dict[str, Any] = op["requestBody"]["content"]["application/json"]["schema"]
+    return schema
+
+
+def test_spec_keeps_flat_body_inline_by_default(_clean_registry: Any) -> None:
+    scan_endpoint_metadata(_make_flat_app())
+    assert get_openapi_registry()
+
+    spec = generate_openapi_spec()
+
+    assert _request_schema(spec) == _FLAT_BODY
+    assert "CreateUser" not in spec.get("components", {}).get("schemas", {})
+
+
+def test_spec_hoists_flat_body_when_opted_in(_clean_registry: Any) -> None:
+    scan_endpoint_metadata(_make_flat_app())
+    assert get_openapi_registry()
+
+    spec = generate_openapi_spec(hoist_flat_schemas=True)
+
+    assert _request_schema(spec) == {"$ref": "#/components/schemas/CreateUser"}
+    assert spec["components"]["schemas"]["CreateUser"]["properties"] == {"name": {"type": "string"}}


### PR DESCRIPTION
## Context

Producer-authored *flat* schemas (objects/arrays with no inline `$defs`) are currently emitted inline at every endpoint. When the same flat schema is reused across endpoints it is duplicated in the document, unlike model-class schemas which already dedupe into `components.schemas`. Targets #375.

This adds an **opt-in** promotion path that lifts structured flat schemas into `components.schemas` and replaces them with a `$ref`, so reused schemas dedupe the same way `$defs` and Pydantic models do. The default preserves the verbatim inline behaviour from #311 (non-breaking; the 8 existing hoist snapshots are untouched).

## Acceptance Checklist
- [x] `hoist_inline_defs(..., hoist_flat=True)` promotes structured flat schemas to `components.schemas` and returns a `$ref`.
- [x] Default `hoist_flat=False` leaves flat schemas inline (byte-identical to prior behaviour).
- [x] Identical flat schemas dedupe to a single component; same-name/different-content gets a deterministic alias via `_resolve_name_collision`.
- [x] Naming prefers `title`; anonymous schemas get a deterministic `InlineSchema_<hash8>` name.
- [x] Trivial scalar schemas (e.g. `{"type": "string"}`) are always left inline.
- [x] `generate_openapi_spec(hoist_flat_schemas=True)` threads the flag through response/parameter/requestBody schemas.
- [x] Input schema is never mutated.
- [x] New tests in `tests/test_hoist_flat.py` (11 cases) cover unit + spec-level integration.
- [x] `make check-all` passes (coverage ≥ 95%).

## Out of scope
- Making `hoist_flat` the default (would break existing snapshots; deferred pending a minor-version decision).
- Hoisting of already-model-backed schemas (already handled by `model_to_schema`).

## References
- Closes #375
- Related hoisting work: #311, #315, #320