### PR TITLE
docs: link runtime-validation callout to a paired cookbook example

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ def http_trigger(req: func.HttpRequest) -> func.HttpResponse:
 
 > **Pydantic v2 is optional.** `requests=` / `responses=` are the recommended path, but you can pass raw JSON Schema dicts instead (see below) if you'd rather not add a dependency.
 
-> **Want runtime validation too? (optional)** `@openapi` documents your Pydantic models — it does not parse or validate requests at runtime. If you also want automatic request parsing, consistent `400`/`422` error responses, and response-model enforcement, layer [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python)'s `@validate_http` on the **same** Pydantic models. It is an optional companion, not a dependency — this package works fully on its own. See the [validation README](https://github.com/yeongseon/azure-functions-validation-python#readme) for details.
+> **Want runtime validation too? (optional)** `@openapi` documents your Pydantic models — it does not parse or validate requests at runtime. If you also want automatic request parsing, consistent `400`/`422` error responses, and response-model enforcement, layer [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python)'s `@validate_http` on the **same** Pydantic models. It is an optional companion, not a dependency — this package works fully on its own. See the [validation README](https://github.com/yeongseon/azure-functions-validation-python#readme) for details, or a full runnable example that pairs both on one resource: [Full Stack CRUD API](https://github.com/yeongseon/azure-functions-cookbook-python/tree/main/examples/apis-and-ingress/full_stack_crud_api).
 
 <details>
 <summary>Wire up the spec + Swagger UI endpoints (openapi.json / openapi.yaml / docs)</summary>


### PR DESCRIPTION
## Summary
- Extends the optional "Want runtime validation too?" README callout to link a concrete, runnable example that pairs `@openapi` + `@validate_http` on the same Pydantic models.
- Improves discoverability of the existing cookbook pairing example without changing any coupling (docs-only, no dependency).

## Details
The callout already explains that `azure-functions-validation` is an optional companion. This adds a direct link to the [Full Stack CRUD API](https://github.com/yeongseon/azure-functions-cookbook-python/tree/main/examples/apis-and-ingress/full_stack_crud_api) cookbook example so users can see both layered on one resource.

Closes #448