### PR TITLE
fix(schema): make component names OpenAPI-name-safe

### DIFF
--- a/src/azure_functions_openapi/utils.py
+++ b/src/azure_functions_openapi/utils.py
@@ -142,10 +142,12 @@ def _needs_hoisting(obj: Any) -> bool:
 
 _FLAT_COMPOSITION_KEYS = ("properties", "items", "anyOf", "oneOf", "allOf")
 
-# JSON Pointer (RFC 6901) treats ``/`` as a path separator and ``~`` as an
-# escape; either inside a hoisted component name breaks ``#/components/schemas``
-# references, so they are normalized out of derived component identifiers.
-_UNSAFE_COMPONENT_NAME_CHARS = re.compile(r"[/~]")
+# OpenAPI component keys must match ``^[a-zA-Z0-9._-]+$``. That set also keeps a
+# hoisted name JSON-Pointer safe (RFC 6901), since ``/`` (path separator) and
+# ``~`` (escape) are excluded. Any other character -- spaces, ``#``, ``@``, etc.
+# -- would produce an invalid ``components``/``$defs`` key, so it is normalized
+# out of derived component identifiers.
+_UNSAFE_COMPONENT_NAME_CHARS = re.compile(r"[^a-zA-Z0-9._-]+")
 
 
 def _schema_short_hash(schema: dict[str, Any]) -> str:
@@ -184,15 +186,23 @@ def _is_hoistable_flat_schema(schema: Any) -> bool:
 
 
 def _sanitize_component_name(name: str) -> str:
-    """Normalize a component name to a JSON-Pointer-safe identifier.
+    """Normalize a component name to an OpenAPI-name-safe identifier.
 
-    A hoisted name is emitted as ``#/components/schemas/<name>``. The JSON
-    Pointer special characters ``/`` and ``~`` would otherwise be read as path
-    separators / escapes (RFC 6901), so ``"Order/Item"`` would resolve to
-    ``components -> schemas -> Order -> Item`` instead of the single key. We
-    normalize them to ``_`` so the reference always resolves to one component.
+    A hoisted name is emitted as ``#/components/schemas/<name>``. OpenAPI
+    component keys must match ``^[a-zA-Z0-9._-]+$``; any other character is
+    normalized to ``_``. This subsumes the JSON-Pointer safety concern (RFC
+    6901): ``/`` (path separator) and ``~`` (escape) are outside the allowed
+    set, so ``"Order/Item"`` becomes ``"Order_Item"`` and always resolves to a
+    single component key rather than a nested path. When no usable character
+    survives (e.g. an all-symbol title like ``"###"``), a deterministic
+    ``Schema_<hash>`` derived from the original name is returned so identical
+    inputs dedupe to one key and the result still matches ``^[a-zA-Z0-9._-]+$``.
     """
-    return _UNSAFE_COMPONENT_NAME_CHARS.sub("_", name)
+    sanitized = _UNSAFE_COMPONENT_NAME_CHARS.sub("_", name)
+    if not sanitized.strip("_"):
+        digest = hashlib.sha256(name.encode("utf-8")).hexdigest()[:8]
+        return f"Schema_{digest}"
+    return sanitized
 
 
 def _flat_schema_name(schema: dict[str, Any]) -> str:

--- a/tests/test_utils_enhanced.py
+++ b/tests/test_utils_enhanced.py
@@ -12,6 +12,7 @@ from azure_functions_openapi.utils import (
     _resolve_name_collision,
     _rewrite_ref,
     _rewrite_refs_with_map,
+    _sanitize_component_name,
     model_to_schema,
     sanitize_operation_id,
     type_to_schema,
@@ -727,3 +728,36 @@ class TestPydanticV2EdgeCases:
         # PersonWithOptional should not have PersonWithLiteral's fields
         assert "role" not in components["schemas"]["PersonWithOptional"].get("properties", {})
         assert "nickname" not in components["schemas"]["PersonWithLiteral"].get("properties", {})
+
+
+class TestSanitizeComponentName:
+    """Test _sanitize_component_name enforces OpenAPI-name-safe keys (#394)."""
+
+    def test_json_pointer_chars_are_normalized(self) -> None:
+        assert _sanitize_component_name("Order/Item") == "Order_Item"
+        assert _sanitize_component_name("A~B") == "A_B"
+
+    def test_plain_names_are_preserved(self) -> None:
+        assert _sanitize_component_name("OrderItem") == "OrderItem"
+        assert _sanitize_component_name("Order_Item.v1-beta") == "Order_Item.v1-beta"
+
+    def test_openapi_invalid_chars_are_normalized(self) -> None:
+        # Spaces, '#', '@' are outside ^[a-zA-Z0-9._-]+$ and must not leak.
+        assert _sanitize_component_name("Order Item") == "Order_Item"
+        assert _sanitize_component_name("Order#1") == "Order_1"
+        assert _sanitize_component_name("user@example") == "user_example"
+
+    def test_result_always_matches_openapi_name_pattern(self) -> None:
+        import re
+
+        pattern = re.compile(r"^[a-zA-Z0-9._-]+$")
+        for raw in ("Order/Item", "Order Item", "###", "@@@", "héllo", "a b c"):
+            assert pattern.match(_sanitize_component_name(raw)), raw
+
+    def test_all_symbol_name_falls_back_to_deterministic_hash(self) -> None:
+        first = _sanitize_component_name("###")
+        second = _sanitize_component_name("###")
+        assert first == second  # deterministic
+        assert first.startswith("Schema_")
+        # A different all-symbol name yields a different key.
+        assert _sanitize_component_name("@@@") != first


### PR DESCRIPTION
## Summary
- Sanitize schema component names against the OpenAPI-safe character set (`[a-zA-Z0-9._-]`).
- Add a deterministic `Schema_<sha256[:8]>` fallback when a source name reduces to only unsafe/empty characters, preventing invalid or empty component keys.
- Add `TestSanitizeComponentName` covering JSON-pointer normalization, plain-name preservation, space/`#`/`@` handling, pattern matching, and all-symbol hash-fallback determinism.

## Verification
- `make check-all` green locally (coverage ≥95%).

Closes #394