### PR TITLE
fix(schema): make hoisted component names JSON-Pointer safe and hash strictly

### DIFF
--- a/src/azure_functions_openapi/utils.py
+++ b/src/azure_functions_openapi/utils.py
@@ -75,7 +75,6 @@ def _resolve_name_collision(
     name = _sanitize_component_name(name)
     if name not in existing:
         return name
-        return name
     if existing[name] == schema:
         return name
     index = 2

--- a/src/azure_functions_openapi/utils.py
+++ b/src/azure_functions_openapi/utils.py
@@ -138,10 +138,22 @@ def _needs_hoisting(obj: Any) -> bool:
 
 _FLAT_COMPOSITION_KEYS = ("properties", "items", "anyOf", "oneOf", "allOf")
 
+# JSON Pointer (RFC 6901) treats ``/`` as a path separator and ``~`` as an
+# escape; either inside a hoisted component name breaks ``#/components/schemas``
+# references, so they are normalized out of derived component identifiers.
+_UNSAFE_COMPONENT_NAME_CHARS = re.compile(r"[/~]")
+
 
 def _schema_short_hash(schema: dict[str, Any]) -> str:
-    """Return a stable 8-char hash of a schema's canonical JSON form."""
-    canonical = json.dumps(schema, sort_keys=True, default=str)
+    """Return a stable 8-char hash of a schema's canonical JSON form.
+
+    Uses strict JSON serialization (no ``default=`` fallback) so a non-JSON
+    value raises :class:`TypeError` instead of being coerced to a string. That
+    keeps the hash deterministic across processes -- ``str(obj)`` can embed a
+    per-process memory address -- and enforces the endpoint-metadata contract
+    that schemas are plain, JSON-compatible dicts.
+    """
+    canonical = json.dumps(schema, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8]
 
 
@@ -167,16 +179,29 @@ def _is_hoistable_flat_schema(schema: Any) -> bool:
     return isinstance(schema.get("additionalProperties"), dict)
 
 
+def _sanitize_component_name(name: str) -> str:
+    """Normalize a component name to a JSON-Pointer-safe identifier.
+
+    A hoisted name is emitted as ``#/components/schemas/<name>``. The JSON
+    Pointer special characters ``/`` and ``~`` would otherwise be read as path
+    separators / escapes (RFC 6901), so ``"Order/Item"`` would resolve to
+    ``components -> schemas -> Order -> Item`` instead of the single key. We
+    normalize them to ``_`` so the reference always resolves to one component.
+    """
+    return _UNSAFE_COMPONENT_NAME_CHARS.sub("_", name)
+
+
 def _flat_schema_name(schema: dict[str, Any]) -> str:
     """Derive a component name for a flat schema.
 
-    Prefers the schema's ``title`` (the natural name Pydantic emits); falls back
-    to a deterministic ``InlineSchema_<hash>`` for anonymous schemas so identical
-    schemas dedupe to the same component.
+    Prefers the schema's ``title`` (the natural name Pydantic emits), sanitized
+    to a JSON-Pointer-safe identifier; falls back to a deterministic
+    ``InlineSchema_<hash>`` for anonymous schemas so identical schemas dedupe to
+    the same component.
     """
     title = schema.get("title")
     if isinstance(title, str) and title.strip():
-        return title.strip()
+        return _sanitize_component_name(title.strip())
     return f"InlineSchema_{_schema_short_hash(schema)}"
 
 

--- a/src/azure_functions_openapi/utils.py
+++ b/src/azure_functions_openapi/utils.py
@@ -69,7 +69,12 @@ def _resolve_name_collision(
     schema: dict[str, Any],
     existing: dict[str, dict[str, Any]],
 ) -> str:
+    # Sanitize first so JSON-Pointer-unsafe characters (``/``, ``~``) can never
+    # reach a ``#/components/schemas/<name>`` reference, regardless of which
+    # hoisting path (``$defs``, model class, or flat schema) supplied the name.
+    name = _sanitize_component_name(name)
     if name not in existing:
+        return name
         return name
     if existing[name] == schema:
         return name
@@ -194,14 +199,15 @@ def _sanitize_component_name(name: str) -> str:
 def _flat_schema_name(schema: dict[str, Any]) -> str:
     """Derive a component name for a flat schema.
 
-    Prefers the schema's ``title`` (the natural name Pydantic emits), sanitized
-    to a JSON-Pointer-safe identifier; falls back to a deterministic
-    ``InlineSchema_<hash>`` for anonymous schemas so identical schemas dedupe to
-    the same component.
+    Prefers the schema's ``title`` (the natural name Pydantic emits); falls back
+    to a deterministic ``InlineSchema_<hash>`` for anonymous schemas so identical
+    schemas dedupe to the same component. JSON-Pointer sanitization of the name
+    is applied centrally in :func:`_resolve_name_collision`, so every hoisting
+    path shares one escaping rule.
     """
     title = schema.get("title")
     if isinstance(title, str) and title.strip():
-        return _sanitize_component_name(title.strip())
+        return title.strip()
     return f"InlineSchema_{_schema_short_hash(schema)}"
 
 

--- a/tests/test_hoist_flat.py
+++ b/tests/test_hoist_flat.py
@@ -303,3 +303,54 @@ def test_generate_openapi_report_forwards_hoist_flag(_clean_registry: Any) -> No
     assert _request_schema(hoisted_report.spec) == {
         "$ref": "#/components/schemas/CreateUser"
     }
+# ---------------------------------------------------------------------------
+# JSON-Pointer-safe component names + strict hashing (issue #379)
+# ---------------------------------------------------------------------------
+
+
+def test_title_with_slash_is_sanitized_to_resolvable_ref() -> None:
+    schema = {"title": "Order/Item", "type": "object", "properties": {"id": {"type": "integer"}}}
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components, hoist_flat=True)
+
+    # ``/`` would otherwise be read as a JSON Pointer path separator.
+    assert result == {"$ref": "#/components/schemas/Order_Item"}
+    assert "Order_Item" in components["schemas"]
+    assert "Order/Item" not in components["schemas"]
+
+
+def test_title_with_tilde_is_sanitized_to_resolvable_ref() -> None:
+    schema = {"title": "Order~Item", "type": "object", "properties": {"id": {"type": "integer"}}}
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components, hoist_flat=True)
+
+    # ``~`` is the JSON Pointer escape character and must not survive verbatim.
+    assert result == {"$ref": "#/components/schemas/Order_Item"}
+    assert "Order_Item" in components["schemas"]
+
+
+def test_sanitized_names_collide_and_alias_deterministically() -> None:
+    # Two distinct titles sanitize to the same identifier with differing content.
+    schema_a = {"title": "Order/Item", "type": "object", "properties": {"id": {"type": "integer"}}}
+    schema_b = {"title": "Order~Item", "type": "object", "properties": {"id": {"type": "string"}}}
+    components = _make_components()
+
+    ref_a = hoist_inline_defs(schema_a, components, hoist_flat=True)
+    ref_b = hoist_inline_defs(schema_b, components, hoist_flat=True)
+
+    assert ref_a == {"$ref": "#/components/schemas/Order_Item"}
+    assert ref_b != ref_a
+    assert ref_b["$ref"].startswith("#/components/schemas/Order_Item")
+    assert len(components["schemas"]) == 2
+
+
+def test_anonymous_hash_rejects_non_json_schema() -> None:
+    # Strict serialization (no ``default=str``) surfaces non-JSON metadata as a
+    # loud failure instead of a non-deterministic, memory-address-tainted name.
+    schema = {"type": "object", "properties": {"id": {"type": "integer"}}, "x": object()}
+    components = _make_components()
+
+    with pytest.raises(TypeError):
+        hoist_inline_defs(schema, components, hoist_flat=True)

--- a/tests/test_hoist_flat.py
+++ b/tests/test_hoist_flat.py
@@ -354,3 +354,22 @@ def test_anonymous_hash_rejects_non_json_schema() -> None:
 
     with pytest.raises(TypeError):
         hoist_inline_defs(schema, components, hoist_flat=True)
+
+
+def test_defs_path_sanitizes_names_without_opt_in() -> None:
+    # Regression (#379): the JSON-Pointer-safety bug is NOT opt-in-only. The
+    # default ``$defs`` hoisting path (``hoist_flat=False``) flows through the
+    # same ``_resolve_name_collision`` entry, so a ``$defs`` key containing ``/``
+    # must also be sanitized and its ref rewritten to resolve.
+    schema = {
+        "$defs": {"Order/Item": {"type": "object", "properties": {"id": {"type": "integer"}}}},
+        "type": "object",
+        "properties": {"item": {"$ref": "#/$defs/Order/Item"}},
+    }
+    components = _make_components()
+
+    result = hoist_inline_defs(schema, components)  # default: hoist_flat=False
+
+    assert "Order_Item" in components["schemas"]
+    assert "Order/Item" not in components["schemas"]
+    assert result["properties"]["item"] == {"$ref": "#/components/schemas/Order_Item"}

--- a/tests/test_hoist_flat.py
+++ b/tests/test_hoist_flat.py
@@ -373,3 +373,21 @@ def test_defs_path_sanitizes_names_without_opt_in() -> None:
     assert "Order_Item" in components["schemas"]
     assert "Order/Item" not in components["schemas"]
     assert result["properties"]["item"] == {"$ref": "#/components/schemas/Order_Item"}
+
+
+def test_model_path_sanitizes_name_and_rewrites_ref() -> None:
+    # Regression (#379): the model hoisting path (``model_to_schema``) also flows
+    # through ``_resolve_name_collision``, so a model whose name contains ``/``
+    # must be sanitized and its root ``$ref`` rewritten to the resolvable key.
+    from pydantic import create_model
+
+    from azure_functions_openapi.utils import model_to_schema
+
+    weird_model = create_model("Order/Item", id=(int, ...))
+    components = _make_components()
+
+    result = model_to_schema(weird_model, components)
+
+    assert result == {"$ref": "#/components/schemas/Order_Item"}
+    assert "Order_Item" in components["schemas"]
+    assert "Order/Item" not in components["schemas"]


### PR DESCRIPTION
## Summary
- Sanitize hoisted component names so `/` and `~` never leak into `#/components/schemas/{name}` refs (JSON-Pointer safe), using `_sanitize_component_name`.
- Make `_schema_short_hash` strict: serialize with `json.dumps(schema, sort_keys=True, separators=(",", ":"))` and drop the `default=str` fallback so non-JSON-serializable schemas raise `TypeError` instead of silently producing unstable hashes.

## Acceptance
- [x] Titles containing `/` or `~` are sanitized (e.g. `Order/Item` -> `Order_Item`).
- [x] Sanitized-name collisions get a distinct alias.
- [x] Non-JSON-serializable schema raises `TypeError`.
- [x] `make check-all` green (coverage >= 95%).

Closes #379