### PR TITLE
docs(ci): correct lib-tests description in publish-pypi workflow

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -19,8 +19,11 @@ permissions:
 #   build -> lib-tests -> cookbook-smoke -> cookbook-host-smoke
 #         -> verify-azure-certification -> publish
 # Tiered runtime verification before any PyPI upload:
-#   * lib-tests            : the library's own unit suite (against the built wheel).
-#   * cookbook-smoke       : downstream module-import checks (catches registration/import drift).
+#   * lib-tests            : the library's own unit suite, run from a source checkout via
+#                            `hatch run test` (not against the built wheel; the candidate-wheel
+#                            tiers are cookbook-smoke and cookbook-host-smoke below).
+#   * cookbook-smoke       : install the candidate wheel into the cookbook, then run downstream
+#                            module-import checks (catches registration/import drift).
 #   * cookbook-host-smoke  : install the candidate wheel into the cookbook, then boot a real func
 #                            host + Azurite and run the cookbook HTTP e2e. This proves the candidate
 #                            installs cleanly and the Functions host starts with it present in the


### PR DESCRIPTION
## Context
Closes #454. The `lib-tests` tier header comment in `publish-pypi.yml` claimed the library unit suite runs "against the built wheel", but the job checks out source and runs `hatch run test` — no wheel involved. The candidate-wheel tiers are actually `cookbook-smoke` and `cookbook-host-smoke`.

## Acceptance Checklist
- [x] `lib-tests` comment states it runs from source via `hatch run test`, not the built wheel
- [x] Clarifies the candidate-wheel tiers are cookbook-smoke / cookbook-host-smoke

## Out of scope
- Changing the actual verification behavior (the tiering is intentional).