### PR TITLE
docs: sync docs and examples with unified requests/responses contract

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,8 +10,14 @@ from azure_functions_openapi import (
     OPENAPI_VERSION_3_0,
     OPENAPI_VERSION_3_1,
     OpenAPIOperationMetadata,
+    OpenAPIRegistry,
     OpenAPISpecConfigError,
+    SDKIncompatibleError,
+    SpecReport,
+    SpecWarning,
+    WarningCode,
     clear_openapi_registry,
+    generate_openapi_report,
     generate_openapi_spec,
     get_openapi_json,
     get_openapi_yaml,
@@ -30,12 +36,19 @@ from azure_functions_openapi import (
 | `register_openapi_metadata` | function | Register metadata for dynamically-created endpoints |
 | `clear_openapi_registry` | function | Remove all entries from the registry |
 | `scan_endpoint_metadata` | function | Auto-discover validation metadata from `@validate_http` handlers |
+| `scan_validation_metadata` | function | **Deprecated** alias for `scan_endpoint_metadata` (emits `DeprecationWarning`; removed in a future minor release) |
 | `generate_openapi_spec` | function | Build OpenAPI dictionary from decorator registry |
+| `generate_openapi_report` | function | Build the spec plus a deterministic tuple of structured warnings (returns `SpecReport`) |
 | `get_openapi_json` | function | Build OpenAPI and serialize to JSON string |
 | `get_openapi_yaml` | function | Build OpenAPI and serialize to YAML string |
 | `render_swagger_ui` | function | Return Swagger UI `HttpResponse` |
 | `OpenAPIOperationMetadata` | dataclass | Frozen dataclass for operation metadata |
+| `OpenAPIRegistry` | class | Thread-safe registry backing the decorator; pass an instance for isolated (test-friendly) registration |
+| `SpecReport` | dataclass | Result of `generate_openapi_report`: the `spec` dict plus a `warnings` tuple |
+| `SpecWarning` | dataclass | A single structured warning (`code`, `message`, `function_name`) emitted during generation |
+| `WarningCode` | enum | Stable string identifiers for warning categories (e.g. `version-skew`, `namespace-fallback`) |
 | `OpenAPISpecConfigError` | exception | Raised for configuration errors |
+| `SDKIncompatibleError` | exception | Subclass of `OpenAPISpecConfigError`; raised when the installed Functions SDK is incompatible |
 | `OPENAPI_VERSION_3_0` | constant | OpenAPI version string `"3.0.0"` |
 | `OPENAPI_VERSION_3_1` | constant | OpenAPI version string `"3.1.0"` |
 ## Decorator behavior model
@@ -77,7 +90,7 @@ class ItemResponse(BaseModel):
     summary="Create item",
     method="post",
     route="/api/items",
-    request_model=CreateItemRequest,
+    requests=CreateItemRequest,
     response_model=ItemResponse,
     response={201: {"description": "Created"}},
     )
@@ -86,18 +99,24 @@ def create_item(req: func.HttpRequest) -> func.HttpResponse:
     ...
 ```
 
+!!! note
+    This operation pairs a model-derived `200` schema (`response_model`) with an
+    extra `201` status, so the response side keeps the discrete parameters — the
+    unified `responses=` cannot express both at once yet (issue #410). The
+    request side uses the preferred `requests=` parameter.
+
 ### With raw schema dictionaries
 
 ```python
 @openapi(
     summary="Raw schema example",
     method="post",
-    request_body={
+    requests={
         "type": "object",
         "properties": {"value": {"type": "string"}},
         "required": ["value"],
     },
-    response={
+    responses={
         200: {
             "description": "OK",
             "content": {
@@ -189,6 +208,36 @@ scan_endpoint_metadata(app)
 | Both with same models | Merges additional OpenAPI fields |
 | Both with different models | Raises `OpenAPISpecConfigError` |
 | Explicit `@openapi` | Always takes precedence |
+
+!!! warning "`scan_validation_metadata` is deprecated"
+    `scan_validation_metadata()` is a deprecated alias for `scan_endpoint_metadata()`.
+    The scanner now consumes the namespace-neutral `"endpoint"` contract (the
+    `"validation"` namespace is only a fallback), so the old name is a misnomer.
+    Calling it forwards unchanged but emits a `DeprecationWarning`, and it will be
+    removed in a future minor release. Switch to `scan_endpoint_metadata()`.
+
+## Structured warnings
+
+`generate_openapi_report()` mirrors `generate_openapi_spec()` but returns a
+`SpecReport` — the identical `spec` mapping plus a deterministic `warnings` tuple.
+This lets CI gate a build on API drift without parsing log output.
+
+```python
+from azure_functions_openapi import generate_openapi_report
+
+report = generate_openapi_report(title="My API", version="1.0.0")
+if report.warnings:
+    for w in report.warnings:
+        print(w.code, w.message, w.function_name)
+    raise SystemExit(1)  # fail the build on any warning
+spec = report.spec
+```
+
+| Symbol | Purpose |
+| --- | --- |
+| `SpecReport` | Dataclass with `spec: dict` and `warnings: tuple[SpecWarning, ...]` |
+| `SpecWarning` | Frozen dataclass: `code: WarningCode`, `message: str`, `function_name: str \| None`; `to_dict()` for JSON |
+| `WarningCode` | `str`-based enum of stable codes: `version-skew`, `namespace-fallback`, `ambiguous-namespace`, `duplicate-operation`, `spec-validation`, `discovery-skipped`, `empty-discovery`, `method-binding-mismatch` |
 
 ## Related internals
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -100,10 +100,11 @@ def create_item(req: func.HttpRequest) -> func.HttpResponse:
 ```
 
 !!! note
-    This operation pairs a model-derived `200` schema (`response_model`) with an
-    extra `201` status, so the response side keeps the discrete parameters — the
-    unified `responses=` cannot express both at once yet (issue #410). The
-    request side uses the preferred `requests=` parameter.
+    Here `response_model` supplies the schema while `response={201: ...}` sets the
+    status and description; the model schema is attached to the `201` response (the
+    first `2xx` status present), so this pairing keeps the discrete parameters — the
+    unified `responses=` cannot yet put a model schema on a non-`200` success status
+    (issue #410). The request side uses the preferred `requests=` parameter.
 
 ### With raw schema dictionaries
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -139,7 +139,7 @@ Discovery semantics:
 | Code | Meaning |
 | --- | --- |
 | `0` | Success |
-| `1` | Runtime or generation error (including `--fail-on-empty-paths` with no paths, or an unhonorable `--isolate-app`) |
+| `1` | Runtime or generation error (including `--fail-on-empty-paths` with no paths, or an `--isolate-app` that cannot be honored) |
 | `2` | Either invalid CLI arguments (argparse parse error) **or** structured warnings were emitted while `--fail-on-warnings` is set |
 
 ## Validate generated output

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -130,14 +130,17 @@ Discovery semantics:
 | `--pretty` | `-p` | flag | `false` | Pretty-print JSON output (adds indentation); no effect on YAML |
 | `--route-prefix` | - | any string (or `""`) | `/api` | HTTP route prefix from `host.json` `extensions.http.routePrefix`. See [Route Prefix](route-prefix.md). |
 | `--fail-on-empty-paths` | - | flag | `false` | Exit with code 1 if the generated spec has no paths |
+| `--strict` | - | flag | `false` | Fail on any malformed registry entry instead of skipping it. Recommended for CI where a missing path should break the build |
+| `--fail-on-warnings` | - | flag | `false` | Exit with code 2 if the generator emits any structured warnings (version skew, namespace fallback, or spec-validation issues). Use in CI to stop a wrong-but-plausible spec from being published |
+| `--isolate-app` | - | flag | `false` | Scan the `--app` `FunctionApp` into a fresh, app-scoped registry instead of the shared global one. Requires `--app module:variable`. Use when several apps are imported in one process to avoid cross-app route leakage |
 
 ## Exit codes
 
 | Code | Meaning |
 | --- | --- |
 | `0` | Success |
-| `1` | Runtime or generation error |
-| `2` | Invalid CLI arguments (argparse parse error) |
+| `1` | Runtime or generation error (including `--fail-on-empty-paths` with no paths, or an unhonorable `--isolate-app`) |
+| `2` | Either invalid CLI arguments (argparse parse error) **or** structured warnings were emitted while `--fail-on-warnings` is set |
 
 ## Validate generated output
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,15 +38,38 @@ This guide covers configuration points across:
 
 ### Body and response fields
 
+Prefer the **unified** `requests` / `responses` parameters. Each accepts either
+a Pydantic model class or a raw schema dict.
+
 | Parameter | Type | Purpose |
 | --- | --- | --- |
-| `request_model` | `type[BaseModel] \| None` | Pydantic model for request body schema |
-| `request_body` | `dict \| None` | Raw OpenAPI request body schema |
-| `response_model` | `type[BaseModel] \| None` | Pydantic model for `200` JSON response schema |
-| `response` | `dict[int, dict] \| None` | Response map by status code |
+| `requests` | `type[BaseModel] \| dict \| None` | Unified request body — model (like `request_model`) or raw schema dict (like `request_body`) |
+| `request_body_required` | `bool` | Whether the request body is required; defaults to `True` |
+| `responses` | `type[BaseModel] \| dict[int, dict] \| None` | Unified responses — model (typed `200` schema) or a status-code map (like `response`) |
+
+#### Deprecated (issue #285)
+
+These discrete parameters still work but emit a `DeprecationWarning`. Migrate to
+`requests` / `responses`.
+
+| Deprecated parameter | Type | Replacement |
+| --- | --- | --- |
+| `request_model` | `type[BaseModel] \| None` | `requests=Model` |
+| `request_body` | `dict \| None` | `requests={...}` |
+| `response_model` | `type[BaseModel] \| None` | `responses=Model` |
+| `response` | `dict[int, dict] \| None` | `responses={...}` |
 
 !!! warning
-    `request_model` and `response_model` must be Pydantic `BaseModel` classes. If you want schema dicts, use `request_body` and `response`.
+    A model passed to `requests` / `responses` must be a Pydantic `BaseModel`
+    class; pass a `dict` for raw schemas. You cannot combine `requests` with
+    `request_model`/`request_body`, nor `responses` with
+    `response_model`/`response` — doing so raises `ValueError`.
+
+!!! note "One response case cannot migrate yet (issue #410)"
+    `responses=` accepts a model **or** a status-code map, but not both. An
+    operation that needs a model-derived `200` schema *and* extra status codes
+    must keep the discrete `response_model=` + `response=` pair for now (still
+    emits a `DeprecationWarning`). Tracked in issue #410.
 
 ## Parameter examples
 
@@ -98,10 +121,21 @@ class ProductResponse(BaseModel):
     name: str
 
 
+# Single typed response — fully migratable to the unified parameters:
 @openapi(
     summary="Create product",
     method="post",
-    request_model=ProductCreate,
+    requests=ProductCreate,
+    responses=ProductResponse,
+)
+
+
+# Model-derived 200 plus extra status codes — keep the discrete response
+# parameters until issue #410 lands (still emits a DeprecationWarning):
+@openapi(
+    summary="Create product",
+    method="post",
+    requests=ProductCreate,
     response_model=ProductResponse,
     response={201: {"description": "Created"}, 400: {"description": "Bad request"}},
 )

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -8,8 +8,8 @@ We welcome contributions to the `azure-functions-openapi` project.
 2. Clone your fork locally:
 
 ```bash
-git clone https://github.com/<your-username>/azure-functions-openapi.git
-cd azure-functions-openapi
+git clone https://github.com/<your-username>/azure-functions-openapi-python.git
+cd azure-functions-openapi-python
 ```
 
 3. Set up the development environment:

--- a/docs/development.md
+++ b/docs/development.md
@@ -52,7 +52,7 @@ azure-functions-openapi/
 1. **Clone the repository**:
     ```bash
     git clone https://github.com/yeongseon/azure-functions-openapi-python.git
-    cd azure-functions-openapi
+    cd azure-functions-openapi-python
     ```
 
 2. **Create environment and install dependencies**:

--- a/docs/examples/report_jobs.md
+++ b/docs/examples/report_jobs.md
@@ -23,7 +23,7 @@ Source: `examples/report_jobs/function_app.py`
 - Path parameters (`{job_id}`)
 - `generate_openapi_spec()` with `OPENAPI_VERSION_3_1`
 - `render_swagger_ui()` with `custom_csp` and `enable_client_logging=True`
-- `request_model` and `response_model`
+- `requests` for the request model (plus `response_model` for the typed success body)
 - Multiple response codes per endpoint (200, 202, 400, 401, 404)
 
 ## Data models
@@ -79,7 +79,7 @@ _BEARER_SECURITY = [{"BearerAuth": []}]
     summary="Submit a report job",
     description="Queue a new report generation job. Returns a job ID for status polling.",
     tags=["reports"],
-    request_model=ReportRequest,
+    requests=ReportRequest,
     response_model=ReportJobResponse,
     response={
         202: {"description": "Report job queued"},

--- a/docs/examples/webhook_receiver.md
+++ b/docs/examples/webhook_receiver.md
@@ -18,7 +18,7 @@ Source: `examples/webhook_receiver/function_app.py`
 ## Features demonstrated
 
 - `@openapi()` with `summary`, `description`, `tags`
-- `request_model` and `response_model` for Pydantic schema generation
+- `requests` for Pydantic request schema generation (plus `response_model` for the typed success body)
 - `response` dict for documenting multiple status codes (202, 400, 401, 409)
 - `get_openapi_json()`, `get_openapi_yaml()`
 - `render_swagger_ui()`
@@ -54,7 +54,7 @@ class WebhookAcceptedResponse(BaseModel):
         "Duplicate deliveries are rejected via the `X-Delivery-Id` header."
     ),
     tags=["webhooks"],
-    request_model=WebhookEvent,
+    requests=WebhookEvent,
     response_model=WebhookAcceptedResponse,
     response={
         202: {"description": "Webhook accepted for processing"},

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,12 +28,12 @@ Use `security` + `security_scheme` in `@openapi`, or pass `security_schemes` to 
 
 ## Can I use this package without Pydantic?
 
-Yes. Use raw schema dictionaries with `request_body` and `response`.
+Yes. Use raw schema dictionaries with the unified `requests` and `responses` parameters.
 
 ```python
 @openapi(
-    request_body={"type": "object", "properties": {"name": {"type": "string"}}},
-    response={200: {"description": "OK"}},
+    requests={"type": "object", "properties": {"name": {"type": "string"}}},
+    responses={200: {"description": "OK"}},
 )
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,6 +84,14 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     )
 ```
 
+!!! note "Response parameters here"
+    This example pairs a model-derived `200` schema with a manual `400`
+    response, so it uses the discrete `response_model=` + `response=`
+    parameters. That combination still emits a `DeprecationWarning` and cannot
+    yet be expressed with the unified `responses=` parameter (tracked in issue
+    #410). For request bodies and single-form responses, prefer the unified
+    `requests=` / `responses=` parameters — see [Usage](usage.md#migrating-to-requests-responses).
+
 ## Add spec endpoints
 
 Add JSON and YAML routes to publish the generated spec:

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ class HelloResponse(BaseModel):
             "schema": {"type": "string"},
         }
     ],
-    response_model=HelloResponse,
+    responses=HelloResponse,
     )
 @app.route(route="http_trigger", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
@@ -101,8 +101,8 @@ Open:
 
 - `summary`, `description`, `tags`, `operation_id`
 - `parameters` (query/path/header/cookie)
-- `request_model` or `request_body`
-- `response_model` or `response`
+- `requests` (Pydantic model or raw schema dict) and `request_body_required`
+- `responses` (Pydantic model or status-code map)
 - `security` and `security_scheme`
 
 ### OpenAPI generation

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -68,7 +68,7 @@ Clone the repository and create a virtual environment:
 
 ```bash
 git clone https://github.com/yeongseon/azure-functions-openapi-python.git
-cd azure-functions-openapi
+cd azure-functions-openapi-python
 python -m venv .venv
 source .venv/bin/activate   # Windows: .venv\Scripts\activate
 pip install -e .[dev]

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,7 +1,5 @@
 # Security Guide
 
-# Security Guide
-
 The canonical security policy is maintained in the root [SECURITY.md](https://github.com/yeongseon/azure-functions-openapi-python/blob/main/SECURITY.md).
 
 #### Operation ID Sanitization

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -124,7 +124,7 @@ def test_response_model_schema():
         summary="Get item",
         route="/api/items",
         method="get",
-        response_model=ItemResponse,
+        responses=ItemResponse,
     )
     def get_item(req):
         pass

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -83,13 +83,13 @@ collisions occur.
 
 ### Common mistakes
 
-- passing a dict to `request_model` or `response_model`
+- passing a dict where a Pydantic model is expected (or vice versa) to `requests` / `responses`
 - mixing incompatible Pydantic usage patterns in your own function code
 
 ### Fixes
 
-- pass Pydantic classes to `request_model` and `response_model`
-- if you need raw schema dicts, use `request_body` and `response`
+- pass Pydantic model classes to `requests` / `responses` for model-derived schemas
+- if you need raw schema dicts, pass a `dict` to `requests` / `responses`
 - keep a single Pydantic major version in your environment
 
 ## 4) Route mismatch between function and OpenAPI output

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -42,7 +42,7 @@ class EchoResponse(BaseModel):
     operation_id="echoMessage",
     route="/api/echo",
     method="post",
-    request_model=EchoRequest,
+    requests=EchoRequest,
     response_model=EchoResponse,
     response={200: {"description": "Echoed message"}, 400: {"description": "Invalid body"}},
     )
@@ -112,11 +112,21 @@ def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
 
 ## Request and response schema styles
 
-Use one of two schema styles depending on your app architecture.
+`@openapi` exposes two **unified** schema parameters — `requests` and
+`responses` — each of which accepts *either* a Pydantic model class *or* a raw
+schema dict. Prefer these over the older discrete parameters.
+
+!!! warning "Discrete parameters are deprecated (issue #285)"
+    The discrete parameters `request_model` / `request_body` and
+    `response_model` / `response` still work but now emit a
+    `DeprecationWarning`. New code should use `requests` and `responses`. See
+    the [migration note](#migrating-to-requests-responses) below for the one
+    response-side case that cannot migrate yet.
 
 ### Style A: Pydantic models
 
-Best when you already validate payloads with Pydantic.
+Best when you already validate payloads with Pydantic. Pass the model class
+directly to `requests` / `responses`.
 
 ```python
 class CreateOrderRequest(BaseModel):
@@ -133,21 +143,23 @@ class OrderResponse(BaseModel):
 @openapi(
     summary="Create order",
     method="post",
-    request_model=CreateOrderRequest,
-    response_model=OrderResponse,
-    response={201: {"description": "Created"}},
+    requests=CreateOrderRequest,
+    responses=OrderResponse,
 )
 ```
 
+`responses=OrderResponse` derives the `200` response schema from the model.
+
 ### Style B: Raw schema dictionaries
 
-Best when you do not use Pydantic.
+Best when you do not use Pydantic. Pass a raw requestBody schema dict to
+`requests` and a manual responses map (keyed by status code) to `responses`.
 
 ```python
 @openapi(
     summary="Create order",
     method="post",
-    request_body={
+    requests={
         "type": "object",
         "properties": {
             "sku": {"type": "string"},
@@ -155,7 +167,7 @@ Best when you do not use Pydantic.
         },
         "required": ["sku", "quantity"],
     },
-    response={
+    responses={
         201: {
             "description": "Created",
             "content": {
@@ -171,8 +183,43 @@ Best when you do not use Pydantic.
 )
 ```
 
-!!! warning
-    Do not pass dict schemas to `request_model` or `response_model`. Those parameters require Pydantic `BaseModel` classes.
+!!! note
+    `requests` decides its meaning by type: a `BaseModel` subclass is treated
+    like the old `request_model`, and a `dict` is treated like the old
+    `request_body`. `responses` behaves the same way. You cannot pass both
+    `requests` and `request_model`/`request_body` (or both `responses` and
+    `response_model`/`response`) — doing so raises `ValueError`.
+
+### Optional request bodies
+
+Set `request_body_required=False` when the request body is optional (it
+defaults to `True`):
+
+```python
+@openapi(
+    summary="Partial update",
+    method="patch",
+    requests=PatchOrderRequest,
+    request_body_required=False,
+)
+```
+
+### Migrating to `requests` / `responses`
+
+| Old (deprecated) | New |
+| --- | --- |
+| `request_model=Model` | `requests=Model` |
+| `request_body={...}` | `requests={...}` |
+| `response_model=Model` | `responses=Model` |
+| `response={201: {...}}` | `responses={201: {...}}` |
+
+!!! warning "One response case cannot migrate yet (issue #410)"
+    `responses=` accepts **either** a model (typed `200` schema) **or** a manual
+    status-code map — not both at once. If an operation needs a model-derived
+    success schema *and* additional status codes (e.g. `response_model=Model`
+    combined with `response={400: {...}}`), keep using the discrete
+    `response_model=` + `response=` pair for now. Those calls still emit a
+    `DeprecationWarning`; closing the gap is tracked in issue #410.
 
 ## Parameters (query/path/header/cookie)
 

--- a/examples/report_jobs/function_app.py
+++ b/examples/report_jobs/function_app.py
@@ -121,7 +121,7 @@ def _check_bearer_auth(req: func.HttpRequest) -> func.HttpResponse | None:
     summary="Submit a report job",
     description="Queue a new report generation job. Returns a job ID for status polling.",
     tags=["reports"],
-    request_model=ReportRequest,
+    requests=ReportRequest,
     response_model=ReportJobResponse,
     response={
         202: {"description": "Report job queued"},
@@ -130,7 +130,7 @@ def _check_bearer_auth(req: func.HttpRequest) -> func.HttpResponse | None:
     },
     security=_BEARER_SECURITY,
     security_scheme=_BEARER_SCHEME,
-    )
+)
 @app.route(route="reports", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 def submit_report(req: func.HttpRequest) -> func.HttpResponse:
     auth_error = _check_bearer_auth(req)
@@ -186,7 +186,7 @@ def submit_report(req: func.HttpRequest) -> func.HttpResponse:
     },
     security=_BEARER_SECURITY,
     security_scheme=_BEARER_SCHEME,
-    )
+)
 @app.route(route="reports/{job_id}/status", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def get_report_status(req: func.HttpRequest) -> func.HttpResponse:
     auth_error = _check_bearer_auth(req)
@@ -231,7 +231,7 @@ def get_report_status(req: func.HttpRequest) -> func.HttpResponse:
             "schema": {"type": "string"},
         }
     ],
-    response={
+    responses={
         200: {"description": "Report file contents"},
         401: {"description": "Unauthorized"},
         404: {"description": "Job not found or not completed"},

--- a/examples/webhook_receiver/function_app.py
+++ b/examples/webhook_receiver/function_app.py
@@ -1,7 +1,7 @@
 """Webhook receiver example — representative use of @openapi.
 
 Demonstrates:
-- @openapi() with summary, description, tags, request_model, response_model, response
+- @openapi() with summary, description, tags, requests, response_model, response
 - get_openapi_json(), get_openapi_yaml()
 - render_swagger_ui()
 - Practical pattern: accept inbound webhook events and return 202 Accepted
@@ -83,7 +83,7 @@ def _verify_signature(payload: bytes, timestamp: str, signature: str, secret: st
         "Duplicate deliveries are rejected via the `X-Delivery-Id` header."
     ),
     tags=["webhooks"],
-    request_model=WebhookEvent,
+    requests=WebhookEvent,
     response_model=WebhookAcceptedResponse,
     response={
         202: {"description": "Webhook accepted for processing"},
@@ -91,7 +91,7 @@ def _verify_signature(payload: bytes, timestamp: str, signature: str, secret: st
         401: {"description": "Invalid webhook signature or expired timestamp"},
         409: {"description": "Duplicate delivery (replay)"},
     },
-    )
+)
 @app.route(route="webhooks/orders", methods=["POST"], auth_level=func.AuthLevel.ANONYMOUS)
 def receive_order_webhook(req: func.HttpRequest) -> func.HttpResponse:
     # --- Replay protection: delivery ID deduplication ---


### PR DESCRIPTION
## Context

Documentation and example code had drifted from the current public API (v0.21.1). This PR audits `docs/` against `src/` and the `@openapi` contract, and migrates docs/examples to the unified `requests=`/`responses=` parameters.

## Changes

- **api.md**: document 6 public symbols missing from the reference (`SpecReport`, `generate_openapi_report`, `SpecWarning`, `WarningCode`, `OpenAPIRegistry`, `SDKIncompatibleError`); refresh import list; add "Structured warnings" section; mark `scan_validation_metadata` as a deprecated alias; migrate code examples.
- **cli.md**: add `--strict` / `--fail-on-warnings` / `--isolate-app`; fix exit-code table (exit 2 = argparse OR `--fail-on-warnings`).
- **usage.md / configuration.md**: unified `requests`/`responses` teaching + migration table + `request_body_required`; deprecated-param table.
- **getting-started.md / configuration.md / getting-started.md**: add note for the `responses=` model+multi-status gap (see #410).
- **installation.md / development.md / contributing.md**: fix `cd azure-functions-openapi` -> `cd azure-functions-openapi-python` (clone dir name).
- **security.md**: remove duplicate `# Security Guide` heading.
- **faq.md / index.md / troubleshooting.md / testing.md**: migrate raw dict / `response_model` examples to `requests`/`responses`.
- **examples/webhook_receiver, examples/report_jobs** (code + docs): migrate `request_model=` -> `requests=`, pure-dict `response=` -> `responses=`.

## Verification

- Migrated request-side snippets: **0 DeprecationWarning** (verified by direct execution).
- Changed examples snapshot tests **PASS** (spec byte-identical); ruff clean; byte-compile OK.
- `notification_request` / `partner_import_bridge` intentionally unchanged (already correct or use `register_openapi_metadata` / `@validate_http`).
- Pre-existing `NotificationRequest` snapshot failures are unrelated to this PR (fail on clean tree).

## Out of scope

- Root `README.md` + translations migration -> tracked in #411.
- `responses=` cannot express model-200 + multi-status combos -> tracked in #410 (affected examples keep discrete `response_model=`/`response=` with the documented note).

## References

Closes #409
Refs #285, #410, #411