### PR TITLE
docs(ci): correct lib-tests description in publish-pypi workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,7 +19,9 @@ permissions:
 #   build -> lib-tests -> cookbook-smoke -> cookbook-host-smoke
 #         -> verify-azure-certification -> publish
 # Tiered runtime verification before any PyPI upload:
-#   * lib-tests            : the library's own unit suite (against the built wheel).
+#   * lib-tests            : the library's own unit suite, run from source via `hatch run test`
+#                            (NOT the built wheel; candidate-wheel coverage is provided by the
+#                            cookbook-smoke / cookbook-host-smoke tiers below).
 #   * cookbook-smoke       : downstream module-import checks (catches registration/import drift).
 #   * cookbook-host-smoke  : install the candidate wheel into the cookbook, then boot a real func
 #                            host + Azurite and run the cookbook HTTP e2e. This proves the candidate


### PR DESCRIPTION
## Summary
- `lib-tests` job runs `hatch run test` from source, not against the built wheel; correct the misleading header comment.
- Point candidate-wheel coverage to the cookbook-smoke / cookbook-host-smoke tiers.

Closes #454