### PR TITLE
docs: consolidate official documentation URL onto yeongseon.dev (STEP 3)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://yeongseon.github.io/azure-functions-openapi-python/
+    url: https://yeongseon.dev/azure-functions-python/openapi/
     about: Check our documentation for usage guides and examples
   - name: Security Advisories
     url: /security/advisories/new

--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/openapi/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
@@ -290,7 +290,7 @@ func start
 
 ## Documentation
 
-- 全ドキュメント: [yeongseon.github.io/azure-functions-openapi-python](https://yeongseon.github.io/azure-functions-openapi-python/)
+- 全ドキュメント: [yeongseon.dev/azure-functions-python/openapi](https://yeongseon.dev/azure-functions-python/openapi/)
 - スモークテスト済みサンプル: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/openapi/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -290,7 +290,7 @@ func start
 
 ## Documentation
 
-- 전체 문서: [yeongseon.github.io/azure-functions-openapi-python](https://yeongseon.github.io/azure-functions-openapi-python/)
+- 전체 문서: [yeongseon.dev/azure-functions-python/openapi](https://yeongseon.dev/azure-functions-python/openapi/)
 - 스모크 테스트된 예제: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/openapi/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -372,7 +372,7 @@ The web preview below is generated from the same representative example and capt
 
 ## Documentation
 
-- Full docs: [yeongseon.github.io/azure-functions-openapi-python](https://yeongseon.github.io/azure-functions-openapi-python/)
+- Full docs: [yeongseon.dev/azure-functions-python/openapi](https://yeongseon.dev/azure-functions-python/openapi/)
 - Smoke-tested examples: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-openapi-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-openapi-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-openapi-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-openapi-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/openapi/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
@@ -290,7 +290,7 @@ func start
 
 ## Documentation
 
-- 完整文档: [yeongseon.github.io/azure-functions-openapi-python](https://yeongseon.github.io/azure-functions-openapi-python/)
+- 完整文档: [yeongseon.dev/azure-functions-python/openapi](https://yeongseon.dev/azure-functions-python/openapi/)
 - 经过 smoke test 的示例: `examples/`
 - [Installation Guide](docs/installation.md)
 - [Usage Guide](docs/usage.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,21 +5,21 @@
 Part of the **Azure Functions Python DX Toolkit**. Decorate HTTP-triggered functions to auto-generate an OpenAPI 3 specification and serve Swagger UI, bringing a FastAPI-like developer experience to Azure Functions. Install from PyPI with `pip install azure-functions-openapi`.
 
 ## Getting Started
-- [Installation](https://yeongseon.github.io/azure-functions-openapi-python/installation/): Install the package and prerequisites.
-- [Quickstart](https://yeongseon.github.io/azure-functions-openapi-python/getting-started/): Minimal end-to-end example.
-- [Configuration](https://yeongseon.github.io/azure-functions-openapi-python/configuration/): Customize spec metadata, servers, and routes.
+- [Installation](https://yeongseon.dev/azure-functions-python/openapi/installation/): Install the package and prerequisites.
+- [Quickstart](https://yeongseon.dev/azure-functions-python/openapi/getting-started/): Minimal end-to-end example.
+- [Configuration](https://yeongseon.dev/azure-functions-python/openapi/configuration/): Customize spec metadata, servers, and routes.
 
 ## User Guide
-- [Usage](https://yeongseon.github.io/azure-functions-openapi-python/usage/): Decorator reference, request/response models.
-- [CLI](https://yeongseon.github.io/azure-functions-openapi-python/cli/): Generate specs from the command line.
-- [Route Prefix](https://yeongseon.github.io/azure-functions-openapi-python/route-prefix/): Handle custom route prefixes.
-- [Architecture](https://yeongseon.github.io/azure-functions-openapi-python/architecture/): How spec generation and the handler bridge work.
+- [Usage](https://yeongseon.dev/azure-functions-python/openapi/usage/): Decorator reference, request/response models.
+- [CLI](https://yeongseon.dev/azure-functions-python/openapi/cli/): Generate specs from the command line.
+- [Route Prefix](https://yeongseon.dev/azure-functions-python/openapi/route-prefix/): Handle custom route prefixes.
+- [Architecture](https://yeongseon.dev/azure-functions-python/openapi/architecture/): How spec generation and the handler bridge work.
 
 ## Reference
-- [API Reference](https://yeongseon.github.io/azure-functions-openapi-python/api/): Public API surface.
-- [FAQ](https://yeongseon.github.io/azure-functions-openapi-python/faq/): Frequently asked questions.
-- [Troubleshooting](https://yeongseon.github.io/azure-functions-openapi-python/troubleshooting/): Common issues and fixes.
+- [API Reference](https://yeongseon.dev/azure-functions-python/openapi/api/): Public API surface.
+- [FAQ](https://yeongseon.dev/azure-functions-python/openapi/faq/): Frequently asked questions.
+- [Troubleshooting](https://yeongseon.dev/azure-functions-python/openapi/troubleshooting/): Common issues and fixes.
 
 ## Optional
-- [Deploy to Azure](https://yeongseon.github.io/azure-functions-openapi-python/deployment/): Deployment guide.
-- [Changelog](https://yeongseon.github.io/azure-functions-openapi-python/changelog/): Release history.
+- [Deploy to Azure](https://yeongseon.dev/azure-functions-python/openapi/deployment/): Deployment guide.
+- [Changelog](https://yeongseon.dev/azure-functions-python/openapi/changelog/): Release history.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 - Version: 0.16.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-openapi-python/
+- Docs: https://yeongseon.dev/azure-functions-python/openapi/
 - Repository: https://github.com/yeongseon/azure-functions-openapi-python
 - Azure Functions programming model: v2
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 - Version: 0.16.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-openapi-python/
+- Docs: https://yeongseon.dev/azure-functions-python/openapi/
 - Repository: https://github.com/yeongseon/azure-functions-openapi-python
 
 ## What It Does
@@ -62,10 +62,10 @@ def openapi_spec(req: func.HttpRequest) -> func.HttpResponse:
 
 ## Documentation
 
-- [Installation](https://yeongseon.github.io/azure-functions-openapi-python/installation/)
-- [Usage Guide](https://yeongseon.github.io/azure-functions-openapi-python/usage/)
-- [API Reference](https://yeongseon.github.io/azure-functions-openapi-python/api/)
-- [CLI Guide](https://yeongseon.github.io/azure-functions-openapi-python/cli/)
+- [Installation](https://yeongseon.dev/azure-functions-python/openapi/installation/)
+- [Usage Guide](https://yeongseon.dev/azure-functions-python/openapi/usage/)
+- [API Reference](https://yeongseon.dev/azure-functions-python/openapi/api/)
+- [CLI Guide](https://yeongseon.dev/azure-functions-python/openapi/cli/)
 
 ## Ecosystem
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: Azure Functions OpenAPI
 site_description: OpenAPI (Swagger) integration for Python-based Azure Functions
 site_author: Yeongseon Choe
-site_url: https://yeongseon.github.io/azure-functions-openapi-python/
+site_url: https://yeongseon.dev/azure-functions-python/openapi/
 repo_url: https://github.com/yeongseon/azure-functions-openapi-python
 edit_uri: edit/main/docs/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,8 @@ dependencies = [
 ]
 
     [project.urls]
-    Homepage = "https://yeongseon.github.io/azure-functions-openapi-python/"
-    Documentation = "https://yeongseon.github.io/azure-functions-openapi-python/"
+    Homepage = "https://yeongseon.dev/azure-functions-python/openapi/"
+    Documentation = "https://yeongseon.dev/azure-functions-python/openapi/"
     Repository = "https://github.com/yeongseon/azure-functions-openapi-python"
 Issues = "https://github.com/yeongseon/azure-functions-openapi-python/issues"
 


### PR DESCRIPTION
## Summary
Consolidate the official documentation URL onto **https://yeongseon.dev/azure-functions-python/openapi/**.

- `pyproject.toml`: `Homepage` / `Documentation` → new URL. `Repository` / `Issues` unchanged.
- `mkdocs.yml`: `site_url` → new URL. `repo_url` / `edit_uri` unchanged (GitHub).
- README (en/ja/ko/zh-CN): docs link → new URL; stale `docs-gh--pages` badge label → `docs-yeongseon.dev`.
- `llms.txt`, `llms-full.txt`, `docs/llms.txt`, `.github/ISSUE_TEMPLATE/config.yml`: legacy `github.io` doc links → new URL (subpaths preserved).

## Verification
- All new `/openapi/` subpaths (installation, usage, api, cli, getting-started, configuration, route-prefix, architecture, faq, troubleshooting, deployment, changelog) return HTTP 200.
- `mkdocs build --strict` passes.
- No `yeongseon.github.io` references remain in tracked files.

## Notes
- The old GitHub Pages site is served via a redirect stub (canonical + 0s meta refresh + visible link + hash-preserving JS); this is not an HTTP 301.
- No PyPI release in this pass (metadata release handled in STEP 5).

Closes #438