### PR TITLE
fix(registry): distinguish dynamically-created handlers with identical qualnames

### DIFF
--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -9,7 +9,11 @@ from pydantic import BaseModel
 
 from azure_functions_openapi import adapters
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
-from azure_functions_openapi.registry import OpenAPIRegistry, canonical_function_id, registry
+from azure_functions_openapi.registry import (
+    OpenAPIRegistry,
+    ensure_canonical_identity,
+    registry,
+)
 from azure_functions_openapi.utils import sanitize_operation_id, validate_route_path
 
 # Define a generic type variable for functions
@@ -331,7 +335,7 @@ def openapi(
                 metadata_func.__name__,
             )
 
-            function_id = canonical_function_id(metadata_func)
+            function_id = ensure_canonical_identity(metadata_func)
 
             with _registry_lock:
                 registry_key = metadata_func.__name__

--- a/src/azure_functions_openapi/registry.py
+++ b/src/azure_functions_openapi/registry.py
@@ -16,6 +16,12 @@ import copy
 import inspect
 import threading
 from typing import Any
+import uuid
+
+# Attribute stamped by :func:`ensure_canonical_identity` on dynamically-created
+# handlers so :func:`canonical_function_id` can keep same-qualname closures
+# distinct (#392).
+_OPENAPI_UID_ATTR = "_openapi_uid"
 
 
 class OpenAPIRegistry:
@@ -266,4 +272,42 @@ def canonical_function_id(handler: Any) -> str:
     target = inspect.unwrap(handler) if callable(handler) else handler
     module = getattr(target, "__module__", "") or ""
     qualname = getattr(target, "__qualname__", None) or getattr(target, "__name__", "") or ""
-    return f"{module}.{qualname}"
+    base = f"{module}.{qualname}"
+    # Dynamically-created handlers (factory/closure) share a qualname such as
+    # ``factory.<locals>.handler`` across every factory call, so the qualified
+    # name alone collapses distinct handlers onto one registry entry (#392).
+    # When :func:`ensure_canonical_identity` has stamped a per-object token on
+    # the handler, fold it in to keep those handlers distinct. Module-level
+    # functions carry no token and keep their plain ``module.qualname`` identity.
+    token = getattr(target, _OPENAPI_UID_ATTR, None)
+    if token is not None:
+        return f"{base}#{token}"
+    return base
+
+
+def ensure_canonical_identity(handler: Any) -> str:
+    """Stamp a stable per-object identity token, then return the canonical id.
+
+    Factory/closure handlers share their ``__qualname__`` (for example
+    ``factory.<locals>.handler``) across every factory invocation, so
+    :func:`canonical_function_id` alone maps two distinct handlers to one
+    registry entry and silently drops one (#392). The ``@openapi`` decorator
+    calls this at decoration time for such handlers: it attaches a
+    process-local ``uuid4`` token to the unwrapped callable, which
+    :func:`canonical_function_id` (used by both the decorator and the SDK
+    bridge on the *same* handler object) then folds into the identity so the
+    two handlers stay distinct.
+
+    Module-level functions (no ``<locals>`` in their qualname) are left
+    untouched so their identity is unchanged. Handlers that reject attribute
+    assignment (an unusual immutable callable) simply keep the plain qualified
+    identity — a best-effort fallback rather than a hard failure.
+    """
+    target = inspect.unwrap(handler) if callable(handler) else handler
+    qualname = getattr(target, "__qualname__", "") or ""
+    if "<locals>" in qualname and getattr(target, _OPENAPI_UID_ATTR, None) is None:
+        try:
+            setattr(target, _OPENAPI_UID_ATTR, uuid.uuid4().hex)
+        except (AttributeError, TypeError):  # pragma: no cover - immutable callables
+            pass
+    return canonical_function_id(handler)

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -25,6 +25,17 @@ from azure_functions_openapi.spec import (
 OPENAPI_MODULE = importlib.import_module("azure_functions_openapi.spec")
 
 
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> Any:
+    # #392: distinct same-qualname closures now register as distinct entries
+    # (previously they silently collapsed onto one). Order-dependent tests must
+    # therefore start from a clean registry so accumulated fixtures from earlier
+    # tests do not trip duplicate-operation detection.
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
 def _register_http_trigger() -> None:
     @openapi(
         route="/api/http_trigger",

--- a/tests/test_registry_identity.py
+++ b/tests/test_registry_identity.py
@@ -21,6 +21,7 @@ from azure_functions_openapi.decorator import (
 from azure_functions_openapi.registry import (
     OpenAPIRegistry,
     canonical_function_id,
+    ensure_canonical_identity,
 )
 from azure_functions_openapi.spec import generate_openapi_spec
 
@@ -149,6 +150,55 @@ def test_canonical_function_id_unwraps_functools_wraps() -> None:
         return inner(req)
 
     assert canonical_function_id(outer) == canonical_function_id(inner)
+
+# ── #392: dynamically-created (factory/closure) handler identity ────────────
+def _module_level_handler(req: Any) -> Any:  # top-level: no ``<locals>``
+    return req
+
+
+def _openapi_factory(tag: str) -> Any:
+    """Return a fresh @openapi-decorated closure handler per call.
+
+    Every invocation builds a new ``handler`` object whose ``__qualname__`` is
+    identical (``_openapi_factory.<locals>.handler``), reproducing the #392
+    collision that used to collapse distinct handlers onto one registry entry.
+    """
+
+    @openapi(summary=tag, route=f"items/{tag}", method="get")
+    def handler(req: Any) -> Any:
+        return req
+
+    return handler
+
+
+def test_factory_handlers_get_distinct_canonical_ids() -> None:
+    a = _openapi_factory("a")
+    b = _openapi_factory("b")
+    # Same qualname, but decoration stamped a per-object token, so identities
+    # diverge instead of colliding.
+    assert a.__qualname__ == b.__qualname__
+    assert canonical_function_id(a) != canonical_function_id(b)
+
+
+def test_two_factory_handlers_register_as_two_entries() -> None:
+    a = _openapi_factory("a")
+    b = _openapi_factory("b")
+    reg = get_openapi_registry()
+    ids = {entry.get("_function_id") for entry in reg.values()}
+    # Both handlers survive as distinct entries — no silent data loss.
+    assert canonical_function_id(a) in ids
+    assert canonical_function_id(b) in ids
+    assert canonical_function_id(a) != canonical_function_id(b)
+
+
+def test_module_level_identity_is_unchanged() -> None:
+    cid = canonical_function_id(_module_level_handler)
+    # Module-level functions carry no disambiguation token.
+    assert "#" not in cid
+    assert cid == f"{_module_level_handler.__module__}.{_module_level_handler.__qualname__}"
+    # ensure_canonical_identity is a no-op for them (idempotent, unchanged id).
+    assert ensure_canonical_identity(_module_level_handler) == cid
+    assert canonical_function_id(_module_level_handler) == cid
 
 
 # ── #279: bridge merges into the correct entry despite short-name collision ──


### PR DESCRIPTION
## Summary
- `canonical_function_id()` keyed identity on `module.qualname`, so factory/closure handlers (`factory('a')` and `factory('b')`, both `…factory.<locals>.handler`) collapsed onto **one** registry entry and silently dropped one — worsened by #388 seeding, which uses `_function_id` as the membership key.
- Add `ensure_canonical_identity()`, called by `@openapi` at decoration time: it stamps a process-local `uuid4` token on the unwrapped callable **only** when the qualname contains `<locals>`. `canonical_function_id()` — used by both the decorator and the SDK bridge on the *same* handler object — folds the token in, keeping such handlers distinct.
- Module-level functions carry **no** token and keep their plain `module.qualname` identity unchanged.

## Why this is safe
- Both the decorator and bridge resolve the handler via `adapters.get_user_handler`, so the token attached at decoration is visible at scan time — the two sides always agree.
- Re-scan idempotency (#390) is preserved: a re-scanned handler is the same object with the same token → same id.

## Test isolation
Distinct same-qualname closures now correctly persist as distinct entries (previously they self-collapsed, masking accumulation). Added an autouse registry-clear fixture to `tests/test_openapi.py` so order-dependent tests start clean.

## Verification
- `make check-all` green (coverage ≥95%).
- New regression tests in `tests/test_registry_identity.py`:
  - `canonical_function_id(factory('a')) != canonical_function_id(factory('b'))`
  - two factory handlers register as two entries
  - module-level identity unchanged / no token

Closes #392