### PR TITLE
ci: allow refactor/ and test/ branch prefixes in branch-naming validation

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -149,6 +149,8 @@ jobs:
               /^feat\/.+$/,
               /^fix\/.+$/,
               /^docs\/.+$/,
+              /^refactor\/.+$/,
+              /^test\/.+$/,
               /^chore\/.+$/,
               /^ci\/.+$/,
               /^codex\/.+$/,
@@ -164,6 +166,8 @@ jobs:
                 - feat/<description>
                 - fix/<description>
                 - docs/<description>
+                - refactor/<description>
+                - test/<description>
                 - chore/<description>
                 - ci/<description>
                 - codex/<description>
@@ -188,5 +192,5 @@ jobs:
               owner,
               repo,
               issue_number: prNumber,
-              body: 'Warning: branch naming validation failed\n\nYour branch name `' + branchName + '` does not follow our naming conventions.\n\nPlease rename your branch to follow one of these patterns:\n- `feat/<description>` for new features\n- `fix/<description>` for bug fixes\n- `docs/<description>` for documentation changes\n- `chore/<description>` for maintenance tasks\n- `ci/<description>` for CI/CD changes\n- `codex/<description>` for Codex-generated changes\n\nTo rename your branch:\n1. `git checkout ' + branchName + '`\n2. `git branch -m feat/your-new-branch-name`\n3. `git push origin --delete ' + branchName + '`\n4. `git push origin feat/your-new-branch-name`\n\nOnce you have renamed the branch, please update the PR head branch.'
+              body: 'Warning: branch naming validation failed\n\nYour branch name `' + branchName + '` does not follow our naming conventions.\n\nPlease rename your branch to follow one of these patterns:\n- `feat/<description>` for new features\n- `fix/<description>` for bug fixes\n- `docs/<description>` for documentation changes\n- `refactor/<description>` for refactoring\n- `test/<description>` for test changes\n- `chore/<description>` for maintenance tasks\n- `ci/<description>` for CI/CD changes\n- `codex/<description>` for Codex-generated changes\n\nTo rename your branch:\n1. `git checkout ' + branchName + '`\n2. `git branch -m feat/your-new-branch-name`\n3. `git push origin --delete ' + branchName + '`\n4. `git push origin feat/your-new-branch-name`\n\nOnce you have renamed the branch, please update the PR head branch.'
             });


### PR DESCRIPTION
## Context
Closes #443. AGENTS.md lists `refactor` and `test` as valid Conventional-Commit types, but the branch-naming validation in `stale.yml` rejected `refactor/*` and `test/*` branches. Added them to `validPatterns`, the `setFailed` conventions list, and the warn comment body.

## Acceptance Checklist
- [x] `refactor/<description>` accepted
- [x] `test/<description>` accepted
- [x] Failure message and warn comment list both new prefixes