### PR TITLE
fix(warnings): scope registry diagnostics to the current generation

### DIFF
--- a/src/azure_functions_openapi/registry.py
+++ b/src/azure_functions_openapi/registry.py
@@ -93,11 +93,35 @@ class OpenAPIRegistry:
             return copy.deepcopy(self._entries)
 
     def clear(self) -> None:
-        """Remove all entries, under :attr:`lock`."""
+        """Remove all entries and diagnostics, under :attr:`lock`."""
         with self._lock:
             self._entries.clear()
+            self.clear_diagnostics()
+
+    def clear_diagnostics(self) -> None:
+        """Clear all discovery/empty/duplicate diagnostics, leaving entries intact.
+
+        Diagnostics are *run-scoped*: they describe what happened during the
+        current scan/generation cycle, not the lifetime of the registry. The
+        one-shot report entry point (:func:`generate_openapi_report`) calls this
+        at the start of each cycle so a warning fixed between two runs (for
+        example a resolved ``DUPLICATE_OPERATION``) does not linger on the
+        process-wide singleton and resurface on the next generation (#393).
+        """
+        with self._lock:
             self._discovery_warnings.clear()
             self._empty_discoveries.clear()
+            self._duplicate_operations.clear()
+
+    def clear_duplicate_operations(self) -> None:
+        """Clear only the duplicate-operation channel, under :attr:`lock`.
+
+        Duplicate operations are fully recomputed on every
+        :func:`generate_openapi_spec` pass, so that generator clears this channel
+        at entry to avoid reporting a collision that a prior generation observed
+        but the current registry state no longer produces (#393).
+        """
+        with self._lock:
             self._duplicate_operations.clear()
 
     def find_by_function_id(

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -300,6 +300,12 @@ def generate_openapi_spec(
             registry_entries = registry.snapshot()
         else:
             registry_entries = get_openapi_registry()
+        # Duplicate operations are fully recomputed by the loop below, so clear
+        # the channel first: a collision resolved since a prior generation must
+        # not linger on the (process-wide or injected) registry and resurface
+        # here (#393).
+        _diag_registry = registry if registry is not None else _default_registry
+        _diag_registry.clear_duplicate_operations()
         paths: dict[str, dict[str, Any]] = {}
         components: dict[str, Any] = {"schemas": {}}
 

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -497,6 +497,21 @@ class TestDuplicateOperationWarnings:
         default_registry.set("second", _dup_entry("second"))
         assert handle_generate(_args(fail_on_warnings=True)) == 2
 
+    def test_resolved_collision_not_carried_to_next_generation(self) -> None:
+        # #393: diagnostics are run-scoped. A DUPLICATE_OPERATION observed in one
+        # generation must not linger on the registry and resurface after the
+        # collision is resolved, even when the same (long-lived) registry is
+        # reused for a second generation.
+        reg = self._colliding_registry()
+        first = collect_spec_warnings(generate_openapi_spec(registry=reg), registry=reg)
+        assert any(w.code == WarningCode.DUPLICATE_OPERATION for w in first)
+
+        # Resolve the collision by moving one operation to a distinct path, then
+        # regenerate against the SAME registry.
+        reg.set("second", {**_dup_entry("second"), "route": "dup-fixed"})
+        second = collect_spec_warnings(generate_openapi_spec(registry=reg), registry=reg)
+        assert not any(w.code == WarningCode.DUPLICATE_OPERATION for w in second)
+
 
 # ---------------------------------------------------------------------------
 # #381: app-scoped (isolated) registry


### PR DESCRIPTION
## Summary
- Registry diagnostics accumulated on the process-wide singleton and persisted until `clear()`, so a resolved `DUPLICATE_OPERATION` collision still surfaced on the next generation.
- Reset the duplicate-operation channel at the top of `generate_openapi_spec` (it is fully recomputed on every pass); fixed collisions no longer resurface, real ones are re-added.
- Add `OpenAPIRegistry.clear_diagnostics()` / `clear_duplicate_operations()` helpers; `clear()` now reuses `clear_diagnostics()`.
- Discovery/empty channels remain **scan-lifetime** and are intentionally left untouched — clearing them at generation entry would wipe the current run's scan warnings before collection (scan runs before generation).

## Verification
- `make check-all` green (coverage ≥95%).
- New regression `test_resolved_collision_not_carried_to_next_generation` reproduces the stale `DUPLICATE_OPERATION` across two generations against the same registry and asserts it is gone.

## Design note
Cross-verified the lifetime model with Oracle. The concrete, verifiable staleness bug is generation-scoped (`DUPLICATE_OPERATION`); the injected `--isolate-app` registry path uses the same `registry if registry is not None else _default_registry` resolution, so isolated registries clear their own channel with no cross-contamination.

Closes #393