### PR TITLE
chore: ignore agent orchestration state (.sisyphus/, .omc/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ site/
 # Review
 .venv-review/
 .venv-review-cli/
+
+# Agent orchestration state
+.sisyphus/
+.omc/


### PR DESCRIPTION
## Summary
- Ignore local agent orchestration directories (`.sisyphus/`, `.omc/`) so they never get committed.
- Preventive hygiene; no tracked files removed.

Closes #415