### PR TITLE
fix(bridge): make isolated re-scan idempotent by seeding on function id

### DIFF
--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -463,8 +463,13 @@ def _seed_canonical_entry(reg: OpenAPIRegistry, function_id: str) -> None:
 
     Programmatic ``register_openapi_metadata`` entries carry a
     ``"programmatic.*"`` ``_function_id`` and are not tied to any scanned app
-    object, so they are never seeded into an isolated app-scoped spec. Entries
-    already present in ``reg`` are left untouched (idempotent re-scan).
+    object, so they are never seeded into an isolated app-scoped spec. A handler
+    already reconciled into ``reg`` is left untouched: idempotency is judged by
+    ``_function_id`` identity, not registry-key presence, because reconciliation
+    rewrites the seeded ``method=None`` canonical into per-method ``method::path``
+    keys and deletes the original key (#358). Re-seeding on a later scan solely
+    because that original key vanished would resurrect a stale ``route=None``
+    ghost entry that spec.py then documents as a phantom endpoint (#388 regression).
     """
     if function_id.startswith("programmatic."):
         return
@@ -480,9 +485,15 @@ def _seed_canonical_entry(reg: OpenAPIRegistry, function_id: str) -> None:
             if entry.get("_function_id") == function_id
         }
     with reg.lock:
+        # Idempotency guard keyed on identity, not key presence: if ANY entry for
+        # this handler already lives in ``reg`` (including an exploded
+        # ``method::path`` entry whose original ``method=None`` key was deleted
+        # during reconciliation) the handler is already seeded. Re-seeding would
+        # reintroduce the stale canonical as a phantom endpoint on re-scan (#388).
+        if reg.find_by_function_id(function_id) is not None:
+            return
         for key, entry in seeds.items():
-            if reg.get(key) is None:
-                reg.set(key, entry)
+            reg.set(key, entry)
 
 
 def scan_endpoint_metadata(

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -532,6 +532,39 @@ def _decorated_app(
     return MockApp([MockBuilder(fn)])
 
 
+def _binding_only_app(
+    *,
+    fn_name: str,
+    route: str,
+    method: str = "POST",
+    qual_prefix: str = "_binding_only_app.<locals>",
+    func: Any = None,
+) -> MockApp:
+    """Build a MockApp whose handler is decorated WITHOUT method/route.
+
+    Unlike :func:`_decorated_app`, ``@openapi`` records a ``method=None`` /
+    ``route=None`` canonical entry; the HTTP verb and path come only from the
+    binding. This is the shape that makes reconciliation *explode* the canonical
+    into a per-method ``method::path`` entry and delete the original key, which is
+    the precondition for the #388 isolated re-scan phantom regression.
+
+    Passing ``func`` reuses an already-decorated handler (same ``_function_id``),
+    so a Blueprint and the app that registers it can be modelled as two builders
+    over one handler.
+    """
+    if func is None:
+
+        def handler(req: Any) -> Any:
+            return req
+
+        handler.__name__ = fn_name
+        handler.__qualname__ = f"{qual_prefix}.{fn_name}"
+        func = openapi(summary=fn_name)(handler)
+    binding = MockBinding(route=route, methods=[method.upper()])
+    fn = MockFunction(name=fn_name, func=func, bindings=[binding])
+    return MockApp([MockBuilder(fn)])
+
+
 class TestIsolatedRegistry:
     def test_isolated_scan_excludes_other_apps_openapi(self) -> None:
         # Two apps register @openapi entries globally at decoration time. An
@@ -600,6 +633,49 @@ class TestIsolatedRegistry:
 
         assert "/api/a/one" in spec["paths"]
         assert "/api/prog" not in spec["paths"]
+
+    def test_isolated_rescan_is_idempotent(self) -> None:
+        # #388 regression: scanning the SAME app twice into one isolated registry
+        # must not fabricate a phantom endpoint. Reconciliation explodes the
+        # seeded method=None canonical into a method::path entry and deletes the
+        # original key; a second scan that re-seeds purely because that key is
+        # gone would resurrect a stale route=None canonical, which spec.py then
+        # documents as GET /api/<function-name>. Seeding must be idempotent.
+        app = _binding_only_app(fn_name="handler_one", route="users/create")
+        iso = OpenAPIRegistry()
+
+        scan_endpoint_metadata(app, registry=iso)
+        first = generate_openapi_spec(registry=iso)
+        assert sorted(first["paths"]) == ["/api/users/create"]
+
+        scan_endpoint_metadata(app, registry=iso)
+        second = generate_openapi_spec(registry=iso)
+        # No phantom: the second scan yields byte-for-byte the same paths.
+        assert sorted(second["paths"]) == ["/api/users/create"]
+        assert "/api/handler_one" not in second["paths"]
+
+    def test_isolated_shared_handler_scan_no_phantom(self) -> None:
+        # #388 regression, single-call form: a Blueprint and the app that
+        # registers it expose the SAME handler, so a single isolated generate
+        # scans that handler twice (once per builder). Sharing one _function_id
+        # must still reconcile to one operation -- not seed a phantom that also
+        # trips a duplicate operationId during validation.
+        def handler(req: Any) -> Any:
+            return req
+
+        handler.__name__ = "bph"
+        handler.__qualname__ = "test_shared.bph"
+        decorated = openapi(summary="bph")(handler)
+        blueprint = _binding_only_app(fn_name="bph", route="bp/one", func=decorated)
+        app = _binding_only_app(fn_name="bph", route="bp/one", func=decorated)
+
+        iso = OpenAPIRegistry()
+        scan_endpoint_metadata(blueprint, registry=iso)
+        scan_endpoint_metadata(app, registry=iso)
+        spec = generate_openapi_spec(registry=iso)
+
+        assert sorted(spec["paths"]) == ["/api/bp/one"]
+        assert sorted(spec["paths"]["/api/bp/one"]) == ["post"]
 
 
 class TestCliIsolateApp:


### PR DESCRIPTION
## Summary
- Fixes a regression in the opt-in app-scoped registry isolation path (#388) where scanning the same app twice produced **phantom endpoints** (route-less `/api/handler_one`) and duplicate operationIds.
- `_seed_canonical_entry` now guards on **function identity** (`reg.find_by_function_id(function_id)`) instead of key presence, so a canonical entry that was exploded + had its original key deleted during reconcile is not re-seeded on a subsequent scan.

## Root cause
The previous guard used `reg.get(key) is None`. Reconcile explodes a `method=None` canonical into `method::path` keys and deletes the original key (#358). A second scan re-seeded the deleted key -> `route=None` phantom canonical -> `spec.py` renders it with function name + GET fallback. The global path was already idempotent; only isolation regressed.

## Changes
- `src/azure_functions_openapi/bridge.py`: identity-guarded seeding in `_seed_canonical_entry` (sequential lock acquisition: snapshot under global lock, identity-guarded set under registry lock). Docstring updated.
- `tests/test_spec_warnings.py`: two regression tests under `TestIsolatedRegistry` (`test_isolated_rescan_is_idempotent`, `test_isolated_shared_handler_scan_no_phantom`) + `_binding_only_app` helper. Verified both fail without the fix.

## Verification
- `make check-all` green; coverage 96.23% (688 passed, 5 skipped).

Closes #389