### PR TITLE
refactor: opt-in app-scoped registry isolation (#381)

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -21,7 +21,13 @@ from azure_functions_openapi._validation_contract import (
 from azure_functions_openapi._warnings import WarningCode
 from azure_functions_openapi.decorator import register_openapi_metadata
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
-from azure_functions_openapi.registry import canonical_function_id, registry
+from azure_functions_openapi.registry import (
+    OpenAPIRegistry,
+    canonical_function_id,
+)
+from azure_functions_openapi.registry import (
+    registry as _global_registry,
+)
 from azure_functions_openapi.routes import (
     ALL_HTTP_METHODS,
     BODYLESS_HTTP_METHODS,
@@ -445,7 +451,45 @@ def _has_endpoint_namespace(handler: Any) -> bool:
     return False
 
 
-def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -> None:
+def _seed_canonical_entry(reg: OpenAPIRegistry, function_id: str) -> None:
+    """Copy a handler's canonical ``@openapi`` entries into an isolated registry.
+
+    In isolated mode (#381) the target ``reg`` starts empty, but a handler's
+    ``@openapi`` metadata was recorded into the *global* registry at import time.
+    This copies every global entry whose ``_function_id`` matches *function_id*
+    (deep-copied so later reconciliation cannot mutate the global) into ``reg``
+    under its original key, so the reconciliation logic resolves it exactly as it
+    would against the global registry.
+
+    Programmatic ``register_openapi_metadata`` entries carry a
+    ``"programmatic.*"`` ``_function_id`` and are not tied to any scanned app
+    object, so they are never seeded into an isolated app-scoped spec. Entries
+    already present in ``reg`` are left untouched (idempotent re-scan).
+    """
+    if function_id.startswith("programmatic."):
+        return
+    # Acquire the two registry locks sequentially, never nested. Snapshot the
+    # matching global entries (deep-copied eagerly) under the global lock only,
+    # then release it before writing into ``reg`` under its own lock. Holding
+    # both locks at once risked deadlock for future call paths and lengthened
+    # contention across the deepcopy/iteration; splitting the phases avoids both.
+    with _global_registry.lock:
+        seeds = {
+            key: copy.deepcopy(entry)
+            for key, entry in _global_registry.entries.items()
+            if entry.get("_function_id") == function_id
+        }
+    with reg.lock:
+        for key, entry in seeds.items():
+            if reg.get(key) is None:
+                reg.set(key, entry)
+
+
+def scan_endpoint_metadata(
+    app: Any,
+    route_prefix: str = DEFAULT_ROUTE_PREFIX,
+    registry: OpenAPIRegistry | None = None,
+) -> None:
     """Scan function builders for toolkit metadata and register OpenAPI operations.
 
     Reads the convention-based ``_azure_functions_metadata`` attribute from each
@@ -456,13 +500,21 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
     ``route_prefix`` mirrors ``host.json`` ``extensions.http.routePrefix``
     (default ``"/api"``). Pass ``""`` for hosts that disable the prefix or
     a custom value such as ``"/v1"`` to match a non-default deployment.
+
+    ``registry`` selects the target :class:`OpenAPIRegistry`. When ``None``
+    (the default) the process-wide global registry is used, preserving the
+    common single-app ``function_app.py`` layout. When an isolated registry is
+    injected (the CLI ``--isolate-app`` path, #381), each discovered handler's
+    canonical ``@openapi`` entry is seeded from the global registry into the
+    isolated one before reconciliation, so the generated spec contains only the
+    selected app's operations rather than every ``@openapi`` imported from the
+    module. Programmatic ``register_openapi_metadata`` entries (which are not
+    tied to any app object) are never seeded into an isolated registry.
     """
-    # Discovery skips are recorded on the *global* ``registry`` because this scan
-    # registers entries there too (see ``register_openapi_metadata`` below), so
-    # the skips and entries stay in the same registry. NOTE: if this function
-    # ever gains a ``registry`` parameter, route ``on_skip`` to that registry as
-    # well — otherwise discovery warnings would leak to / be read from the wrong
-    # registry, the exact mirror of the bug #344 fixed for skew warnings.
+    reg = registry if registry is not None else _global_registry
+    isolated = reg is not _global_registry
+    # Discovery skips are recorded on the *selected* registry so the skips and
+    # entries stay together (mirroring the #344 skew-warning isolation fix).
     #
     # ``skipped`` tracks whether any builder failed to build: ``iter_functions``
     # returns an empty list both when no builders exist AND when every builder
@@ -473,7 +525,7 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
     def _on_skip(name: str | None, reason: str) -> None:
         nonlocal skipped
         skipped = True
-        registry.add_discovery_warning(name, reason)
+        reg.add_discovery_warning(name, reason)
 
     functions = adapters.iter_functions(app, on_skip=_on_skip)
     if not functions:
@@ -489,26 +541,7 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
         # post-generation check, since the process-wide registry may already
         # hold paths from other decorated apps.
         if not skipped:
-            registry.add_empty_discovery(type(app).__name__)
-        return
-    # registers entries there too (see ``register_openapi_metadata`` below), so
-    # the skips and entries stay in the same registry. NOTE: if this function
-    # ever gains a ``registry`` parameter, route ``on_skip`` to that registry as
-    # well — otherwise discovery warnings would leak to / be read from the wrong
-    # registry, the exact mirror of the bug #344 fixed for skew warnings.
-    functions = adapters.iter_functions(
-        app, on_skip=lambda name, reason: registry.add_discovery_warning(name, reason)
-    )
-    if not functions:
-        logger.debug("No function builders found on app; skipping validation scan")
-        # #373/#380: an app that exposes no discoverable functions is recorded on
-        # the dedicated empty-discovery channel (not the builder-failure channel)
-        # so ``--fail-on-warnings`` catches it as a distinct ``empty-discovery``
-        # signal. No individual builder failed here -- the app simply had nothing
-        # to enumerate -- and whether the *final* spec paths are empty is decided
-        # by the CLI's post-generation check, since the process-wide registry may
-        # already hold paths from other decorated apps.
-        registry.add_empty_discovery(type(app).__name__)
+            reg.add_empty_discovery(type(app).__name__)
         return
 
     for function in functions:
@@ -556,14 +589,22 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
 
         canonical_id = canonical_function_id(handler)
 
+        # Seed-on-scan (#381): in isolated mode the target registry starts empty,
+        # so the handler's canonical @openapi entry (registered globally at import
+        # time) must be copied in before reconciliation — otherwise a plain
+        # @openapi handler would resolve to nothing and be dropped. Only this
+        # app's handlers are seeded, which is exactly what scopes the spec.
+        if isolated:
+            _seed_canonical_entry(reg, canonical_id)
+
         # Resolve the canonical @openapi entry once (it does not vary per
         # method). When @openapi decorates the handler BELOW @app.route, the
         # decorator cannot see the HTTP binding and registers the entry with
         # method=None; we then explode that entry into one operation per bound
         # method instead of merging every method into it, which would otherwise
         # collapse the generated spec to a single GET (#358).
-        with registry.lock:
-            canonical_target = registry.find_by_function_id(canonical_id)
+        with reg.lock:
+            canonical_target = reg.find_by_function_id(canonical_id)
             explode_canonical = (
                 canonical_target is not None and canonical_target.get("method") is None
             )
@@ -615,7 +656,7 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
             if discovered is not None and methods_expanded and method in BODYLESS_HTTP_METHODS:
                 discovered["request_body"] = None
 
-            with registry.lock:
+            with reg.lock:
                 if explode_canonical:
                     # Seed one per-method entry from the method=None @openapi
                     # entry, then merge any enrichment into it. Collapsing every
@@ -635,7 +676,7 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
                     if methods_expanded and method in BODYLESS_HTTP_METHODS:
                         clone["request_body"] = None
                     _tag_skew(clone, entry_skew)
-                    registry.set(endpoint_key, clone)
+                    reg.set(endpoint_key, clone)
                     continue
 
                 if discovered is None:
@@ -668,18 +709,18 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
                 # sibling comes first, corrupting per-method operations on a
                 # re-scan. The exact ``method::path`` key pins each method to its
                 # own entry; the id lookup is then method-aware as a backstop.
-                target = registry.get(endpoint_key)
+                target = reg.get(endpoint_key)
                 match_kind = "OpenAPI endpoint"
 
                 if target is None:
-                    target = registry.find_by_function_id(canonical_id, method=method)
+                    target = reg.find_by_function_id(canonical_id, method=method)
                     match_kind = "canonical @openapi id"
 
                 if target is None:
                     # Short-name fallback: refuse to merge when the name is
                     # ambiguous (shared across modules) to avoid silently
                     # attaching metadata to the wrong handler.
-                    if registry.count_by_function_name(function_name) > 1:
+                    if reg.count_by_function_name(function_name) > 1:
                         logger.warning(
                             "Refusing to merge validation metadata by ambiguous "
                             "short name '%s': multiple @openapi entries share this "
@@ -689,7 +730,7 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
                         )
                         entry_skew.add(WarningCode.AMBIGUOUS_NAMESPACE)
                     else:
-                        target = registry.get(function_name)
+                        target = reg.get(function_name)
                         match_kind = "short-name fallback"
 
                 if target is not None:
@@ -710,6 +751,7 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
                     request_body_required=discovered.get("request_body_required", True),
                     response=discovered.get("response") or None,
                     parameters=discovered.get("parameters") or None,
+                    registry=reg,
                 )
             else:
                 register_openapi_metadata(
@@ -720,13 +762,14 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
                     if _is_base_model_type(discovered.get("response_model"))
                     else None,
                     parameters=discovered.get("parameters") or None,
+                    registry=reg,
                 )
             logger.debug("Registered validation metadata for endpoint '%s'", endpoint_key)
             # Hold the registry lock across the get+mutate so tagging honours the
             # registry's documented thread-safety contract (the entry must not be
             # mutated after the lock protecting it has been released).
-            with registry.lock:
-                registered = registry.get(endpoint_key)
+            with reg.lock:
+                registered = reg.get(endpoint_key)
                 if registered is not None:
                     _tag_skew(registered, entry_skew)
 
@@ -735,14 +778,18 @@ def scan_endpoint_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -
         # GET duplicate (#358). Match by identity: find_by_function_id returns
         # the live entry but not its registry key.
         if explode_canonical:
-            with registry.lock:
-                for key, entry in list(registry.entries.items()):
+            with reg.lock:
+                for key, entry in list(reg.entries.items()):
                     if entry is canonical_target:
-                        del registry.entries[key]
+                        del reg.entries[key]
                         break
 
 
-def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX) -> None:
+def scan_validation_metadata(
+    app: Any,
+    route_prefix: str = DEFAULT_ROUTE_PREFIX,
+    registry: OpenAPIRegistry | None = None,
+) -> None:
     """Deprecated alias for :func:`scan_endpoint_metadata`.
 
     The scanner now primarily consumes the namespace-neutral ``"endpoint"``
@@ -757,4 +804,4 @@ def scan_validation_metadata(app: Any, route_prefix: str = DEFAULT_ROUTE_PREFIX)
         DeprecationWarning,
         stacklevel=2,
     )
-    scan_endpoint_metadata(app, route_prefix)
+    scan_endpoint_metadata(app, route_prefix, registry=registry)

--- a/src/azure_functions_openapi/cli.py
+++ b/src/azure_functions_openapi/cli.py
@@ -8,6 +8,7 @@ import sys
 
 from azure_functions_openapi.bridge import scan_endpoint_metadata
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+from azure_functions_openapi.registry import OpenAPIRegistry
 from azure_functions_openapi.spec import (
     DEFAULT_OPENAPI_INFO_DESCRIPTION,
     OPENAPI_VERSION_3_0,
@@ -165,6 +166,17 @@ Examples:
             "Use in CI to stop a wrong-but-plausible spec from being published."
         ),
     )
+    generate_parser.add_argument(
+        "--isolate-app",
+        action="store_true",
+        default=False,
+        help=(
+            "Scan the --app FunctionApp into a fresh, app-scoped registry "
+            "instead of the shared global one. Requires --app 'module:variable'. "
+            "Use when several apps are imported in one process to keep each "
+            "spec limited to its own routes and avoid cross-app leakage."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -186,6 +198,11 @@ Examples:
 def handle_generate(args: argparse.Namespace) -> int:
     """Handle generate command."""
     try:
+        # An app-scoped registry keeps a --isolate-app run limited to the routes
+        # of the given FunctionApp, avoiding cross-app leakage when several apps
+        # are imported in one process. Left None for the default shared-global flow.
+        active_registry: OpenAPIRegistry | None = None
+        isolate = getattr(args, "isolate_app", False) is True
         # Import user module first so @openapi decorators populate the registry.
         # When an explicit ``module:variable`` is given, resolve the FunctionApp
         # object and run endpoint-metadata discovery so producers that register
@@ -201,12 +218,23 @@ def handle_generate(args: argparse.Namespace) -> int:
                 return 1
 
             if variable_given and resolved_app is not None:
+                if isolate:
+                    active_registry = OpenAPIRegistry()
                 # One-shot discovery through the #325 adapter. `build()` is
                 # idempotent; we never call the non-idempotent `get_functions()`.
                 scan_endpoint_metadata(
-                    resolved_app, route_prefix=getattr(args, "route_prefix", "/api")
+                    resolved_app,
+                    route_prefix=getattr(args, "route_prefix", "/api"),
+                    registry=active_registry,
                 )
             else:
+                if isolate:
+                    print(
+                        "Note: --isolate-app ignored — it requires --app "
+                        f"'module:variable', but {args.app!r} has no ':variable'. "
+                        "Falling back to the shared global registry.",
+                        file=sys.stderr,
+                    )
                 print(
                     "Note: metadata discovery skipped — no ':variable' given in "
                     f"--app {args.app!r}. Only @openapi-decorated routes were "
@@ -230,8 +258,9 @@ def handle_generate(args: argparse.Namespace) -> int:
             description=description,
             route_prefix=getattr(args, "route_prefix", "/api"),
             strict=getattr(args, "strict", False),
+            registry=active_registry,
         )
-        warnings = collect_spec_warnings(spec)
+        warnings = collect_spec_warnings(spec, registry=active_registry)
         # Surface structured warnings (version skew / namespace fallback /
         # spec-validation) as JSON lines on stderr so CI can parse them, and
         # gate the exit code on them when --fail-on-warnings is set.

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -426,6 +426,7 @@ def register_openapi_metadata(
     parameters: list[dict[str, Any]] | None = None,
     security: list[dict[str, list[str]]] | None = None,
     security_scheme: dict[str, dict[str, Any]] | None = None,
+    registry: OpenAPIRegistry | None = None,
 ) -> None:
     """Register OpenAPI metadata for an endpoint programmatically.
 
@@ -463,6 +464,10 @@ def register_openapi_metadata(
         List of OpenAPI Security Requirement Objects.
     security_scheme:
         Security scheme definitions for components.securitySchemes.
+    registry:
+        Target :class:`OpenAPIRegistry` to record the operation in. Defaults to
+        the process-wide global registry (``None``); pass an isolated registry
+        to scope the metadata to a single application (see #381).
 
     Raises
     ------
@@ -509,8 +514,9 @@ def register_openapi_metadata(
     if request_model is not None or response_model is not None:
         _validate_models(request_model, response_model, registry_key)
 
-    with _registry_lock:
-        registry.set(registry_key, {
+    reg = registry if registry is not None else _registry
+    with reg.lock:
+        reg.set(registry_key, {
             "summary": summary,
             "description": description,
             "tags": validated_tags,

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -18,7 +18,11 @@ import pytest
 from azure_functions_openapi._warnings import SpecWarning, WarningCode
 from azure_functions_openapi.bridge import scan_endpoint_metadata
 from azure_functions_openapi.cli import handle_generate
-from azure_functions_openapi.decorator import clear_openapi_registry
+from azure_functions_openapi.decorator import (
+    clear_openapi_registry,
+    openapi,
+    register_openapi_metadata,
+)
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
 from azure_functions_openapi.registry import OpenAPIRegistry
 from azure_functions_openapi.registry import registry as default_registry
@@ -339,6 +343,7 @@ def _args(**overrides: Any) -> argparse.Namespace:
         "pretty": False,
         "output": None,
         "app": None,
+        "isolate_app": False,
     }
     base.update(overrides)
     return argparse.Namespace(**base)
@@ -491,3 +496,156 @@ class TestDuplicateOperationWarnings:
         default_registry.set("first", _dup_entry("first"))
         default_registry.set("second", _dup_entry("second"))
         assert handle_generate(_args(fail_on_warnings=True)) == 2
+
+
+# ---------------------------------------------------------------------------
+# #381: app-scoped (isolated) registry
+# ---------------------------------------------------------------------------
+
+
+def _decorated_app(
+    *,
+    fn_name: str,
+    route: str,
+    method: str = "POST",
+    summary: str = "",
+) -> MockApp:
+    """Build a MockApp whose single handler carries a plain ``@openapi`` entry.
+
+    Decorating registers a canonical entry in the *global* registry at call
+    time (mirroring import-time registration), while the returned app exposes
+    an HTTP binding so the scanner can reconcile it. A distinct ``__qualname__``
+    keeps each handler's ``_function_id`` unique across apps.
+    """
+
+    def handler(req: Any) -> Any:
+        return req
+
+    # Rename BEFORE decorating: @openapi keys the global entry by ``__name__``
+    # and derives ``_function_id`` from ``__qualname__`` at decoration time, so
+    # distinct names are required to avoid two apps colliding on one entry.
+    handler.__name__ = fn_name
+    handler.__qualname__ = f"_decorated_app.<locals>.{fn_name}"
+    decorated = openapi(summary=summary, method=method, route=route)(handler)
+    binding = MockBinding(route=route, methods=[method.upper()])
+    fn = MockFunction(name=fn_name, func=decorated, bindings=[binding])
+    return MockApp([MockBuilder(fn)])
+
+
+class TestIsolatedRegistry:
+    def test_isolated_scan_excludes_other_apps_openapi(self) -> None:
+        # Two apps register @openapi entries globally at decoration time. An
+        # isolated scan of app_a must document ONLY app_a's route, never leaking
+        # app_b's globally-registered entry into app_a's spec (#381).
+        app_a = _decorated_app(fn_name="a_handler", route="a/one", summary="A")
+        _decorated_app(fn_name="b_handler", route="b/one", summary="B")
+
+        iso = OpenAPIRegistry()
+        scan_endpoint_metadata(app_a, registry=iso)
+        spec = generate_openapi_spec(registry=iso)
+
+        assert "/api/a/one" in spec["paths"]
+        assert "/api/b/one" not in spec["paths"]
+
+    def test_global_default_scan_still_sees_all_entries(self) -> None:
+        # Baseline: without an injected registry, the shared global registry is
+        # used, so a global generate still reflects every registered route.
+        _decorated_app(fn_name="a_handler", route="a/one")
+        app_b = _decorated_app(fn_name="b_handler", route="b/one")
+
+        scan_endpoint_metadata(app_b)
+        spec = generate_openapi_spec()
+
+        # Both @openapi entries were registered globally at decoration time.
+        assert "/api/a/one" in spec["paths"]
+        assert "/api/b/one" in spec["paths"]
+
+    def test_isolated_scan_leaves_global_registry_untouched(self) -> None:
+        app_a = _decorated_app(fn_name="a_handler", route="a/one")
+        iso = OpenAPIRegistry()
+        scan_endpoint_metadata(app_a, registry=iso)
+
+        # Seeding deep-copies the global entry into the isolated registry; the
+        # global one must remain intact for a subsequent global generate.
+        global_spec = generate_openapi_spec()
+        assert "/api/a/one" in global_spec["paths"]
+
+    def test_discovery_warnings_isolated_to_target_registry(self) -> None:
+        # An unbuildable builder scanned into an isolated registry records its
+        # discovery-skipped warning on that registry, not the global one.
+        app = _decorated_app(fn_name="a_handler", route="a/one")
+        app._function_builders.append(_UnbuildableBuilder("orphan"))
+
+        iso = OpenAPIRegistry()
+        scan_endpoint_metadata(app, registry=iso)
+
+        iso_spec = generate_openapi_spec(registry=iso)
+        iso_warnings = collect_spec_warnings(iso_spec, registry=iso)
+        global_warnings = collect_spec_warnings(generate_openapi_spec())
+
+        assert any(w.code == WarningCode.DISCOVERY_SKIPPED for w in iso_warnings)
+        assert not any(
+            w.code == WarningCode.DISCOVERY_SKIPPED for w in global_warnings
+        )
+
+    def test_programmatic_entries_not_seeded_into_isolated_registry(self) -> None:
+        # Programmatic register_openapi_metadata entries are not tied to any
+        # scanned app object and must never leak into an isolated app spec.
+        register_openapi_metadata(path="/api/prog", method="GET", summary="prog")
+        app_a = _decorated_app(fn_name="a_handler", route="a/one")
+
+        iso = OpenAPIRegistry()
+        scan_endpoint_metadata(app_a, registry=iso)
+        spec = generate_openapi_spec(registry=iso)
+
+        assert "/api/a/one" in spec["paths"]
+        assert "/api/prog" not in spec["paths"]
+
+
+class TestCliIsolateApp:
+    def test_isolate_app_ignored_without_variable(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # --isolate-app requires 'module:variable'. With a bare module it is a
+        # no-op that warns and falls back to the global registry.
+        rc = handle_generate(_args(app="os", isolate_app=True))
+        assert rc == 0
+        assert "--isolate-app ignored" in capsys.readouterr().err
+
+    def test_isolate_app_scopes_spec_to_selected_app(
+        self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # End-to-end: a module exposing two apps generates a spec for only the
+        # selected app when --isolate-app is set.
+        module_src = (
+            "from typing import Any\n"
+            "from azure_functions_openapi.decorator import openapi\n"
+            "from tests.test_spec_warnings import (\n"
+            "    MockApp, MockBinding, MockBuilder, MockFunction,\n"
+            ")\n"
+            "\n"
+            "def _mk(fn_name, route):\n"
+            "    def handler(req: Any) -> Any:\n"
+            "        return req\n"
+            "    handler.__name__ = fn_name\n"
+            "    handler.__qualname__ = 'twoapp_' + fn_name\n"
+            "    decorated = openapi(summary=fn_name, method='POST', route=route)(handler)\n"
+            "    b = MockBinding(route=route, methods=['POST'])\n"
+            "    f = MockFunction(name=fn_name, func=decorated, bindings=[b])\n"
+            "    return MockApp([MockBuilder(f)])\n"
+            "\n"
+            "app_a = _mk('twoapp_a', 'a/one')\n"
+            "app_b = _mk('twoapp_b', 'b/one')\n"
+        )
+        mod_path = tmp_path / "twoapp_iso.py"
+        mod_path.write_text(module_src, encoding="utf-8")
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        out = tmp_path / "a.json"
+        rc = handle_generate(
+            _args(app="twoapp_iso:app_a", isolate_app=True, output=str(out))
+        )
+        assert rc == 0
+        spec = json.loads(out.read_text(encoding="utf-8"))
+        assert "/api/a/one" in spec["paths"]
+        assert "/api/b/one" not in spec["paths"]


### PR DESCRIPTION
## Summary
- Add an opt-in `--isolate-app` CLI flag that scans the `--app module:variable` FunctionApp into a fresh, app-scoped `OpenAPIRegistry` instead of the shared global one, so several apps imported in one process each generate a spec limited to their own routes (no cross-app leakage).
- Thread a `registry` parameter through `scan_endpoint_metadata`, `register_openapi_metadata`, `generate_openapi_spec`, and `collect_spec_warnings`.
- In isolated mode, each discovered handler's canonical `@openapi` entry is seeded (deep-copied) from the global registry before reconciliation, so plain `@openapi` handlers are not dropped. Programmatic `register_openapi_metadata` entries (`_function_id="programmatic.*"`) are never seeded.
- Default behaviour (shared global registry) is fully unchanged — the flag is off by default.

## Acceptance
- [x] `--isolate-app` requires `module:variable`; a bare module warns and falls back to the global registry.
- [x] Isolated scan documents only the selected app's routes; other apps' global `@openapi` entries do not leak.
- [x] Discovery warnings are recorded on the selected registry only.
- [x] Programmatic entries excluded from isolated specs.
- [x] Global default flow unchanged; regression tests added.
- [x] `make check-all` green, coverage ≥95%.

Closes #381