### PR TITLE
chore: bump ruff to 0.16.2 and repair pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
+default_language_version:
+  python: python3.12
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.16.2
     hooks:
       - id: ruff-format
       - id: ruff
@@ -24,6 +27,7 @@ repos:
     rev: 1.9.4
     hooks:
       - id: bandit
+        language_version: python3.12
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
         files: "^src/"
@@ -32,7 +36,7 @@ repos:
     hooks:
       - id: forbid-korean
         name: Forbid Korean Characters
-        entry: bash -c 'if grep -RIl --exclude-dir=.venv --exclude-dir=.git -n "[가-힣]" docs src README.md CONTRIBUTING.md AGENTS.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null; then echo "Korean characters detected. Please use English only."; exit 1; fi'
+        entry: bash -c 'if grep -RIn --exclude-dir=.venv --exclude-dir=.git "[가-힣]" docs src README.md CONTRIBUTING.md AGENTS.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null | grep -vE "README\.(ko|ja|zh-CN)\.md"; then echo "Korean characters detected. Please use English only."; exit 1; fi'
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/examples/notification_request/function_app.py
+++ b/examples/notification_request/function_app.py
@@ -80,7 +80,7 @@ _notifications: dict[str, dict[str, str]] = {}
         202: {"description": "Notification queued for delivery"},
         422: {"description": "Validation error"},
     },
-    )
+)
 @app.route(route="notifications/email", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 @validate_http(body=EmailNotificationRequest, response_model=NotificationAcceptedResponse)
 def send_notification(req: func.HttpRequest, body: EmailNotificationRequest) -> func.HttpResponse:
@@ -123,7 +123,7 @@ def send_notification(req: func.HttpRequest, body: EmailNotificationRequest) -> 
         200: {"description": "Notification status"},
         404: {"description": "Notification not found"},
     },
-    )
+)
 @app.route(route="notifications/status", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 @validate_http(query=NotificationStatusQuery, response_model=NotificationStatusResponse)
 def get_notification_status(

--- a/examples/report_jobs/function_app.py
+++ b/examples/report_jobs/function_app.py
@@ -130,7 +130,7 @@ def _check_bearer_auth(req: func.HttpRequest) -> func.HttpResponse | None:
     },
     security=_BEARER_SECURITY,
     security_scheme=_BEARER_SCHEME,
-    )
+)
 @app.route(route="reports", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 def submit_report(req: func.HttpRequest) -> func.HttpResponse:
     auth_error = _check_bearer_auth(req)
@@ -186,7 +186,7 @@ def submit_report(req: func.HttpRequest) -> func.HttpResponse:
     },
     security=_BEARER_SECURITY,
     security_scheme=_BEARER_SCHEME,
-    )
+)
 @app.route(route="reports/{job_id}/status", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def get_report_status(req: func.HttpRequest) -> func.HttpResponse:
     auth_error = _check_bearer_auth(req)

--- a/examples/webhook_receiver/function_app.py
+++ b/examples/webhook_receiver/function_app.py
@@ -91,7 +91,7 @@ def _verify_signature(payload: bytes, timestamp: str, signature: str, secret: st
         401: {"description": "Invalid webhook signature or expired timestamp"},
         409: {"description": "Duplicate delivery (replay)"},
     },
-    )
+)
 @app.route(route="webhooks/orders", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 def receive_order_webhook(req: func.HttpRequest) -> func.HttpResponse:
     # --- Replay protection: delivery ID deduplication ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "ruff==0.16.1",
+    "ruff==0.16.2",
     "openapi-spec-validator>=0.7.0",
     "types-PyYAML",
     "requests",

--- a/scripts/lint_mermaid.py
+++ b/scripts/lint_mermaid.py
@@ -11,8 +11,8 @@ Exit code 0 when clean, 1 when any violation is found.
 
 from __future__ import annotations
 
-import sys
 from pathlib import Path
+import sys
 
 # Files/globs to scan, relative to the repository root.
 TARGET_GLOBS = ("README*.md", "DESIGN.md", "docs/**/*.md")

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -363,32 +363,35 @@ def openapi(
                         # Preserve displaced entry under its fully-qualified id
                         registry.setdefault(existing_id, existing)
 
-                registry.set(registry_key, {
-                    # ── basic metadata ────────────────────────────────────────
-                    "summary": summary,
-                    "description": description,
-                    "tags": validated_tags,
-                    "operation_id": sanitized_operation_id,
-                    # ── routing info ─────────────────────────────────────────
-                    "route": validated_route,
-                    "method": validated_method,
-                    # Evidence that the runtime answers every HTTP method
-                    # (binding present, ``methods=`` omitted). Gates all-method
-                    # expansion in the spec generator; a bare @openapi stays
-                    # single-operation (#347).
-                    "_expand_all_methods": expand_all_methods,
-                    "parameters": validated_parameters,
-                    "security": validated_security,
-                    "security_scheme": validated_security_scheme,
-                    # ── request / response schema ────────────────────────
-                    "request_model": resolved_request_model,
-                    "request_body": resolved_request_body,
-                    "request_body_required": request_body_required,
-                    "response_model": resolved_response_model,
-                    "response": resolved_response or {},
-                    "function_name": metadata_func.__name__,
-                    "_function_id": function_id,
-                })
+                registry.set(
+                    registry_key,
+                    {
+                        # ── basic metadata ────────────────────────────────────────
+                        "summary": summary,
+                        "description": description,
+                        "tags": validated_tags,
+                        "operation_id": sanitized_operation_id,
+                        # ── routing info ─────────────────────────────────────────
+                        "route": validated_route,
+                        "method": validated_method,
+                        # Evidence that the runtime answers every HTTP method
+                        # (binding present, ``methods=`` omitted). Gates all-method
+                        # expansion in the spec generator; a bare @openapi stays
+                        # single-operation (#347).
+                        "_expand_all_methods": expand_all_methods,
+                        "parameters": validated_parameters,
+                        "security": validated_security,
+                        "security_scheme": validated_security_scheme,
+                        # ── request / response schema ────────────────────────
+                        "request_model": resolved_request_model,
+                        "request_body": resolved_request_body,
+                        "request_body_required": request_body_required,
+                        "response_model": resolved_response_model,
+                        "response": resolved_response or {},
+                        "function_name": metadata_func.__name__,
+                        "_function_id": function_id,
+                    },
+                )
 
             logger.debug(f"Registered OpenAPI metadata for function '{metadata_func.__name__}'")
             return cast(F, original_func)
@@ -529,9 +532,7 @@ def register_openapi_metadata(
         sanitized_op_id = _validate_and_sanitize_operation_id(operation_id, registry_key)
     else:
         clean_path = path.strip("/").replace("/", "_").replace("{", "").replace("}", "")
-        fallback_op_id = (
-            f"{validated_method}_{clean_path}" if clean_path else validated_method
-        )
+        fallback_op_id = f"{validated_method}_{clean_path}" if clean_path else validated_method
         sanitized_op_id = sanitize_operation_id(fallback_op_id)
 
     validated_parameters = _validate_parameters(parameters, registry_key) if parameters else []
@@ -559,24 +560,27 @@ def register_openapi_metadata(
                 validated_method.upper(),
                 path,
             )
-        reg.set(registry_key, {
-            "summary": summary,
-            "description": description,
-            "tags": validated_tags,
-            "operation_id": sanitized_op_id,
-            "route": path,
-            "method": validated_method,
-            "parameters": validated_parameters,
-            "security": validated_security,
-            "security_scheme": validated_security_scheme,
-            "request_model": request_model,
-            "request_body": request_body,
-            "request_body_required": request_body_required,
-            "response_model": response_model,
-            "response": response or {},
-            "function_name": registry_key,
-            "_function_id": f"programmatic.{registry_key}",
-        })
+        reg.set(
+            registry_key,
+            {
+                "summary": summary,
+                "description": description,
+                "tags": validated_tags,
+                "operation_id": sanitized_op_id,
+                "route": path,
+                "method": validated_method,
+                "parameters": validated_parameters,
+                "security": validated_security,
+                "security_scheme": validated_security_scheme,
+                "request_model": request_model,
+                "request_body": request_body,
+                "request_body_required": request_body_required,
+                "response_model": response_model,
+                "response": response or {},
+                "function_name": registry_key,
+                "_function_id": f"programmatic.{registry_key}",
+            },
+        )
 
     logger.debug("Registered programmatic OpenAPI metadata for '%s %s'", validated_method, path)
 
@@ -731,9 +735,7 @@ def _validate_security_scheme(
             raise ValueError("Security scheme name must be a non-empty string")
 
         if not isinstance(scheme_def, dict):
-            raise ValueError(
-                f"Security scheme '{scheme_name}' definition must be a dictionary"
-            )
+            raise ValueError(f"Security scheme '{scheme_name}' definition must be a dictionary")
 
         scheme_type = scheme_def.get("type")
         if not scheme_type or scheme_type not in valid_types:

--- a/src/azure_functions_openapi/registry.py
+++ b/src/azure_functions_openapi/registry.py
@@ -183,9 +183,7 @@ class OpenAPIRegistry:
         """
         with self._lock:
             return sum(
-                1
-                for entry in self._entries.values()
-                if entry.get("function_name") == function_name
+                1 for entry in self._entries.values() if entry.get("function_name") == function_name
             )
 
     def add_discovery_warning(self, function_name: str | None, reason: str) -> None:
@@ -240,6 +238,7 @@ class OpenAPIRegistry:
         """Return the recorded empty-app type names, deduplicated and sorted."""
         with self._lock:
             return sorted(self._empty_discoveries)
+
     def add_duplicate_operation(self, method: str, path: str) -> None:
         """Record that two registrations collided on the same ``METHOD path``.
 
@@ -261,6 +260,7 @@ class OpenAPIRegistry:
         """Return the recorded ``METHOD path`` collisions, deduplicated and sorted."""
         with self._lock:
             return sorted(self._duplicate_operations)
+
 
 # Process-wide singleton. The ``@openapi`` decorator records metadata at import
 # time — before any application object exists — so a shared instance is required.

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -746,7 +746,7 @@ def get_openapi_yaml(
     strict: bool = False,
     registry: OpenAPIRegistry | None = None,
     hoist_flat_schemas: bool = False,
-    ) -> str:
+) -> str:
     """Return the spec as YAML.
 
     Parameters:
@@ -817,9 +817,7 @@ _DISCOVERY_SKIPPED_MESSAGE = (
 # application object exposed no builders at all, so no per-builder failure
 # occurred. It carries its own message so ``--fail-on-warnings`` users are not
 # told a builder "could not be built" when none was ever present.
-_EMPTY_DISCOVERY_MESSAGE = (
-    "No function builders were discovered on the scanned application object"
-)
+_EMPTY_DISCOVERY_MESSAGE = "No function builders were discovered on the scanned application object"
 
 
 # Duplicate-operation is a merge-time collision, not a skew signal: two
@@ -996,7 +994,7 @@ def generate_openapi_report(
     strict: bool = False,
     registry: OpenAPIRegistry | None = None,
     hoist_flat_schemas: bool = False,
-    ) -> SpecReport:
+) -> SpecReport:
     """Generate the spec together with structured, machine-readable warnings.
 
     Mirrors :func:`generate_openapi_spec` and returns the identical spec mapping

--- a/src/azure_functions_openapi/types.py
+++ b/src/azure_functions_openapi/types.py
@@ -1,4 +1,5 @@
 """Public data types for programmatic OpenAPI metadata registration."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field

--- a/tests/e2e/test_openapi_e2e.py
+++ b/tests/e2e/test_openapi_e2e.py
@@ -6,6 +6,7 @@ Usage:
 The E2E_BASE_URL environment variable must point to the deployed Function App.
 Tests are skipped automatically when the variable is not set (local unit test runs).
 """
+
 from __future__ import annotations
 
 import os
@@ -25,6 +26,7 @@ def _get(path: str, **kwargs: object) -> requests.Response:
 
 # ── Fixtures ───────────────────────────────────────────────────────────────
 
+
 @pytest.fixture(scope="session", autouse=True)
 def warmup() -> None:
     """Retry /api/health until the Consumption cold-start finishes (max 2 min)."""
@@ -43,6 +45,7 @@ def warmup() -> None:
 
 
 # ── Tests ──────────────────────────────────────────────────────────────────
+
 
 @pytest.mark.skipif(not BASE_URL, reason=SKIP_REASON)
 def test_health_returns_200() -> None:

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -82,9 +82,7 @@ class MockFunction:
         return self._bindings
 
     def is_http_function(self) -> bool:
-        return any(
-            str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings
-        )
+        return any(str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings)
 
 
 @dataclass
@@ -611,6 +609,7 @@ def test_scan_below_route_preserves_explicit_openapi_route_override() -> None:
     spec = generate_openapi_spec("T", "1.0.0")
     assert set(spec["paths"].keys()) == {"/api/custom/path"}
 
+
 def test_scan_reconciles_plain_openapi_below_route_explicit_method() -> None:
     # #361: a plain @openapi (no validation/endpoint metadata) below @app.route
     # must infer BOTH the binding method and route. The decorator registered
@@ -817,6 +816,7 @@ def test_collect_spec_warnings_no_mismatch_for_inferred_method() -> None:
     spec = generate_openapi_spec("T", "1.0.0")
     codes = [w.code for w in collect_spec_warnings(spec)]
     assert WarningCode.METHOD_BINDING_MISMATCH not in codes
+
 
 def test_mismatch_flagged_for_validation_carrying_handler() -> None:
     # #368: METHOD_BINDING_MISMATCH must also fire when the explicit
@@ -1342,9 +1342,7 @@ def test_scan_skips_builders_without_function_or_handler() -> None:
     another_without_handler = MockBuilder(
         _function=MockFunction(_name="also_no_handler", _func=None, _bindings=[])
     )
-    app = MockApp(
-        _function_builders=cast(Any, [builder_without_handler, another_without_handler])
-    )
+    app = MockApp(_function_builders=cast(Any, [builder_without_handler, another_without_handler]))
 
     scan_endpoint_metadata(app)
     assert get_openapi_registry() == {}

--- a/tests/test_bridge_endpoint.py
+++ b/tests/test_bridge_endpoint.py
@@ -74,9 +74,7 @@ class MockFunction:
         return self._bindings
 
     def is_http_function(self) -> bool:
-        return any(
-            str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings
-        )
+        return any(str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings)
 
 
 class MockBuilder:
@@ -315,6 +313,7 @@ class _UnbuildableBuilder:
     def build(self, auth_level: Any = None) -> Any:
         name = self._function.get_function_name()
         raise ValueError(f"Function {name} does not have a trigger")
+
 
 def test_scan_all_builders_fail_records_skip_not_empty_discovery() -> None:
     # Regression (#380 review): iter_functions returns [] both when no builders

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -474,6 +474,7 @@ class TestImportAppModule:
             with pytest.raises(ValueError, match="resolved to None"):
                 _import_app_module("fake_mod:app")
 
+
 class TestHandleGenerateWithApp:
     """Tests for --app option in handle_generate."""
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -369,7 +369,6 @@ def test_openapi_registers_request_body_required_false() -> None:
     assert rb["required"] is False
 
 
-
 def test_openapi_raises_error_for_invalid_method() -> None:
     """Test that @openapi rejects invalid HTTP methods like typos."""
     import pytest
@@ -425,6 +424,7 @@ def test_openapi_raises_on_multiple_binding_methods_without_explicit_method() ->
     from azure_functions_openapi.exceptions import OpenAPISpecConfigError
 
     with pytest.raises(OpenAPISpecConfigError, match="multiple methods"):
+
         @openapi(summary="Ambiguous")
         @app.route(route="items", methods=["GET", "POST"])
         def items(req: func.HttpRequest) -> func.HttpResponse:

--- a/tests/test_decorator_enhanced.py
+++ b/tests/test_decorator_enhanced.py
@@ -384,9 +384,7 @@ class TestValidateSecurityScheme:
 
     def test_validate_security_scheme_apikey_missing_name(self) -> None:
         with pytest.raises(ValueError, match="non-empty 'name'"):
-            _validate_security_scheme(
-                {"ApiKey": {"type": "apiKey", "in": "header"}}, "test_func"
-            )
+            _validate_security_scheme({"ApiKey": {"type": "apiKey", "in": "header"}}, "test_func")
 
     def test_validate_security_scheme_apikey_invalid_in(self) -> None:
         with pytest.raises(ValueError, match="'in' as one of"):
@@ -396,18 +394,12 @@ class TestValidateSecurityScheme:
 
     def test_validate_security_scheme_http_missing_scheme(self) -> None:
         with pytest.raises(ValueError, match="non-empty 'scheme'"):
-            _validate_security_scheme(
-                {"Bearer": {"type": "http"}}, "test_func"
-            )
+            _validate_security_scheme({"Bearer": {"type": "http"}}, "test_func")
 
     def test_validate_security_scheme_oauth2_missing_flows(self) -> None:
         with pytest.raises(ValueError, match="'flows' as a dict"):
-            _validate_security_scheme(
-                {"OAuth": {"type": "oauth2"}}, "test_func"
-            )
+            _validate_security_scheme({"OAuth": {"type": "oauth2"}}, "test_func")
 
     def test_validate_security_scheme_openidconnect_missing_url(self) -> None:
         with pytest.raises(ValueError, match="non-empty 'openIdConnectUrl'"):
-            _validate_security_scheme(
-                {"OIDC": {"type": "openIdConnect"}}, "test_func"
-            )
+            _validate_security_scheme({"OIDC": {"type": "openIdConnect"}}, "test_func")

--- a/tests/test_hello_openapi_function_app.py
+++ b/tests/test_hello_openapi_function_app.py
@@ -106,12 +106,14 @@ def test_receive_webhook_non_object_body() -> None:
 def test_receive_webhook_signature_valid() -> None:
     fa = _load_example_module()
 
-    payload = json.dumps({
-        "event_type": "order.completed",
-        "source": "shopify",
-        "occurred_at": "2026-04-12T00:00:00Z",
-        "data": {},
-    }).encode("utf-8")
+    payload = json.dumps(
+        {
+            "event_type": "order.completed",
+            "source": "shopify",
+            "occurred_at": "2026-04-12T00:00:00Z",
+            "data": {},
+        }
+    ).encode("utf-8")
     secret = "test-secret"
     timestamp = datetime.now(timezone.utc).isoformat()
     sig = _make_signature(payload, timestamp, secret)
@@ -140,12 +142,14 @@ def test_receive_webhook_signature_invalid() -> None:
     req = func.HttpRequest(
         method="POST",
         url="/api/webhooks/orders",
-        body=json.dumps({
-            "event_type": "order.completed",
-            "source": "shopify",
-            "occurred_at": "2026-04-12T00:00:00Z",
-            "data": {},
-        }).encode("utf-8"),
+        body=json.dumps(
+            {
+                "event_type": "order.completed",
+                "source": "shopify",
+                "occurred_at": "2026-04-12T00:00:00Z",
+                "data": {},
+            }
+        ).encode("utf-8"),
         params={},
         headers={
             "Content-Type": "application/json",
@@ -167,12 +171,14 @@ def test_receive_webhook_missing_timestamp() -> None:
     req = func.HttpRequest(
         method="POST",
         url="/api/webhooks/orders",
-        body=json.dumps({
-            "event_type": "order.completed",
-            "source": "shopify",
-            "occurred_at": "2026-04-12T00:00:00Z",
-            "data": {},
-        }).encode("utf-8"),
+        body=json.dumps(
+            {
+                "event_type": "order.completed",
+                "source": "shopify",
+                "occurred_at": "2026-04-12T00:00:00Z",
+                "data": {},
+            }
+        ).encode("utf-8"),
         params={},
         headers={"Content-Type": "application/json", "X-Signature": "sha256=abc"},
     )
@@ -189,12 +195,14 @@ def test_receive_webhook_stale_timestamp() -> None:
     fa = _load_example_module()
     secret = "test-secret"
     old_timestamp = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
-    payload = json.dumps({
-        "event_type": "order.completed",
-        "source": "shopify",
-        "occurred_at": "2026-04-12T00:00:00Z",
-        "data": {},
-    }).encode("utf-8")
+    payload = json.dumps(
+        {
+            "event_type": "order.completed",
+            "source": "shopify",
+            "occurred_at": "2026-04-12T00:00:00Z",
+            "data": {},
+        }
+    ).encode("utf-8")
     sig = _make_signature(payload, old_timestamp, secret)
 
     req = func.HttpRequest(
@@ -221,12 +229,14 @@ def test_receive_webhook_naive_timestamp_rejected() -> None:
     fa = _load_example_module()
     secret = "test-secret"
     naive_timestamp = "2026-04-12T00:00:00"  # No timezone
-    payload = json.dumps({
-        "event_type": "order.completed",
-        "source": "shopify",
-        "occurred_at": "2026-04-12T00:00:00Z",
-        "data": {},
-    }).encode("utf-8")
+    payload = json.dumps(
+        {
+            "event_type": "order.completed",
+            "source": "shopify",
+            "occurred_at": "2026-04-12T00:00:00Z",
+            "data": {},
+        }
+    ).encode("utf-8")
     sig = _make_signature(payload, naive_timestamp, secret)
 
     req = func.HttpRequest(
@@ -247,16 +257,19 @@ def test_receive_webhook_naive_timestamp_rejected() -> None:
     assert resp.status_code == 401
     assert "timezone" in json.loads(resp.get_body())["error"].lower()
 
+
 def test_receive_webhook_duplicate_delivery_id() -> None:
     """Duplicate X-Delivery-Id headers are rejected with 409."""
     fa = _load_example_module()
     delivery_id = "dlv-unique-123"
-    payload = json.dumps({
-        "event_type": "order.completed",
-        "source": "shopify",
-        "occurred_at": "2026-04-12T00:00:00Z",
-        "data": {},
-    }).encode("utf-8")
+    payload = json.dumps(
+        {
+            "event_type": "order.completed",
+            "source": "shopify",
+            "occurred_at": "2026-04-12T00:00:00Z",
+            "data": {},
+        }
+    ).encode("utf-8")
 
     def make_req() -> func.HttpRequest:
         return func.HttpRequest(

--- a/tests/test_hoist_flat.py
+++ b/tests/test_hoist_flat.py
@@ -280,7 +280,7 @@ def test_get_openapi_json_forwards_hoist_flag(_clean_registry: Any) -> None:
     hoisted_json = get_openapi_json(hoist_flat_schemas=True)
 
     assert "#/components/schemas/CreateUser" not in default_json
-    assert '#/components/schemas/CreateUser' in hoisted_json
+    assert "#/components/schemas/CreateUser" in hoisted_json
 
 
 def test_get_openapi_yaml_forwards_hoist_flag(_clean_registry: Any) -> None:
@@ -300,9 +300,9 @@ def test_generate_openapi_report_forwards_hoist_flag(_clean_registry: Any) -> No
     hoisted_report = generate_openapi_report(hoist_flat_schemas=True)
 
     assert _request_schema(default_report.spec) == _FLAT_BODY
-    assert _request_schema(hoisted_report.spec) == {
-        "$ref": "#/components/schemas/CreateUser"
-    }
+    assert _request_schema(hoisted_report.spec) == {"$ref": "#/components/schemas/CreateUser"}
+
+
 # ---------------------------------------------------------------------------
 # JSON-Pointer-safe component names + strict hashing (issue #379)
 # ---------------------------------------------------------------------------

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1232,7 +1232,6 @@ class TestDuplicatePathMethod:
         def list_items_b() -> None:
             pass
 
-
         with patch("azure_functions_openapi.spec.logger") as mock_log:
             generate_openapi_spec(route_prefix="")
         calls = [str(c) for c in mock_log.warning.call_args_list]

--- a/tests/test_partner_import_bridge_example.py
+++ b/tests/test_partner_import_bridge_example.py
@@ -10,6 +10,7 @@ import pytest
 try:
     import azure_functions_openapi.decorator as decorator_module
     from examples.partner_import_bridge import function_app as bridge_function_app
+
     HAS_VALIDATION = True
 except ImportError:
     HAS_VALIDATION = False

--- a/tests/test_register_metadata.py
+++ b/tests/test_register_metadata.py
@@ -290,9 +290,7 @@ def test_register_invalid_operation_id_raises() -> None:
 
 def test_register_sanitizable_operation_id_accepted() -> None:
     """An operation_id that sanitizes to a non-empty string should be accepted."""
-    register_openapi_metadata(
-        path="/api/sanitize", method="POST", operation_id="my-op_id.v2"
-    )
+    register_openapi_metadata(path="/api/sanitize", method="POST", operation_id="my-op_id.v2")
     registry = get_openapi_registry()
     entry = registry["post::/api/sanitize"]
     # sanitize_operation_id strips non-alphanumeric except underscore

--- a/tests/test_registry_identity.py
+++ b/tests/test_registry_identity.py
@@ -151,6 +151,7 @@ def test_canonical_function_id_unwraps_functools_wraps() -> None:
 
     assert canonical_function_id(outer) == canonical_function_id(inner)
 
+
 # ── #392: dynamically-created (factory/closure) handler identity ────────────
 def _module_level_handler(req: Any) -> Any:  # top-level: no ``<locals>``
     return req

--- a/tests/test_spec_validity.py
+++ b/tests/test_spec_validity.py
@@ -367,15 +367,12 @@ class TestInlineSchemaConversion31:
         def create_item() -> None:
             pass
 
-        spec = generate_openapi_spec(
-            title="Test", version="1.0.0", route_prefix=""
-        )
+        spec = generate_openapi_spec(title="Test", version="1.0.0", route_prefix="")
 
         # In 3.1, nullable should be converted to type array
-        schema = (
-            spec["paths"]["/items"]["post"]["requestBody"]
-            ["content"]["application/json"]["schema"]
-        )
+        schema = spec["paths"]["/items"]["post"]["requestBody"]["content"]["application/json"][
+            "schema"
+        ]
         name_prop = schema["properties"]["name"]
         assert "nullable" not in name_prop
         assert name_prop["type"] == ["string", "null"]
@@ -398,9 +395,7 @@ class TestInlineSchemaConversion31:
         def list_items() -> None:
             pass
 
-        spec = generate_openapi_spec(
-            title="Test", version="1.0.0", route_prefix=""
-        )
+        spec = generate_openapi_spec(title="Test", version="1.0.0", route_prefix="")
 
         param_schema = spec["paths"]["/items"]["get"]["parameters"][0]["schema"]
         assert "nullable" not in param_schema

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -62,9 +62,7 @@ class MockFunction:
         return self._bindings
 
     def is_http_function(self) -> bool:
-        return any(
-            str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings
-        )
+        return any(str(getattr(b, "type", "")).lower() == "httptrigger" for b in self._bindings)
 
 
 class MockBuilder:
@@ -231,9 +229,7 @@ class TestReportRegistryIsolation:
         assert WarningCode.VERSION_SKEW not in isolated_codes
         assert WarningCode.NAMESPACE_FALLBACK not in isolated_codes
         # Without injection, the same spec still reflects the global skew.
-        assert any(
-            w.code == WarningCode.VERSION_SKEW for w in collect_spec_warnings(spec)
-        )
+        assert any(w.code == WarningCode.VERSION_SKEW for w in collect_spec_warnings(spec))
 
 
 # ---------------------------------------------------------------------------
@@ -251,9 +247,7 @@ class _UnbuildableBuilder:
         self._function = MockFunction(name=name, func=lambda req: req, bindings=[])
 
     def build(self, auth_level: Any = None) -> Any:
-        raise ValueError(
-            f"Function {self._function.get_function_name()} does not have a trigger"
-        )
+        raise ValueError(f"Function {self._function.get_function_name()} does not have a trigger")
 
 
 class TestDiscoverySkippedWarnings:
@@ -268,9 +262,7 @@ class TestDiscoverySkippedWarnings:
         scan_endpoint_metadata(app)
         report = generate_openapi_report()
 
-        skipped = [
-            w for w in report.warnings if w.code == WarningCode.DISCOVERY_SKIPPED
-        ]
+        skipped = [w for w in report.warnings if w.code == WarningCode.DISCOVERY_SKIPPED]
         assert len(skipped) == 1
         assert skipped[0].function_name == "orphan"
         # The valid endpoint is still present in the spec (scan not aborted).
@@ -283,15 +275,10 @@ class TestDiscoverySkippedWarnings:
         # An injected clean registry has recorded no skips of its own.
         isolated = OpenAPIRegistry()
         spec = generate_openapi_spec(registry=isolated)
-        isolated_codes = {
-            w.code for w in collect_spec_warnings(spec, registry=isolated)
-        }
+        isolated_codes = {w.code for w in collect_spec_warnings(spec, registry=isolated)}
         assert WarningCode.DISCOVERY_SKIPPED not in isolated_codes
         # The global path still reports the skip.
-        assert any(
-            w.code == WarningCode.DISCOVERY_SKIPPED
-            for w in collect_spec_warnings(spec)
-        )
+        assert any(w.code == WarningCode.DISCOVERY_SKIPPED for w in collect_spec_warnings(spec))
 
     def test_repeated_scans_do_not_duplicate_discovery_warning(self) -> None:
         # Re-scanning the same app (idempotent like entry registration) must
@@ -304,9 +291,7 @@ class TestDiscoverySkippedWarnings:
         scan_endpoint_metadata(app)
         report = generate_openapi_report()
 
-        skipped = [
-            w for w in report.warnings if w.code == WarningCode.DISCOVERY_SKIPPED
-        ]
+        skipped = [w for w in report.warnings if w.code == WarningCode.DISCOVERY_SKIPPED]
         assert len(skipped) == 1
 
     def test_discovery_warning_message_carries_sdk_reason(self) -> None:
@@ -317,9 +302,7 @@ class TestDiscoverySkippedWarnings:
         scan_endpoint_metadata(app)
         report = generate_openapi_report()
 
-        skipped = [
-            w for w in report.warnings if w.code == WarningCode.DISCOVERY_SKIPPED
-        ]
+        skipped = [w for w in report.warnings if w.code == WarningCode.DISCOVERY_SKIPPED]
         assert len(skipped) == 1
         assert "does not have a trigger" in skipped[0].message
 
@@ -419,9 +402,7 @@ class TestCliFailOnWarnings:
         # Use a real importable module with no ':variable' so the import
         # succeeds (discovery is skipped) and the registry stays empty.
         out = tmp_path / "openapi.json"
-        rc = handle_generate(
-            _args(app="os", fail_on_empty_paths=True, output=str(out))
-        )
+        rc = handle_generate(_args(app="os", fail_on_empty_paths=True, output=str(out)))
         assert rc == 1
         err = capsys.readouterr().err
         assert "Hint: use --app" not in err
@@ -519,12 +500,8 @@ class TestDuplicateOperationWarnings:
         # entry and the caller overrides it with richer metadata. Exactly one
         # entry survives, and it is the last registration.
         reg = OpenAPIRegistry()
-        register_openapi_metadata(
-            path="/api/dup", method="POST", summary="first", registry=reg
-        )
-        register_openapi_metadata(
-            path="/api/dup", method="POST", summary="second", registry=reg
-        )
+        register_openapi_metadata(path="/api/dup", method="POST", summary="first", registry=reg)
+        register_openapi_metadata(path="/api/dup", method="POST", summary="second", registry=reg)
         snapshot = reg.snapshot()
         assert len(snapshot) == 1
         assert snapshot["post::/api/dup"]["summary"] == "second"
@@ -654,9 +631,7 @@ class TestIsolatedRegistry:
         global_warnings = collect_spec_warnings(generate_openapi_spec())
 
         assert any(w.code == WarningCode.DISCOVERY_SKIPPED for w in iso_warnings)
-        assert not any(
-            w.code == WarningCode.DISCOVERY_SKIPPED for w in global_warnings
-        )
+        assert not any(w.code == WarningCode.DISCOVERY_SKIPPED for w in global_warnings)
 
     def test_programmatic_entries_not_seeded_into_isolated_registry(self) -> None:
         # Programmatic register_openapi_metadata entries are not tied to any
@@ -756,9 +731,7 @@ class TestCliIsolateApp:
         monkeypatch.syspath_prepend(str(tmp_path))
 
         out = tmp_path / "a.json"
-        rc = handle_generate(
-            _args(app="twoapp_iso:app_a", isolate_app=True, output=str(out))
-        )
+        rc = handle_generate(_args(app="twoapp_iso:app_a", isolate_app=True, output=str(out)))
         assert rc == 0
         spec = json.loads(out.read_text(encoding="utf-8"))
         assert "/api/a/one" in spec["paths"]

--- a/tests/test_todo_crud_example.py
+++ b/tests/test_todo_crud_example.py
@@ -65,11 +65,13 @@ def test_submit_report_unauthorized() -> None:
     req = func.HttpRequest(
         method="POST",
         url="/api/reports",
-        body=json.dumps({
-            "report_type": "monthly_sales",
-            "date_from": "2026-01-01",
-            "date_to": "2026-01-31",
-        }).encode("utf-8"),
+        body=json.dumps(
+            {
+                "report_type": "monthly_sales",
+                "date_from": "2026-01-01",
+                "date_to": "2026-01-31",
+            }
+        ).encode("utf-8"),
         params={},
         headers={"Content-Type": "application/json"},
     )
@@ -87,11 +89,13 @@ def test_get_report_status_found() -> None:
     submit_req = func.HttpRequest(
         method="POST",
         url="/api/reports",
-        body=json.dumps({
-            "report_type": "monthly_sales",
-            "date_from": "2026-01-01",
-            "date_to": "2026-01-31",
-        }).encode("utf-8"),
+        body=json.dumps(
+            {
+                "report_type": "monthly_sales",
+                "date_from": "2026-01-01",
+                "date_to": "2026-01-31",
+            }
+        ).encode("utf-8"),
         params={},
         headers=_AUTH_HEADERS,
     )
@@ -153,11 +157,13 @@ def test_download_report_not_ready() -> None:
     submit_req = func.HttpRequest(
         method="POST",
         url="/api/reports",
-        body=json.dumps({
-            "report_type": "monthly_sales",
-            "date_from": "2026-01-01",
-            "date_to": "2026-01-31",
-        }).encode("utf-8"),
+        body=json.dumps(
+            {
+                "report_type": "monthly_sales",
+                "date_from": "2026-01-01",
+                "date_to": "2026-01-31",
+            }
+        ).encode("utf-8"),
         params={},
         headers=_AUTH_HEADERS,
     )
@@ -184,11 +190,13 @@ def test_download_report_completed() -> None:
     submit_req = func.HttpRequest(
         method="POST",
         url="/api/reports",
-        body=json.dumps({
-            "report_type": "monthly_sales",
-            "date_from": "2026-01-01",
-            "date_to": "2026-01-31",
-        }).encode("utf-8"),
+        body=json.dumps(
+            {
+                "report_type": "monthly_sales",
+                "date_from": "2026-01-01",
+                "date_to": "2026-01-31",
+            }
+        ).encode("utf-8"),
         params={},
         headers=_AUTH_HEADERS,
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -32,6 +32,7 @@ def test_model_to_schema(model_cls: type[BaseModel]) -> None:
 
 def test_model_to_schema_non_pydantic_raises_type_error() -> None:
     """model_to_schema must raise TypeError for non-Pydantic v2 classes."""
+
     class NotAModel:
         pass
 

--- a/tests/test_with_validation_example.py
+++ b/tests/test_with_validation_example.py
@@ -11,6 +11,7 @@ import pytest
 try:
     import azure_functions_openapi.decorator as decorator_module
     from examples.notification_request import function_app as notification_function_app
+
     HAS_VALIDATION = True
 except ImportError:
     HAS_VALIDATION = False
@@ -19,6 +20,7 @@ pytestmark = pytest.mark.skipif(
     not HAS_VALIDATION,
     reason="azure-functions-validation not installed",
 )
+
 
 def _load_example_module() -> Any:
     with decorator_module._registry_lock:
@@ -89,11 +91,13 @@ def test_get_notification_status_found() -> None:
     send_req = func.HttpRequest(
         method="POST",
         url="/api/notifications/email",
-        body=json.dumps({
-            "to": ["user@example.com"],
-            "subject": "Test",
-            "body_text": "Hello",
-        }).encode("utf-8"),
+        body=json.dumps(
+            {
+                "to": ["user@example.com"],
+                "subject": "Test",
+                "body_text": "Hello",
+            }
+        ).encode("utf-8"),
         params={},
         headers={"Content-Type": "application/json"},
     )


### PR DESCRIPTION
## Summary
- Bump pinned `ruff` dev dependency **0.16.1 → 0.16.2** and apply the resulting formatter changes across `src`, `tests`, `examples`, and `scripts`.
- Bump `ruff-pre-commit` rev **v0.15.6 → v0.16.2** so the hook formats identically to the pinned tool.
- Repair pre-commit env: pin the `bandit` hook (and default python-language version) to **python3.12** — the default env was resolving to system Python 3.9.6, which modern bandit rejects (`requires >=3.10`), crashing every commit.
- Narrow the `forbid-korean` hook so the README language-selector nav links no longer trip the Hangul check (it previously failed on `main`).

## Verification
- `pre-commit run --all-files` → ruff-format, ruff, mypy, bandit, forbid-korean all **Passed**.

## Scope
- Dev tooling + pre-commit config only. No runtime dependency or logic changes.
- `mypy`/`bandit` version pins left untouched (already at/above the highest versions on the active package index).

Closes #406