### PR TITLE
feat(decorator): let responses= express model-derived schemas across multiple status codes

### DIFF
--- a/examples/notification_request/function_app.py
+++ b/examples/notification_request/function_app.py
@@ -75,9 +75,11 @@ _notifications: dict[str, dict[str, str]] = {}
     description="Validate and queue an email notification for delivery.",
     tags=["notifications"],
     requests=EmailNotificationRequest,
-    response_model=NotificationAcceptedResponse,
-    response={
-        202: {"description": "Notification queued for delivery"},
+    responses={
+        202: {
+            "description": "Notification queued for delivery",
+            "content": {"application/json": {"schema": NotificationAcceptedResponse}},
+        },
         422: {"description": "Validation error"},
     },
 )
@@ -118,9 +120,11 @@ def send_notification(req: func.HttpRequest, body: EmailNotificationRequest) -> 
             "schema": {"type": "string"},
         }
     ],
-    response_model=NotificationStatusResponse,
-    response={
-        200: {"description": "Notification status"},
+    responses={
+        200: {
+            "description": "Notification status",
+            "content": {"application/json": {"schema": NotificationStatusResponse}},
+        },
         404: {"description": "Notification not found"},
     },
 )

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -119,9 +119,9 @@ def _default_response_description(status: int) -> str:
 
 
 def _normalize_unified_responses(
-    responses: dict[int, Any], func_name: str
+    responses: Mapping[int, Any], func_name: str
 ) -> dict[int, dict[str, Any]]:
-    """Normalize a unified ``responses=`` dict into OpenAPI Response Objects.
+    """Normalize a unified ``responses=`` mapping into OpenAPI Response Objects.
 
     Each value may be either:
 
@@ -368,7 +368,7 @@ def openapi(
                     raise ValueError(
                         "Cannot provide both 'responses' and 'response_model'/'response'."
                     )
-                if isinstance(responses, dict):
+                if isinstance(responses, Mapping):
                     resolved_response = _normalize_unified_responses(
                         responses, metadata_func.__name__
                     )

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -1,8 +1,9 @@
 # src/azure_functions_openapi/decorator.py
 from __future__ import annotations
 
+from collections.abc import Mapping
 import logging
-from typing import Any, Callable, TypeVar, cast
+from typing import Any, Callable, TypeGuard, TypeVar, cast
 import warnings
 
 from pydantic import BaseModel
@@ -107,6 +108,51 @@ def _extract_binding_hints(func: Any) -> tuple[str | None, str | None, bool, boo
     return None, None, False, False
 
 
+def _is_pydantic_model(value: Any) -> TypeGuard[type[BaseModel]]:
+    """Return True when *value* is a Pydantic ``BaseModel`` subclass (a class)."""
+    return isinstance(value, type) and issubclass(value, BaseModel)
+
+
+def _default_response_description(status: int) -> str:
+    """Default OpenAPI response description for a bare per-status model shorthand."""
+    return "Successful Response" if 200 <= status < 300 else "Response"
+
+
+def _normalize_unified_responses(
+    responses: dict[int, Any], func_name: str
+) -> dict[int, dict[str, Any]]:
+    """Normalize a unified ``responses=`` dict into OpenAPI Response Objects.
+
+    Each value may be either:
+
+    * a Pydantic ``BaseModel`` subclass — shorthand for a JSON body of that
+      schema, expanded to ``{"description": ..., "content":
+      {"application/json": {"schema": Model}}}`` (the model class is resolved to
+      a schema at spec-generation time, where the ``components`` registry lives), or
+    * an OpenAPI Response Object dict (unchanged; a Pydantic model may also appear
+      in its ``content.<media>.schema`` position and is resolved the same way).
+
+    Raises ``ValueError`` for any other value type so misuse fails fast at
+    decoration time rather than silently producing an invalid spec.
+    """
+    normalized: dict[int, dict[str, Any]] = {}
+    for status, value in responses.items():
+        if _is_pydantic_model(value):
+            normalized[status] = {
+                "description": _default_response_description(status),
+                "content": {"application/json": {"schema": value}},
+            }
+        elif isinstance(value, dict):
+            normalized[status] = value
+        else:
+            raise ValueError(
+                f"Invalid 'responses' entry for status {status} in function "
+                f"'{func_name}': each value must be a Pydantic BaseModel subclass "
+                f"or an OpenAPI Response Object dict, got {type(value).__name__}."
+            )
+    return normalized
+
+
 def openapi(
     # ── basic metadata ───────────────────────────────────────────
     summary: str = "",
@@ -126,7 +172,7 @@ def openapi(
     request_body_required: bool = True,
     response_model: type[BaseModel] | None = None,
     response: dict[int, dict[str, Any]] | None = None,
-    responses: type[BaseModel] | dict[int, dict[str, Any]] | None = None,
+    responses: type[BaseModel] | Mapping[int, type[BaseModel] | dict[str, Any]] | None = None,
 ) -> Callable[[F], F]:
     """
     Decorator that attaches OpenAPI metadata to an Azure Functions handler.
@@ -223,9 +269,19 @@ def openapi(
     response:
         Manual responses dict keyed by status code.
     responses:
-        Unified response parameter that accepts either a Pydantic model class
-        (equivalent to `response_model`) or a manual responses dict keyed by
-        status code (equivalent to `response`).
+        Unified response parameter. Accepts either:
+
+        * a Pydantic model class (equivalent to `response_model`; its schema is
+          injected into the first 2xx response), or
+        * a dict keyed by status code whose values are OpenAPI Response Objects
+          (equivalent to `response`). Each value may additionally be a bare
+          Pydantic model class as shorthand for a JSON body of that schema, and
+          a model class may also appear in the `content.<media>.schema` position
+          of a Response Object. This lets a single operation express a typed
+          success body together with several documented status codes — e.g.
+          ``responses={202: AcceptedModel, 422: {"description": "Validation error"}}``
+          — which previously required combining the discrete `response_model` and
+          `response` parameters.
 
     .. deprecated::
        This decorator currently exposes two parallel parameter styles: the
@@ -313,8 +369,10 @@ def openapi(
                         "Cannot provide both 'responses' and 'response_model'/'response'."
                     )
                 if isinstance(responses, dict):
-                    resolved_response = responses
-                elif isinstance(responses, type) and issubclass(responses, BaseModel):
+                    resolved_response = _normalize_unified_responses(
+                        responses, metadata_func.__name__
+                    )
+                elif _is_pydantic_model(responses):
                     resolved_response_model = responses
                 else:
                     raise ValueError(

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -8,6 +8,7 @@ import logging
 import re
 from typing import Any
 
+from pydantic import BaseModel
 import yaml
 
 from azure_functions_openapi._warnings import SpecWarning, WarningCode
@@ -344,14 +345,21 @@ def generate_openapi_spec(
                         hoisted_content: dict[str, Any] = {}
                         for media, media_obj in resp_content.items():
                             if isinstance(media_obj, dict) and "schema" in media_obj:
-                                media_obj = {
-                                    **media_obj,
-                                    "schema": hoist_inline_defs(
-                                        media_obj["schema"],
+                                raw_schema = media_obj["schema"]
+                                if isinstance(raw_schema, type) and issubclass(
+                                    raw_schema, BaseModel
+                                ):
+                                    # Unified per-status model shorthand (#410):
+                                    # resolve the model to a $ref here, where the
+                                    # components registry is available.
+                                    resolved_schema = model_to_schema(raw_schema, components)
+                                else:
+                                    resolved_schema = hoist_inline_defs(
+                                        raw_schema,
                                         components,
                                         hoist_flat=hoist_flat_schemas,
-                                    ),
-                                }
+                                    )
+                                media_obj = {**media_obj, "schema": resolved_schema}
                             hoisted_content[media] = media_obj
                         resp["content"] = hoisted_content
                     responses[str(status)] = resp

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -546,3 +546,115 @@ def test_resolve_metadata_target_reraises_when_handler_unrecoverable(
     builder = app._function_builders[0]
     with pytest.raises(ValueError):
         decorator_module._resolve_metadata_target(builder)
+
+
+
+# ── #410: unified responses= with per-status model-derived schemas ──────────
+
+
+def test_openapi_responses_dict_accepts_per_status_model() -> None:
+    """A bare Pydantic model as a status value is normalized to a Response Object."""
+    _clear_registry()
+
+    @openapi(
+        summary="Typed 2xx body + extra statuses",
+        route="/api/items",
+        method="post",
+        responses={
+            202: _UnifiedResponseModel,
+            400: {"description": "Bad request"},
+        },
+    )
+    def per_status_model_func() -> None:
+        pass
+
+    entry = get_openapi_registry()["per_status_model_func"]
+    # No discrete response_model channel is used for per-status dict form.
+    assert entry["response_model"] is None
+    resp = entry["response"]
+    # 202 expanded to a Response Object carrying the model in schema position.
+    assert resp[202]["description"] == "Successful Response"
+    assert resp[202]["content"]["application/json"]["schema"] is _UnifiedResponseModel
+    # Non-model dict entries pass through unchanged.
+    assert resp[400] == {"description": "Bad request"}
+
+
+def test_openapi_responses_dict_non_2xx_model_default_description() -> None:
+    """A bare model on a non-2xx status defaults to a generic 'Response' description."""
+    _clear_registry()
+
+    @openapi(summary="Error body", responses={409: _UnifiedResponseModel})
+    def non_2xx_model_func() -> None:
+        pass
+
+    resp = get_openapi_registry()["non_2xx_model_func"]["response"]
+    assert resp[409]["description"] == "Response"
+    assert resp[409]["content"]["application/json"]["schema"] is _UnifiedResponseModel
+
+
+def test_openapi_responses_dict_per_status_model_generates_schema() -> None:
+    """End-to-end: per-status model resolves to a $ref and registers a component."""
+    _clear_registry()
+
+    @openapi(
+        summary="Typed 2xx body + extra statuses",
+        route="/api/items",
+        method="post",
+        responses={
+            202: _UnifiedResponseModel,
+            400: {"description": "Bad request"},
+        },
+    )
+    def per_status_spec_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="")
+    op = spec["paths"]["/api/items"]["post"]
+    responses = op["responses"]
+    # 202 carries a $ref to the model schema; 400 keeps its plain description.
+    schema = responses["202"]["content"]["application/json"]["schema"]
+    assert "$ref" in schema
+    assert schema["$ref"].endswith("/_UnifiedResponseModel")
+    assert responses["400"]["description"] == "Bad request"
+    assert "_UnifiedResponseModel" in spec["components"]["schemas"]
+
+
+def test_openapi_responses_dict_model_in_content_schema() -> None:
+    """A Pydantic model in the content.schema position is resolved at spec-gen."""
+    _clear_registry()
+
+    @openapi(
+        summary="Model in explicit content schema",
+        route="/api/items",
+        method="post",
+        responses={
+            201: {
+                "description": "Created",
+                "content": {"application/json": {"schema": _UnifiedResponseModel}},
+            },
+        },
+    )
+    def content_schema_model_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="")
+    op = spec["paths"]["/api/items"]["post"]
+    schema = op["responses"]["201"]["content"]["application/json"]["schema"]
+    assert "$ref" in schema
+    assert "_UnifiedResponseModel" in spec["components"]["schemas"]
+
+
+def test_openapi_responses_dict_rejects_invalid_value() -> None:
+    """A non-dict, non-model status value fails fast at decoration time."""
+    _clear_registry()
+
+    with pytest.raises(ValueError) as exc_info:
+
+        @openapi(
+            summary="Invalid responses entry",
+            responses={200: "bad"},  # type: ignore[dict-item]
+        )
+        def invalid_responses_func() -> None:
+            pass
+
+    assert "Invalid 'responses' entry for status 200" in str(exc_info.value)

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -658,3 +658,31 @@ def test_openapi_responses_dict_rejects_invalid_value() -> None:
             pass
 
     assert "Invalid 'responses' entry for status 200" in str(exc_info.value)
+
+
+def test_openapi_responses_accepts_non_dict_mapping() -> None:
+    """A non-dict Mapping (e.g. MappingProxyType) is accepted, matching the
+    advertised Mapping[...] type contract rather than requiring a concrete dict."""
+    from types import MappingProxyType
+
+    _clear_registry()
+
+    @openapi(
+        summary="Non-dict mapping responses",
+        route="/api/items",
+        method="post",
+        responses=MappingProxyType(
+            {
+                202: _UnifiedResponseModel,
+                400: {"description": "Bad request"},
+            }
+        ),
+    )
+    def non_dict_mapping_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="")
+    responses = spec["paths"]["/api/items"]["post"]["responses"]
+    schema = responses["202"]["content"]["application/json"]["schema"]
+    assert schema["$ref"].endswith("/_UnifiedResponseModel")
+    assert responses["400"]["description"] == "Bad request"


### PR DESCRIPTION
## Summary

Closes #410.

Makes the unified `responses=` parameter able to express a **typed success body together with several documented status codes** in one place. Previously this required combining the discrete `response_model` and `response` parameters on the same operation — the last API gap blocking their deprecation.

### What changed

- **`responses={status: Model}` bare-model shorthand** — a Pydantic model class as a per-status value is normalized (at decoration time) to a full OpenAPI Response Object: `{"description": <default>, "content": {"application/json": {"schema": Model}}}`. Default description is `"Successful Response"` for 2xx, `"Response"` otherwise.
- **Model in `content.<media>.schema`** — a model class may also appear directly in a Response Object's schema position.
- Model classes are resolved to component `$ref`s at **spec-generation time**, where the `components` registry lives (via `model_to_schema`).
- Invalid per-status values raise `ValueError` at decoration time (fail fast).
- `responses=Model` (whole-operation) behaviour is unchanged.

### Design

Implemented per the "hybrid A+B" design: bare-model shorthand + explicit-content form both supported, registry keys unchanged, detection via `isinstance(value, type) and issubclass(value, BaseModel)`.

### Example migration

`examples/notification_request/function_app.py` previously carried **both** `response_model=` and `response=` on the same operation because the gap couldn't be expressed with `responses=`. It's now migrated to a single unified `responses={...}`. **Generated spec output is unchanged** (snapshot diff is empty — the explicit content-schema form preserves the original per-status descriptions).

## Verification

- `make lint` ✅ clean
- `make typecheck` ✅ (52 files, no issues)
- `hatch run pytest --cov` ✅ **712 passed, 5 skipped**, coverage **96.32%** (gate ≥95%)
- Snapshots regenerated with `UPDATE_SNAPSHOTS=1` → **no on-disk change** (true equivalence)
- 5 new tests in `tests/test_decorator.py` covering: per-status model, non-2xx default description, generated `$ref`, model-in-content-schema, and invalid-value rejection.

## Follow-up

Re-affirms the deprecation of the discrete `response_model`/`response` params — no residual case now requires them.
