### PR TITLE
fix(warnings): scope empty-discovery reason to the selected application object

### DIFF
--- a/src/azure_functions_openapi/_warnings.py
+++ b/src/azure_functions_openapi/_warnings.py
@@ -32,6 +32,7 @@ class WarningCode(str, Enum):
     DUPLICATE_OPERATION = "duplicate-operation"
     SPEC_VALIDATION = "spec-validation"
     DISCOVERY_SKIPPED = "discovery-skipped"
+    EMPTY_DISCOVERY = "empty-discovery"
     METHOD_BINDING_MISMATCH = "method-binding-mismatch"
 
     def __str__(self) -> str:  # pragma: no cover - trivial

--- a/src/azure_functions_openapi/adapters/azure_functions.py
+++ b/src/azure_functions_openapi/adapters/azure_functions.py
@@ -122,8 +122,9 @@ def iter_functions(
     Skips any builder whose :meth:`FunctionBuilder.build` raises ``ValueError``
     (e.g. a function with no trigger, or a trigger not present in its bindings).
     Such a function is a *user app state*, not an SDK incompatibility, so it is
-    empty list when *app* exposes no builders (e.g. an app with no registered
-    functions). When the app itself carries no builders but wraps a real
+    skipped rather than raising. Returns an empty list when *app* exposes
+    no builders (e.g. an app with no registered functions). When the app
+    itself carries no builders but wraps a real
     ``FunctionApp`` via a property (e.g. ``LangGraphApp.function_app``), the
     inner app is unwrapped and enumerated (#374); a truly empty app still
     returns an empty list, matching the previous "skip quietly" behaviour.

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -468,17 +468,14 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
     )
     if not functions:
         logger.debug("No function builders found on app; skipping validation scan")
-        # #373: an app that exposes no discoverable functions is recorded as a
-        # structured discovery-skipped warning (in addition to the debug log) so
-        # ``--fail-on-warnings`` can catch it. #380: state only the observed fact
-        # -- whether the *final* spec paths are empty is decided by the CLI's
-        # post-generation check (``cli.py``), because the process-wide registry
-        # may already hold paths from other decorated apps.
-        registry.add_discovery_warning(
-            None,
-            "no functions were discovered from the selected application object "
-            f"({type(app).__name__})",
-        )
+        # #373/#380: an app that exposes no discoverable functions is recorded on
+        # the dedicated empty-discovery channel (not the builder-failure channel)
+        # so ``--fail-on-warnings`` catches it as a distinct ``empty-discovery``
+        # signal. No individual builder failed here -- the app simply had nothing
+        # to enumerate -- and whether the *final* spec paths are empty is decided
+        # by the CLI's post-generation check, since the process-wide registry may
+        # already hold paths from other decorated apps.
+        registry.add_empty_discovery(type(app).__name__)
         return
 
     for function in functions:

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -463,6 +463,39 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
     # ever gains a ``registry`` parameter, route ``on_skip`` to that registry as
     # well — otherwise discovery warnings would leak to / be read from the wrong
     # registry, the exact mirror of the bug #344 fixed for skew warnings.
+    #
+    # ``skipped`` tracks whether any builder failed to build: ``iter_functions``
+    # returns an empty list both when no builders exist AND when every builder
+    # fails (each firing ``on_skip`` without appending). Only the former is a
+    # true empty discovery -- see the ``EMPTY_DISCOVERY`` guard below.
+    skipped = False
+
+    def _on_skip(name: str | None, reason: str) -> None:
+        nonlocal skipped
+        skipped = True
+        registry.add_discovery_warning(name, reason)
+
+    functions = adapters.iter_functions(app, on_skip=_on_skip)
+    if not functions:
+        logger.debug("No function builders found on app; skipping validation scan")
+        # #373/#380: an app that exposes no discoverable functions is recorded on
+        # the dedicated empty-discovery channel (not the builder-failure channel)
+        # so ``--fail-on-warnings`` catches it as a distinct ``empty-discovery``
+        # signal. Guard on ``not skipped``: when builders existed but all failed
+        # to build, ``on_skip`` already recorded per-builder DISCOVERY_SKIPPED
+        # warnings, so emitting EMPTY_DISCOVERY too would be semantically wrong
+        # (builders were present) and would double-trip ``--fail-on-warnings``.
+        # Whether the *final* spec paths are empty is decided by the CLI's
+        # post-generation check, since the process-wide registry may already
+        # hold paths from other decorated apps.
+        if not skipped:
+            registry.add_empty_discovery(type(app).__name__)
+        return
+    # registers entries there too (see ``register_openapi_metadata`` below), so
+    # the skips and entries stay in the same registry. NOTE: if this function
+    # ever gains a ``registry`` parameter, route ``on_skip`` to that registry as
+    # well — otherwise discovery warnings would leak to / be read from the wrong
+    # registry, the exact mirror of the bug #344 fixed for skew warnings.
     functions = adapters.iter_functions(
         app, on_skip=lambda name, reason: registry.add_discovery_warning(name, reason)
     )

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -468,14 +468,16 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
     )
     if not functions:
         logger.debug("No function builders found on app; skipping validation scan")
-        # #373: an app that exposes no discoverable functions produces an empty
-        # ``paths`` object. Record a structured discovery-skipped warning (in
-        # addition to the debug log) so ``--fail-on-warnings`` can catch a
-        # silently-empty spec instead of the skip vanishing.
+        # #373: an app that exposes no discoverable functions is recorded as a
+        # structured discovery-skipped warning (in addition to the debug log) so
+        # ``--fail-on-warnings`` can catch it. #380: state only the observed fact
+        # -- whether the *final* spec paths are empty is decided by the CLI's
+        # post-generation check (``cli.py``), because the process-wide registry
+        # may already hold paths from other decorated apps.
         registry.add_discovery_warning(
             None,
-            "no functions were discovered on the application object "
-            f"({type(app).__name__}); the generated spec will have empty paths",
+            "no functions were discovered from the selected application object "
+            f"({type(app).__name__})",
         )
         return
 

--- a/src/azure_functions_openapi/registry.py
+++ b/src/azure_functions_openapi/registry.py
@@ -30,6 +30,7 @@ class OpenAPIRegistry:
     def __init__(self) -> None:
         self._entries: dict[str, dict[str, Any]] = {}
         self._discovery_warnings: list[tuple[str | None, str]] = []
+        self._empty_discoveries: list[str] = []
         self._lock = threading.RLock()
 
     @property
@@ -95,6 +96,7 @@ class OpenAPIRegistry:
         with self._lock:
             self._entries.clear()
             self._discovery_warnings.clear()
+            self._empty_discoveries.clear()
 
     def find_by_function_id(
         self, function_id: str, method: str | None = None
@@ -178,6 +180,26 @@ class OpenAPIRegistry:
                 self._discovery_warnings,
                 key=lambda record: (record[0] is not None, record[0] or "", record[1]),
             )
+
+    def add_empty_discovery(self, app_repr: str) -> None:
+        """Record that a scanned application object exposed no function builders.
+
+        This is a *different* condition from a builder-build failure recorded by
+        :meth:`add_discovery_warning`: no individual builder failed -- the app
+        simply had nothing to enumerate (#380). Keeping it on its own channel
+        lets the spec generator surface a distinct ``empty-discovery`` warning
+        instead of mislabelling it as a builder failure. Identical ``app_repr``
+        values are deduplicated, mirroring :meth:`add_discovery_warning`.
+        """
+        with self._lock:
+            if app_repr not in self._empty_discoveries:
+                self._empty_discoveries.append(app_repr)
+
+    @property
+    def empty_discoveries(self) -> list[str]:
+        """Return the recorded empty-app type names, deduplicated and sorted."""
+        with self._lock:
+            return sorted(self._empty_discoveries)
 
 # Process-wide singleton. The ``@openapi`` decorator records metadata at import
 # time — before any application object exists — so a shared instance is required.

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -791,6 +791,15 @@ _DISCOVERY_SKIPPED_MESSAGE = (
     "A function builder could not be built during discovery and was omitted from the spec"
 )
 
+# Empty-discovery is distinct from a builder-build failure (#380): the scanned
+# application object exposed no builders at all, so no per-builder failure
+# occurred. It carries its own message so ``--fail-on-warnings`` users are not
+# told a builder "could not be built" when none was ever present.
+_EMPTY_DISCOVERY_MESSAGE = (
+    "No function builders were discovered on the scanned application object"
+)
+
+
 # Method/binding mismatch is authored disagreement, not a skew signal: an
 # explicit ``@openapi(method=...)`` names a verb the HTTP binding does not serve,
 # so the generated operation cannot be reached at runtime.
@@ -861,6 +870,28 @@ def _collect_discovery_warnings(
             function_name=function_name,
         )
         for function_name, reason in reg.discovery_warnings
+    ]
+
+
+def _collect_empty_discovery_warnings(
+    registry: OpenAPIRegistry | None = None,
+) -> list[SpecWarning]:
+    """Derive empty-discovery warnings from the registry's recorded empty scans.
+
+    A scanned application object that exposes no function builders (#380) is a
+    distinct condition from a builder-build failure, so it gets its own
+    :class:`WarningCode.EMPTY_DISCOVERY` rather than reusing the builder-failure
+    template. When ``registry`` is provided its records are used, keeping
+    warnings isolated to the same registry the spec was built from.
+    """
+    reg = registry if registry is not None else _default_registry
+    return [
+        SpecWarning(
+            code=WarningCode.EMPTY_DISCOVERY,
+            message=f"{_EMPTY_DISCOVERY_MESSAGE} ({app_repr})",
+            function_name=None,
+        )
+        for app_repr in reg.empty_discoveries
     ]
 
 
@@ -957,6 +988,7 @@ def collect_spec_warnings(
     """
     warnings_list: list[SpecWarning] = _collect_skew_warnings(registry)
     warnings_list.extend(_collect_discovery_warnings(registry))
+    warnings_list.extend(_collect_empty_discovery_warnings(registry))
     warnings_list.extend(_collect_binding_mismatch_warnings(registry))
     for message in _validate_spec(spec):
         warnings_list.append(SpecWarning(code=WarningCode.SPEC_VALIDATION, message=message))

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -293,7 +293,10 @@ def test_scan_empty_app_records_discovery_warning() -> None:
 
     warnings = registry.discovery_warnings
     assert warnings, "expected a discovery-skipped warning for an empty app"
-    assert any(name is None and "empty paths" in reason for name, reason in warnings)
+    assert any(
+        name is None and "discovered from the selected application object" in reason
+        for name, reason in warnings
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel
 import pytest
 
+from azure_functions_openapi._warnings import WarningCode
 from azure_functions_openapi.bridge import (
     _HANDLER_METADATA_ATTR,
     _discovered_operation_from_endpoint,
@@ -18,7 +19,7 @@ from azure_functions_openapi.decorator import (
     register_openapi_metadata,
 )
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
-from azure_functions_openapi.spec import generate_openapi_spec
+from azure_functions_openapi.spec import collect_spec_warnings, generate_openapi_spec
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
@@ -282,21 +283,27 @@ def test_scan_endpoint_request_body_not_required() -> None:
     assert entry["request_body_required"] is False
 
 
-def test_scan_empty_app_records_discovery_warning() -> None:
-    # Regression (#373): an app exposing no discoverable functions must record a
-    # structured discovery-skipped warning (not just a debug log) so
-    # ``--fail-on-warnings`` can catch a silently-empty spec.
+def test_scan_empty_app_records_empty_discovery() -> None:
+    # Regression (#373/#380): an app exposing no discoverable functions must
+    # record a structured EMPTY_DISCOVERY warning (not just a debug log) so
+    # ``--fail-on-warnings`` can catch a silently-empty scan -- and it must NOT
+    # be mislabelled as a builder-build failure, nor predict empty final paths.
     from azure_functions_openapi.registry import registry
 
     app = MockApp([])
     scan_endpoint_metadata(app)
 
-    warnings = registry.discovery_warnings
-    assert warnings, "expected a discovery-skipped warning for an empty app"
-    assert any(
-        name is None and "discovered from the selected application object" in reason
-        for name, reason in warnings
-    )
+    assert registry.empty_discoveries == ["MockApp"]
+    # No builder-failure record was created for the empty app.
+    assert registry.discovery_warnings == []
+
+    warnings = collect_spec_warnings(generate_openapi_spec("t", "1"))
+    empty = [w for w in warnings if w.code == WarningCode.EMPTY_DISCOVERY]
+    assert len(empty) == 1
+    assert "MockApp" in empty[0].message
+    # The false builder-failure and empty-paths clauses must be gone.
+    assert "could not be built" not in empty[0].message
+    assert "empty paths" not in empty[0].message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, cast
 
 from pydantic import BaseModel
 import pytest
@@ -304,6 +304,36 @@ def test_scan_empty_app_records_empty_discovery() -> None:
     # The false builder-failure and empty-paths clauses must be gone.
     assert "could not be built" not in empty[0].message
     assert "empty paths" not in empty[0].message
+
+
+class _UnbuildableBuilder:
+    """A builder whose build() always raises, so the adapter skips it."""
+
+    def __init__(self, name: str) -> None:
+        self._function = MockFunction(name=name, func=lambda req: req, bindings=[])
+
+    def build(self, auth_level: Any = None) -> Any:
+        name = self._function.get_function_name()
+        raise ValueError(f"Function {name} does not have a trigger")
+
+def test_scan_all_builders_fail_records_skip_not_empty_discovery() -> None:
+    # Regression (#380 review): iter_functions returns [] both when no builders
+    # exist AND when every builder fails to build. The latter is NOT an empty
+    # discovery -- builders were present and each fired a DISCOVERY_SKIPPED
+    # warning, so recording EMPTY_DISCOVERY too would be semantically wrong and
+    # would double-trip --fail-on-warnings.
+    from azure_functions_openapi.registry import registry
+
+    app = MockApp([cast(MockBuilder, _UnbuildableBuilder("orphan"))])
+    scan_endpoint_metadata(app)
+
+    # The build failure was recorded, but no empty-discovery signal was emitted.
+    assert registry.empty_discoveries == []
+    assert len(registry.discovery_warnings) == 1
+
+    warnings = collect_spec_warnings(generate_openapi_spec("t", "1"))
+    assert not [w for w in warnings if w.code == WarningCode.EMPTY_DISCOVERY]
+    assert [w for w in warnings if w.code == WarningCode.DISCOVERY_SKIPPED]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reword the empty-discovery warning in `scan_endpoint_metadata` to claim only the observed fact — *"no functions were discovered from the selected application object (`<type>`)"* — dropping the "the generated spec will have empty paths" prediction.
- The process-wide registry can already hold paths from other decorated apps, so the scan-time skip does not imply an empty final spec. The authoritative empty-paths determination stays with the CLI's post-generation check (`cli.py`).

## Acceptance
- [x] Warning states only the observed fact, no "empty paths" claim.
- [x] CLI post-generation empty-paths check unchanged.
- [x] Associated test updated to assert the new wording.
- [x] `make check-all` green (coverage >= 95%).

Closes #380