### PR TITLE
docs(readme): migrate README examples to unified requests/responses params

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -62,8 +62,8 @@ class UserResponse(BaseModel):
 
 @openapi(
     summary="Create user",
-    request_model=CreateUserRequest,
-    response_model=UserResponse,
+    requests=CreateUserRequest,
+    responses=UserResponse,
 )
 @app.route(route="users", methods=["POST"])
 def create_user(req):
@@ -176,8 +176,8 @@ class GreetResponse(BaseModel):
 @openapi(
     summary="Greet user",
     tags=["Example"],
-    request_model=GreetRequest,
-    response_model=GreetResponse,
+    requests=GreetRequest,
+    responses=GreetResponse,
 )
 @app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
@@ -191,7 +191,7 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     )
 ```
 
-> **Pydantic v2 は任意です。** `request_model=` / `response_model=` を推奨しますが、依存関係を追加したくなければ生の JSON Schema dict を代わりに渡すこともできます（下記参照）。
+> **Pydantic v2 は任意です。** `requests=` / `responses=` を推奨しますが、依存関係を追加したくなければ生の JSON Schema dict を代わりに渡すこともできます（下記参照）。
 
 <details>
 <summary>スペック + Swagger UI エンドポイントの接続 (openapi.json / openapi.yaml / docs)</summary>
@@ -234,12 +234,12 @@ def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
 @openapi(
     summary="Greet user",
     tags=["Example"],
-    request_body={
+    requests={
         "type": "object",
         "properties": {"name": {"type": "string"}},
         "required": ["name"],
     },
-    response={
+    responses={
         200: {
             "description": "Successful greeting",
             "content": {

--- a/README.ko.md
+++ b/README.ko.md
@@ -62,8 +62,8 @@ class UserResponse(BaseModel):
 
 @openapi(
     summary="Create user",
-    request_model=CreateUserRequest,
-    response_model=UserResponse,
+    requests=CreateUserRequest,
+    responses=UserResponse,
 )
 @app.route(route="users", methods=["POST"])
 def create_user(req):
@@ -176,8 +176,8 @@ class GreetResponse(BaseModel):
 @openapi(
     summary="Greet user",
     tags=["Example"],
-    request_model=GreetRequest,
-    response_model=GreetResponse,
+    requests=GreetRequest,
+    responses=GreetResponse,
 )
 @app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
@@ -191,7 +191,7 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     )
 ```
 
-> **Pydantic v2는 선택 사항입니다.** `request_model=` / `response_model=`을 권장하지만, 의존성을 추가하고 싶지 않다면 원시 JSON Schema dict를 대신 전달할 수 있습니다(아래 참고).
+> **Pydantic v2는 선택 사항입니다.** `requests=` / `responses=`을 권장하지만, 의존성을 추가하고 싶지 않다면 원시 JSON Schema dict를 대신 전달할 수 있습니다(아래 참고).
 
 <details>
 <summary>스펙 + Swagger UI 엔드포인트 연결 (openapi.json / openapi.yaml / docs)</summary>
@@ -234,12 +234,12 @@ def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
 @openapi(
     summary="Greet user",
     tags=["Example"],
-    request_body={
+    requests={
         "type": "object",
         "properties": {"name": {"type": "string"}},
         "required": ["name"],
     },
-    response={
+    responses={
         200: {
             "description": "Successful greeting",
             "content": {

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ class UserResponse(BaseModel):
 
 @openapi(
     summary="Create user",
-    request_model=CreateUserRequest,
-    response_model=UserResponse,
+    requests=CreateUserRequest,
+    responses=UserResponse,
 )
 @app.route(route="users", methods=["POST"])
 def create_user(req):
@@ -115,7 +115,7 @@ flowchart LR
 | Swagger UI | `/docs` auto-served | `render_swagger_ui()` endpoint |
 | OpenAPI spec | Auto-generated `/openapi.json` | `get_openapi_json()` endpoint |
 | CLI spec export | N/A | `azure-functions-openapi generate` |
-| Pydantic integration | Native | `request_model=` / `response_model=` |
+| Pydantic integration | Native | `requests=` / `responses=` |
 
 ## Scope
 
@@ -220,8 +220,8 @@ class GreetResponse(BaseModel):
 @openapi(
     summary="Greet user",
     tags=["Example"],
-    request_model=GreetRequest,
-    response_model=GreetResponse,
+    requests=GreetRequest,
+    responses=GreetResponse,
 )
 @app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
@@ -235,7 +235,7 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     )
 ```
 
-> **Pydantic v2 is optional.** `request_model=` / `response_model=` are the recommended path, but you can pass raw JSON Schema dicts instead (see below) if you'd rather not add a dependency.
+> **Pydantic v2 is optional.** `requests=` / `responses=` are the recommended path, but you can pass raw JSON Schema dicts instead (see below) if you'd rather not add a dependency.
 
 <details>
 <summary>Wire up the spec + Swagger UI endpoints (openapi.json / openapi.yaml / docs)</summary>
@@ -278,12 +278,12 @@ def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
 @openapi(
     summary="Greet user",
     tags=["Example"],
-    request_body={
+    requests={
         "type": "object",
         "properties": {"name": {"type": "string"}},
         "required": ["name"],
     },
-    response={
+    responses={
         200: {
             "description": "Successful greeting",
             "content": {

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,8 +62,8 @@ class UserResponse(BaseModel):
 
 @openapi(
     summary="Create user",
-    request_model=CreateUserRequest,
-    response_model=UserResponse,
+    requests=CreateUserRequest,
+    responses=UserResponse,
 )
 @app.route(route="users", methods=["POST"])
 def create_user(req):
@@ -176,8 +176,8 @@ class GreetResponse(BaseModel):
 @openapi(
     summary="Greet user",
     tags=["Example"],
-    request_model=GreetRequest,
-    response_model=GreetResponse,
+    requests=GreetRequest,
+    responses=GreetResponse,
 )
 @app.route(route="http_trigger", auth_level=func.AuthLevel.ANONYMOUS, methods=["POST"])
 def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
@@ -191,7 +191,7 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
     )
 ```
 
-> **Pydantic v2 为可选项。** 推荐使用 `request_model=` / `response_model=`，但如果你不想添加依赖，也可以改为传入原始 JSON Schema dict（见下文）。
+> **Pydantic v2 为可选项。** 推荐使用 `requests=` / `responses=`，但如果你不想添加依赖，也可以改为传入原始 JSON Schema dict（见下文）。
 
 <details>
 <summary>连接规范 + Swagger UI 端点 (openapi.json / openapi.yaml / docs)</summary>
@@ -234,12 +234,12 @@ def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
 @openapi(
     summary="Greet user",
     tags=["Example"],
-    request_body={
+    requests={
         "type": "object",
         "properties": {"name": {"type": "string"}},
         "required": ["name"],
     },
-    response={
+    responses={
         200: {
             "description": "Successful greeting",
             "content": {


### PR DESCRIPTION
## Summary

Closes #411.

Migrates the **root READMEs** — the highest-visibility entry point — from the deprecated discrete params to the unified `requests=`/`responses=` params (established in #285/#409). Previously, users following the README's first snippet would immediately hit `DeprecationWarning`. This is now unblocked end-to-end because #410 closed the `responses=` per-status model-schema gap, so the response side can migrate too (not just the request side).

### Migration applied

| Before | After |
|---|---|
| `request_model=Model` | `requests=Model` |
| `request_body={...}` (raw JSON Schema) | `requests={...}` |
| `response_model=Model` | `responses=Model` |
| `response={200: {...}}` | `responses={200: {...}}` |

Plus the FastAPI-comparison **"Pydantic integration"** row and the **"Pydantic v2 is optional"** note now reference `requests=` / `responses=`.

### Translation sync (AGENTS.md rule)

Applied **identically** to `README.ko.md`, `README.ja.md`, `README.zh-CN.md` in the same PR. The Python code blocks are language-agnostic; only the surrounding prose sentence (the "Pydantic v2 is optional" note) is translated per language.

## Verification

- No residual `request_model=` / `response_model=` / `request_body=` / `response=` in any README (grep clean).
- Executed both migrated snippets under `warnings.simplefilter("error")` — **no `DeprecationWarning`** emitted (acceptance criterion).
- `make lint` clean. Docs-only change; no source/test/behavior changes.

## Out of scope

- `docs/` guide/example sync — already done in #409.
- A dedicated `response_model=`/`response=` **deprecation migration guide** + alias-retention policy (≥2 minors) for the public-API generational change — this is a broader follow-up beyond README snippet migration and should be tracked as its own issue.
