### PR TITLE
ci(e2e): certify the release candidate wheel, not the PyPI build

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -104,11 +104,17 @@ jobs:
           RESOLVED_VERSION="${REQ_VERSION:-$FILE_VERSION}"
           echo "RESOLVED_VERSION=${RESOLVED_VERSION}" >> "$GITHUB_ENV"
           python -m build --wheel --outdir dist
-          WHEEL=$(ls dist/azure_functions_openapi-*.whl | head -n1)
-          if [ -z "$WHEEL" ]; then
-            echo "::error ::No candidate wheel produced by python -m build"
+          shopt -s nullglob
+          wheels=(dist/azure_functions_openapi-${RESOLVED_VERSION}-*.whl)
+          if [ ${#wheels[@]} -eq 0 ]; then
+            echo "::error ::No candidate wheel matching version ${RESOLVED_VERSION} produced by python -m build"
             exit 1
           fi
+          if [ ${#wheels[@]} -gt 1 ]; then
+            echo "::error ::Expected exactly one candidate wheel for ${RESOLVED_VERSION}, found ${#wheels[@]}: ${wheels[*]}"
+            exit 1
+          fi
+          WHEEL="${wheels[0]}"
           mkdir -p examples/e2e_app/wheels
           cp "$WHEEL" examples/e2e_app/wheels/
           BASENAME=$(basename "$WHEEL")

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -92,6 +92,32 @@ jobs:
           pip install -e ".[dev]"
           pip install requests pyyaml pytest pytest-html
 
+      - name: Build candidate wheel and bundle into e2e app
+        run: |
+          python -m pip install --upgrade pip build
+          FILE_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_openapi/__init__.py)
+          REQ_VERSION="${{ inputs.version }}"
+          if [ -n "$REQ_VERSION" ] && [ "$REQ_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error ::Requested version ($REQ_VERSION) != source version ($FILE_VERSION)"
+            exit 1
+          fi
+          RESOLVED_VERSION="${REQ_VERSION:-$FILE_VERSION}"
+          echo "RESOLVED_VERSION=${RESOLVED_VERSION}" >> "$GITHUB_ENV"
+          python -m build --wheel --outdir dist
+          WHEEL=$(ls dist/azure_functions_openapi-*.whl | head -n1)
+          if [ -z "$WHEEL" ]; then
+            echo "::error ::No candidate wheel produced by python -m build"
+            exit 1
+          fi
+          mkdir -p examples/e2e_app/wheels
+          cp "$WHEEL" examples/e2e_app/wheels/
+          BASENAME=$(basename "$WHEEL")
+          # Append the locally-built candidate so the remote Oryx build installs it
+          # instead of resolving azure-functions-openapi from PyPI.
+          echo "./wheels/${BASENAME}" >> examples/e2e_app/requirements.txt
+          echo "Bundled candidate wheel: ${BASENAME} (version ${RESOLVED_VERSION})"
+          cat examples/e2e_app/requirements.txt
+
       - name: Publish function app
         working-directory: examples/e2e_app
         run: |
@@ -101,6 +127,7 @@ jobs:
         run: pytest tests/e2e -v --no-cov --html=e2e-report/report.html --self-contained-html
         env:
           E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+          E2E_EXPECTED_VERSION: ${{ env.RESOLVED_VERSION }}
 
       - name: Record certification
         run: |

--- a/examples/e2e_app/function_app.py
+++ b/examples/e2e_app/function_app.py
@@ -6,6 +6,7 @@ against a real Azure Functions Consumption host.
 
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import logging
 
@@ -28,6 +29,19 @@ class ItemResponse(BaseModel):
 def health(req: func.HttpRequest) -> func.HttpResponse:
     """Liveness probe used by e2e warmup loop."""
     return func.HttpResponse(json.dumps({"status": "ok"}), mimetype="application/json")
+
+
+@app.route(route="version", auth_level=func.AuthLevel.ANONYMOUS)
+def version(req: func.HttpRequest) -> func.HttpResponse:
+    """Report the installed package version so e2e can certify the candidate.
+
+    Proves the deployed host is running the exact wheel bundled by CI rather
+    than whatever is currently published on PyPI.
+    """
+    installed = importlib.metadata.version("azure-functions-openapi")
+    return func.HttpResponse(
+        json.dumps({"version": installed}), mimetype="application/json"
+    )
 
 
 @openapi(

--- a/examples/e2e_app/requirements.txt
+++ b/examples/e2e_app/requirements.txt
@@ -1,3 +1,5 @@
 azure-functions
-azure-functions-openapi
+# azure-functions-openapi is injected as a locally-built candidate wheel by
+# .github/workflows/e2e-azure.yml (see the "Build candidate wheel" step) so the
+# remote Oryx build certifies the release candidate, not the published PyPI build.
 pydantic>=2.0,<3.0

--- a/tests/e2e/test_openapi_e2e.py
+++ b/tests/e2e/test_openapi_e2e.py
@@ -17,6 +17,7 @@ import requests
 import yaml  # PyYAML
 
 BASE_URL = os.environ.get("E2E_BASE_URL", "").rstrip("/")
+EXPECTED_VERSION = os.environ.get("E2E_EXPECTED_VERSION", "").strip()
 SKIP_REASON = "E2E_BASE_URL not set — skipping real-Azure e2e tests"
 
 
@@ -96,3 +97,17 @@ def test_list_items_endpoint() -> None:
     assert len(items) > 0
     assert "id" in items[0]
     assert "name" in items[0]
+
+
+@pytest.mark.skipif(not BASE_URL, reason=SKIP_REASON)
+def test_deployed_version_matches_candidate() -> None:
+    """Certify the deployed host runs the candidate wheel, not the PyPI build."""
+    r = _get("/api/version")
+    assert r.status_code == 200
+    deployed = r.json()["version"]
+    if EXPECTED_VERSION:
+        assert deployed == EXPECTED_VERSION, (
+            f"Deployed version {deployed!r} != expected candidate "
+            f"{EXPECTED_VERSION!r} — remote build did not install the "
+            "bundled wheel"
+        )

--- a/tests/e2e/test_openapi_e2e.py
+++ b/tests/e2e/test_openapi_e2e.py
@@ -105,9 +105,15 @@ def test_deployed_version_matches_candidate() -> None:
     r = _get("/api/version")
     assert r.status_code == 200
     deployed = r.json()["version"]
-    if EXPECTED_VERSION:
-        assert deployed == EXPECTED_VERSION, (
-            f"Deployed version {deployed!r} != expected candidate "
-            f"{EXPECTED_VERSION!r} — remote build did not install the "
-            "bundled wheel"
-        )
+    # Fail closed: when this test runs at all (BASE_URL is set), a missing/blank
+    # E2E_EXPECTED_VERSION means the workflow wiring regressed and the
+    # certification can no longer prove the deployed host ran the candidate wheel.
+    assert EXPECTED_VERSION, (
+        "E2E_EXPECTED_VERSION is not set — cannot certify that the deployed "
+        "host runs the candidate wheel. Check the e2e-azure workflow wiring."
+    )
+    assert deployed == EXPECTED_VERSION, (
+        f"Deployed version {deployed!r} != expected candidate "
+        f"{EXPECTED_VERSION!r} — remote build did not install the "
+        "bundled wheel"
+    )


### PR DESCRIPTION
## Context

`e2e-azure.yml` is the real-Azure certification gate: `verify-azure-certification` in `publish-pypi.yml` refuses to publish without a fresh, SHA+version-matched certification for the release commit. But the certification was not actually exercising the release candidate.

The Deploy step ran `func azure functionapp publish "$APP" --python --build remote` with an **unpinned** `azure-functions-openapi` in `examples/e2e_app/requirements.txt`. With `--build remote`, the Oryx build on the Azure host resolved that dependency from **PyPI** (the last-published version), not the commit under certification. The runner's `pip install -e ".[dev]"` only affected the local pytest client — and the e2e tests make pure HTTP requests, never importing the package — so the deployed host ran a **stale published build**, not the candidate. This is exactly the failure class the tiered gate exists to prevent (0.21.0 / 0.8.1-style regressions slipping to PyPI).

This follows the LangGraph #305 wheel-injection recipe for sibling alignment, keeping `--build remote`.

## Changes

- **Build & bundle the candidate wheel** (`e2e-azure.yml`): new step builds a wheel from the checked-out release ref (`python -m build --wheel`), copies it into `examples/e2e_app/wheels/`, and appends `./wheels/<wheel>` to the e2e app's `requirements.txt` so the remote build installs the candidate. The step also resolves/validates the release version (fails fast if `inputs.version` != source `__version__`) and exports it as `RESOLVED_VERSION`.
- **De-pin PyPI** (`examples/e2e_app/requirements.txt`): removed the unpinned `azure-functions-openapi` line (replaced by a comment) so PyPI is no longer resolved for this package.
- **Deployed-version assertion**: added a `/api/version` route (`function_app.py`) reporting `importlib.metadata.version("azure-functions-openapi")`, plus an e2e test (`test_deployed_version_matches_candidate`) that asserts the deployed version equals `E2E_EXPECTED_VERSION` (wired to `RESOLVED_VERSION`). This proves the deployed host is running the candidate.

`.funcignore` does not exclude `wheels/`, so the bundled wheel uploads with the app.

## Acceptance checklist (from #414)

- [x] e2e-azure builds a wheel from the checked-out release ref (`python -m build --wheel`)
- [x] Wheel injected into the deployed app (`wheels/` + requirements.txt append) so the remote build installs the candidate, not PyPI
- [x] Unpinned/PyPI `azure-functions-openapi` removed from the e2e app requirements
- [x] Deployed `importlib.metadata.version("azure-functions-openapi")` asserted to match the release version

## Out of scope

- Library unit / `lib-tests` tier changes.

## Verification

- `python -m build` wheel glob + empty-wheel guard in CI.
- Local: `ruff check` clean; Python + YAML parse clean.
- Full certification requires a `workflow_dispatch` real-Azure run (cannot run locally).

Closes #414
