### PR TITLE
docs: surface azure-functions-validation as optional runtime companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
 
 > **Pydantic v2 is optional.** `requests=` / `responses=` are the recommended path, but you can pass raw JSON Schema dicts instead (see below) if you'd rather not add a dependency.
 
+> **Want runtime validation too? (optional)** `@openapi` documents your Pydantic models — it does not parse or validate requests at runtime. If you also want automatic request parsing, consistent `400`/`422` error responses, and response-model enforcement, layer [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python)'s `@validate_http` on the **same** Pydantic models. It is an optional companion, not a dependency — this package works fully on its own. See the [validation README](https://github.com/yeongseon/azure-functions-validation-python#readme) for details.
+
 <details>
 <summary>Wire up the spec + Swagger UI endpoints (openapi.json / openapi.yaml / docs)</summary>
 


### PR DESCRIPTION
## Summary

- Adds a concise optional callout on the README's **main onramp** (right after the Quick Start example) telling readers they can layer `azure-functions-validation`'s `@validate_http` on the **same** Pydantic models for runtime parsing, consistent `400`/`422` errors, and response-model enforcement.
- Keeps the core Quick Start pydantic-only and self-contained; validation is framed as an **optional companion, not a dependency**. No install-list changes, no runtime/code changes.

Design-reviewed to preserve the deliberate loose coupling between the two packages (openapi = docs/spec, validation = runtime).

Closes #446