### PR TITLE
feat(responses): ergonomics + robustness fixes for unified responses= (list shorthand, string keys, inner Mapping, HTTP phrases)

### DIFF
--- a/docs/migration/unified-params.md
+++ b/docs/migration/unified-params.md
@@ -130,6 +130,20 @@ model (expanded to a JSON body of that schema) *or* a raw Response Object dict:
 )
 ```
 
+### Array response bodies → `responses={200: list[Model]}`
+
+A per-status value may also be a generic collection alias such as
+`list[Model]`, resolved to an array schema in the generated spec — no wrapper
+model required:
+
+```python
+@openapi(
+    summary="List orders",
+    method="get",
+    responses={200: list[OrderResponse]},   # → array of OrderResponse
+)
+```
+
 ### Optional request bodies are unchanged
 
 `request_body_required=` is orthogonal to this migration — keep using it

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from http import HTTPStatus
 import logging
-from typing import Any, Callable, TypeGuard, TypeVar, cast
+from typing import Any, Callable, TypeGuard, TypeVar, cast, get_origin
 import warnings
 
 from pydantic import BaseModel
@@ -115,11 +116,32 @@ def _is_pydantic_model(value: Any) -> TypeGuard[type[BaseModel]]:
 
 def _default_response_description(status: int) -> str:
     """Default OpenAPI response description for a bare per-status model shorthand."""
-    return "Successful Response" if 200 <= status < 300 else "Response"
+    try:
+        return HTTPStatus(status).phrase
+    except ValueError:
+        return "Successful Response" if 200 <= status < 300 else "Response"
+
+
+def _coerce_status_key(status: Any, func_name: str) -> int:
+    """Coerce a ``responses`` status key to an int, accepting numeric strings."""
+    if isinstance(status, bool):
+        raise ValueError(
+            f"Invalid 'responses' status key {status!r} in function '{func_name}': "
+            f"status keys must be integers (e.g. 200) or numeric strings (e.g. '200')."
+        )
+    if isinstance(status, int):
+        return status
+    if isinstance(status, str) and status.isdigit():
+        return int(status)
+    raise ValueError(
+        f"Invalid 'responses' status key {status!r} in function '{func_name}': "
+        f"status keys must be integers (e.g. 200) or numeric strings (e.g. '200'). "
+        f"To describe a full Response Object, use the dict form as the value."
+    )
 
 
 def _normalize_unified_responses(
-    responses: Mapping[int, Any], func_name: str
+    responses: Mapping[Any, Any], func_name: str
 ) -> dict[int, dict[str, Any]]:
     """Normalize a unified ``responses=`` mapping into OpenAPI Response Objects.
 
@@ -129,26 +151,32 @@ def _normalize_unified_responses(
       schema, expanded to ``{"description": ..., "content":
       {"application/json": {"schema": Model}}}`` (the model class is resolved to
       a schema at spec-generation time, where the ``components`` registry lives), or
-    * an OpenAPI Response Object dict (unchanged; a Pydantic model may also appear
+    * a generic collection alias such as ``list[Model]`` — the same bare-shorthand
+      treatment, resolved to an array schema at spec-generation time, or
+    * an OpenAPI Response Object mapping (unchanged; a Pydantic model may also appear
       in its ``content.<media>.schema`` position and is resolved the same way).
 
-    Raises ``ValueError`` for any other value type so misuse fails fast at
-    decoration time rather than silently producing an invalid spec.
+    Status keys may be ints (``200``) or numeric strings (``"200"``); any other
+    key type raises ``ValueError``. Values of any other type also raise
+    ``ValueError`` so misuse fails fast at decoration time rather than silently
+    producing an invalid spec.
     """
     normalized: dict[int, dict[str, Any]] = {}
-    for status, value in responses.items():
-        if _is_pydantic_model(value):
+    for raw_status, value in responses.items():
+        status = _coerce_status_key(raw_status, func_name)
+        if _is_pydantic_model(value) or get_origin(value) is not None:
             normalized[status] = {
                 "description": _default_response_description(status),
                 "content": {"application/json": {"schema": value}},
             }
-        elif isinstance(value, dict):
-            normalized[status] = value
+        elif isinstance(value, Mapping):
+            normalized[status] = dict(value)
         else:
             raise ValueError(
                 f"Invalid 'responses' entry for status {status} in function "
-                f"'{func_name}': each value must be a Pydantic BaseModel subclass "
-                f"or an OpenAPI Response Object dict, got {type(value).__name__}."
+                f"'{func_name}': each value must be a Pydantic BaseModel subclass, "
+                f"a generic collection alias (e.g. list[Model]), or an OpenAPI "
+                f"Response Object mapping, got {type(value).__name__}."
             )
     return normalized
 
@@ -172,7 +200,7 @@ def openapi(
     request_body_required: bool = True,
     response_model: type[BaseModel] | None = None,
     response: dict[int, dict[str, Any]] | None = None,
-    responses: type[BaseModel] | Mapping[int, type[BaseModel] | dict[str, Any]] | None = None,
+    responses: type[BaseModel] | Mapping[int, Any] | None = None,
 ) -> Callable[[F], F]:
     """
     Decorator that attaches OpenAPI metadata to an Azure Functions handler.

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 import json
 import logging
 import re
-from typing import Any
+from typing import Any, get_origin
 
 from pydantic import BaseModel
 import yaml
@@ -22,7 +22,7 @@ from azure_functions_openapi.routes import (
     apply_route_prefix,
     normalize_route_prefix,
 )
-from azure_functions_openapi.utils import hoist_inline_defs, model_to_schema
+from azure_functions_openapi.utils import hoist_inline_defs, model_to_schema, type_to_schema
 
 logger = logging.getLogger(__name__)
 
@@ -353,6 +353,12 @@ def generate_openapi_spec(
                                     # resolve the model to a $ref here, where the
                                     # components registry is available.
                                     resolved_schema = model_to_schema(raw_schema, components)
+                                elif get_origin(raw_schema) is not None:
+                                    # Generic collection alias shorthand (#450),
+                                    # e.g. list[Model]: resolve via TypeAdapter to a
+                                    # valid array schema; hoist_inline_defs expects a
+                                    # dict JSON-Schema and would break on a raw alias.
+                                    resolved_schema = type_to_schema(raw_schema, components)
                                 else:
                                     resolved_schema = hoist_inline_defs(
                                         raw_schema,

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -572,14 +572,14 @@ def test_openapi_responses_dict_accepts_per_status_model() -> None:
     assert entry["response_model"] is None
     resp = entry["response"]
     # 202 expanded to a Response Object carrying the model in schema position.
-    assert resp[202]["description"] == "Successful Response"
+    assert resp[202]["description"] == "Accepted"
     assert resp[202]["content"]["application/json"]["schema"] is _UnifiedResponseModel
     # Non-model dict entries pass through unchanged.
     assert resp[400] == {"description": "Bad request"}
 
 
 def test_openapi_responses_dict_non_2xx_model_default_description() -> None:
-    """A bare model on a non-2xx status defaults to a generic 'Response' description."""
+    """A bare model on a standard status defaults to its HTTP reason phrase."""
     _clear_registry()
 
     @openapi(summary="Error body", responses={409: _UnifiedResponseModel})
@@ -587,7 +587,7 @@ def test_openapi_responses_dict_non_2xx_model_default_description() -> None:
         pass
 
     resp = get_openapi_registry()["non_2xx_model_func"]["response"]
-    assert resp[409]["description"] == "Response"
+    assert resp[409]["description"] == "Conflict"
     assert resp[409]["content"]["application/json"]["schema"] is _UnifiedResponseModel
 
 
@@ -651,7 +651,7 @@ def test_openapi_responses_dict_rejects_invalid_value() -> None:
 
         @openapi(
             summary="Invalid responses entry",
-            responses={200: "bad"},  # type: ignore[dict-item]
+            responses={200: "bad"},
         )
         def invalid_responses_func() -> None:
             pass
@@ -684,4 +684,75 @@ def test_openapi_responses_accepts_non_dict_mapping() -> None:
     responses = spec["paths"]["/api/items"]["post"]["responses"]
     schema = responses["202"]["content"]["application/json"]["schema"]
     assert schema["$ref"].endswith("/_UnifiedResponseModel")
+    assert responses["400"]["description"] == "Bad request"
+
+
+def test_openapi_responses_accepts_generic_alias_shorthand() -> None:
+    """A generic alias such as list[Model] is accepted and resolves to an array schema."""
+    _clear_registry()
+
+    @openapi(
+        summary="List body shorthand",
+        route="/api/items",
+        method="get",
+        responses={200: list[_UnifiedResponseModel]},
+    )
+    def list_shorthand_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="")
+    schema = spec["paths"]["/api/items"]["get"]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+    assert schema["type"] == "array"
+    assert schema["items"]["$ref"].endswith("/_UnifiedResponseModel")
+    assert "_UnifiedResponseModel" in spec["components"]["schemas"]
+
+
+def test_openapi_responses_normalizes_numeric_string_key() -> None:
+    """A numeric-string status key (e.g. '200') is normalized to an int."""
+    _clear_registry()
+
+    @openapi(summary="String key", responses={"200": _UnifiedResponseModel})  # type: ignore[dict-item]
+    def string_key_func() -> None:
+        pass
+
+    resp = get_openapi_registry()["string_key_func"]["response"]
+    assert 200 in resp
+    assert resp[200]["description"] == "OK"
+
+
+def test_openapi_responses_rejects_non_numeric_key() -> None:
+    """A non-int, non-numeric-string status key fails fast with a clear ValueError."""
+    _clear_registry()
+
+    with pytest.raises(ValueError) as exc_info:
+
+        @openapi(
+            summary="Bad key",
+            responses={"twohundred": _UnifiedResponseModel},  # type: ignore[dict-item]
+        )
+        def bad_key_func() -> None:
+            pass
+
+    assert "status key" in str(exc_info.value)
+
+
+def test_openapi_responses_accepts_inner_mapping_response_object() -> None:
+    """A non-dict Mapping (MappingProxyType) used as an inner Response Object value is accepted."""
+    from types import MappingProxyType
+
+    _clear_registry()
+
+    @openapi(
+        summary="Inner mapping response object",
+        route="/api/items",
+        method="post",
+        responses={400: MappingProxyType({"description": "Bad request"})},
+    )
+    def inner_mapping_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="")
+    responses = spec["paths"]["/api/items"]["post"]["responses"]
     assert responses["400"]["description"] == "Bad request"


### PR DESCRIPTION
## Context
Closes #450. Four ergonomics/robustness gaps in the unified `responses=` contract, targeting the next patch. First-class `"default"` key support remains out of scope (tracked by #451).

## Fixes
1. **Generic-collection shorthand** `responses={200: list[Item]}` now accepted at decoration and resolved to a valid array schema (`decorator.py` accepts generic aliases as bare shorthand; `spec.py` routes `get_origin(raw_schema) is not None` through `type_to_schema`).
2. **Numeric-string keys** `{"200": Model}` normalized to int `200`; other non-int keys raise a clear, actionable `ValueError` instead of a `TypeError`.
3. **Inner Response Object value** now accepts any `Mapping` (e.g. `MappingProxyType`), matching the earlier outer-container widening.
4. **Default descriptions** use `http.HTTPStatus(status).phrase` (`404 -> "Not Found"`), falling back to the previous strings for unknown/non-standard codes.

## Acceptance Checklist
- [x] `responses={200: list[Item]}` accepted and resolved to an array schema (decorator.py + spec.py)
- [x] `responses={"200": Model}` normalized to int; non-numeric non-int keys raise a clear `ValueError`
- [x] Inner Response Object value accepts any `Mapping`; regression test added for a `MappingProxyType` inner value
- [x] Standard status codes get their HTTP reason phrase; unknown codes fall back to existing strings
- [x] `make check-all` green; coverage 95.40% (>= 95%)
- [x] Migration docs updated with the `list[Model]` shorthand

## Out of scope
- First-class OpenAPI `"default"` response key support (#451).