### PR TITLE
feat(responses): first-class OpenAPI "default" response key in unified responses=

### DIFF
--- a/docs/migration/unified-params.md
+++ b/docs/migration/unified-params.md
@@ -144,6 +144,25 @@ model required:
 )
 ```
 
+### Fallback error responses → `responses={..., "default": ErrorModel}`
+
+The OpenAPI `"default"` response key documents the response for any status code
+not otherwise listed — ideal for a shared error model. Pass it alongside your
+concrete statuses; a bare model is expanded to a Response Object just like a
+numeric key:
+
+```python
+@openapi(
+    summary="Get order",
+    method="get",
+    responses={
+        200: OrderResponse,
+        404: ErrorResponse,
+        "default": ErrorResponse,   # any other status → ErrorResponse
+    },
+)
+```
+
 ### Optional request bodies are unchanged
 
 `request_body_required=` is orthogonal to this migration — keep using it

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from http import HTTPStatus
 import logging
-from typing import Any, Callable, TypeGuard, TypeVar, cast, get_origin
+from typing import Any, Callable, Literal, TypeGuard, TypeVar, cast, get_origin
 import warnings
 
 from pydantic import BaseModel
@@ -114,20 +114,25 @@ def _is_pydantic_model(value: Any) -> TypeGuard[type[BaseModel]]:
     return isinstance(value, type) and issubclass(value, BaseModel)
 
 
-def _default_response_description(status: int) -> str:
+def _default_response_description(status: int | Literal["default"]) -> str:
     """Default OpenAPI response description for a bare per-status model shorthand."""
+    if status == "default":
+        return "Response"
     try:
         return HTTPStatus(status).phrase
     except ValueError:
         return "Successful Response" if 200 <= status < 300 else "Response"
 
 
-def _coerce_status_key(status: Any, func_name: str) -> int:
-    """Coerce a ``responses`` status key to an int, accepting numeric strings."""
+def _coerce_status_key(status: Any, func_name: str) -> int | Literal["default"]:
+    """Coerce a ``responses`` status key to an int or the literal ``"default"``."""
+    if status == "default":
+        return "default"
     if isinstance(status, bool):
         raise ValueError(
             f"Invalid 'responses' status key {status!r} in function '{func_name}': "
-            f"status keys must be integers (e.g. 200) or numeric strings (e.g. '200')."
+            f"status keys must be integers (e.g. 200), numeric strings (e.g. '200'), "
+            f"or the literal 'default'."
         )
     if isinstance(status, int):
         return status
@@ -135,14 +140,15 @@ def _coerce_status_key(status: Any, func_name: str) -> int:
         return int(status)
     raise ValueError(
         f"Invalid 'responses' status key {status!r} in function '{func_name}': "
-        f"status keys must be integers (e.g. 200) or numeric strings (e.g. '200'). "
-        f"To describe a full Response Object, use the dict form as the value."
+        f"status keys must be integers (e.g. 200), numeric strings (e.g. '200'), "
+        f"or the literal 'default'. To describe a full Response Object, use the "
+        f"dict form as the value."
     )
 
 
 def _normalize_unified_responses(
     responses: Mapping[Any, Any], func_name: str
-) -> dict[int, dict[str, Any]]:
+) -> dict[int | str, dict[str, Any]]:
     """Normalize a unified ``responses=`` mapping into OpenAPI Response Objects.
 
     Each value may be either:
@@ -156,12 +162,13 @@ def _normalize_unified_responses(
     * an OpenAPI Response Object mapping (unchanged; a Pydantic model may also appear
       in its ``content.<media>.schema`` position and is resolved the same way).
 
-    Status keys may be ints (``200``) or numeric strings (``"200"``); any other
-    key type raises ``ValueError``. Values of any other type also raise
+    Status keys may be ints (``200``), numeric strings (``"200"``), or the literal
+    OpenAPI ``"default"`` key (the fallback response for any undocumented status);
+    any other key raises ``ValueError``. Values of any other type also raise
     ``ValueError`` so misuse fails fast at decoration time rather than silently
     producing an invalid spec.
     """
-    normalized: dict[int, dict[str, Any]] = {}
+    normalized: dict[int | str, dict[str, Any]] = {}
     for raw_status, value in responses.items():
         status = _coerce_status_key(raw_status, func_name)
         if _is_pydantic_model(value) or get_origin(value) is not None:
@@ -200,7 +207,7 @@ def openapi(
     request_body_required: bool = True,
     response_model: type[BaseModel] | None = None,
     response: dict[int, dict[str, Any]] | None = None,
-    responses: type[BaseModel] | Mapping[int, Any] | None = None,
+    responses: type[BaseModel] | Mapping[int | Literal["default"], Any] | None = None,
 ) -> Callable[[F], F]:
     """
     Decorator that attaches OpenAPI metadata to an Azure Functions handler.
@@ -375,7 +382,9 @@ def openapi(
             resolved_request_model = request_model
             resolved_request_body = request_body
             resolved_response_model = response_model
-            resolved_response = response
+            resolved_response: dict[int | str, dict[str, Any]] | None = cast(
+                "dict[int | str, dict[str, Any]] | None", response
+            )
 
             if requests is not None:
                 if request_model is not None or request_body is not None:

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -52,9 +52,11 @@ def _ensure_default_response(
 ) -> None:
     """Ensure *responses* contains at least one entry.
 
-    If *responses* is non-empty this function is a no-op.  When it is empty
-    a generic ``200 Successful Response`` entry is added using *schema* when
-    provided, or a plain ``{type: object}`` schema otherwise.
+    If *responses* already contains a concrete (non-``"default"``) entry this
+    function is a no-op.  When it is empty — or contains only the OpenAPI
+    ``"default"`` fallback entry — a generic ``200 Successful Response`` entry is
+    added using *schema* when provided, or a plain ``{type: object}`` schema
+    otherwise, so every operation advertises at least one concrete status.
 
     Parameters:
         responses: The responses dict being built for the current operation.
@@ -63,7 +65,7 @@ def _ensure_default_response(
             ``content.application/json.schema``.  Defaults to
             ``{"type": "object"}``.
     """
-    if responses:
+    if any(status != "default" for status in responses):
         return
     resolved_schema: dict[str, Any] = schema if schema is not None else {"type": "object"}
     responses["200"] = {
@@ -375,8 +377,9 @@ def generate_openapi_spec(
                         model_schema = model_to_schema(meta["response_model"], components)
                         target_status = "200"
                         for status_key in responses:
-                            if str(status_key).startswith("2"):
-                                target_status = str(status_key)
+                            key = str(status_key)
+                            if key.isdigit() and 200 <= int(key) < 300:
+                                target_status = key
                                 break
 
                         if target_status not in responses:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -287,7 +287,7 @@ def test_openapi_responses_accepts_model() -> None:
 def test_openapi_responses_accepts_dict() -> None:
     manual_responses = {201: {"description": "Created"}}
 
-    @openapi(summary="Unified response dict", responses=manual_responses)
+    @openapi(summary="Unified response dict", responses={201: {"description": "Created"}})
     def unified_response_dict_func() -> None:
         pass
 
@@ -756,3 +756,106 @@ def test_openapi_responses_accepts_inner_mapping_response_object() -> None:
     spec = generate_openapi_spec(route_prefix="")
     responses = spec["paths"]["/api/items"]["post"]["responses"]
     assert responses["400"]["description"] == "Bad request"
+
+
+def test_openapi_responses_default_key_model_shorthand() -> None:
+    """A `"default"` key with a bare model produces a valid default Response Object."""
+    _clear_registry()
+
+    @openapi(
+        summary="Default error fallback",
+        route="/api/items",
+        method="get",
+        responses={200: _UnifiedResponseModel, "default": _UnifiedResponseModel},
+    )
+    def default_shorthand_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="")
+    responses = spec["paths"]["/api/items"]["get"]["responses"]
+    assert "default" in responses
+    assert responses["default"]["description"] == "Response"
+    assert responses["default"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/_UnifiedResponseModel"
+    )
+    assert responses["200"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/_UnifiedResponseModel"
+    )
+
+
+def test_openapi_responses_default_key_response_object_dict() -> None:
+    """A `"default"` key with a Response Object dict passes through unchanged."""
+    _clear_registry()
+
+    @openapi(
+        summary="Default fallback dict",
+        route="/api/items",
+        method="get",
+        responses={404: {"description": "Not there"}, "default": {"description": "Fallback"}},
+    )
+    def default_dict_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="")
+    responses = spec["paths"]["/api/items"]["get"]["responses"]
+    assert responses["default"]["description"] == "Fallback"
+    assert responses["404"]["description"] == "Not there"
+
+
+def test_openapi_responses_default_only_gets_explicit_200() -> None:
+    """A mapping containing only `"default"` still gets an explicit 200 success entry."""
+    _clear_registry()
+
+    @openapi(
+        summary="Only default",
+        route="/api/items",
+        method="get",
+        responses={"default": {"description": "Anything"}},
+    )
+    def default_only_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="")
+    responses = spec["paths"]["/api/items"]["get"]["responses"]
+    assert "200" in responses
+    assert responses["default"]["description"] == "Anything"
+
+
+def test_openapi_responses_default_with_response_model_not_targeted() -> None:
+    """`response_model` never selects `"default"` as its 2xx target."""
+    _clear_registry()
+
+    @openapi(
+        summary="Response model plus default",
+        route="/api/items",
+        method="get",
+        response_model=_UnifiedResponseModel,
+        response={"default": {"description": "Fallback"}},  # type: ignore[dict-item]
+    )
+    def model_plus_default_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="")
+    responses = spec["paths"]["/api/items"]["get"]["responses"]
+    assert responses["200"]["content"]["application/json"]["schema"]["$ref"].endswith(
+        "/_UnifiedResponseModel"
+    )
+    assert "content" not in responses["default"]
+
+
+def test_openapi_responses_default_key_preserved_in_3_0() -> None:
+    """The `"default"` key survives OpenAPI 3.0 downconversion unchanged."""
+    _clear_registry()
+
+    @openapi(
+        summary="Default under 3.0",
+        route="/api/items",
+        method="get",
+        responses={200: {"description": "OK"}, "default": {"description": "Fallback"}},
+    )
+    def default_3_0_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="", openapi_version="3.0.0")
+    responses = spec["paths"]["/api/items"]["get"]["responses"]
+    assert responses["default"]["description"] == "Fallback"


### PR DESCRIPTION
## Context
Closes #451. Promotes the OpenAPI `"default"` response key (the fallback for any undocumented status) from "rejected" to first-class in unified `responses=`. Builds on #450, whose non-int-key `ValueError` is relaxed here to admit `"default"`. Design per the Oracle review recorded on the issue.

## Design
- **Key contract:** `"default"` is now a valid normalized key alongside int status codes; public type widened to `Mapping[int | Literal["default"], ...]` (numeric strings still tolerated at runtime).
- **Shorthand:** `"default": ErrorModel` expands to a normal Response Object; default description `"Response"`. `_default_response_description` handles `"default"` explicitly.
- **`response_model` 2xx-target loop:** now guarded to numeric status codes (`key.isdigit() and 200 <= int(key) < 300`) so `"default"` can never be picked.
- **`_ensure_default_response`:** a mapping containing only `"default"` still receives an explicit `200`.
- **3.0<->3.1 conversion:** `"default"` preserved unchanged.
- **Rejected:** a dedicated `default_response=` kwarg (overloading the mapping is the right call).

## Acceptance Checklist
- [x] `responses={404: ErrorModel, "default": ErrorModel}` produces a valid spec with a `default` entry
- [x] Public type contract widened to `int | Literal["default"]`; numeric strings still tolerated
- [x] `response_model` 2xx-target selection guarded to numeric codes (never targets `"default"`)
- [x] `_default_response_description` handles `"default"`
- [x] `"default"` preserved through 3.0<->3.1 conversion
- [x] Tests: `"default"` shorthand model, Response Object dict, coexistence with numeric keys, `response_model` alongside `"default"`, default-only → 200, 3.0 preservation
- [x] #450's non-int-key `ValueError` relaxed to admit `"default"`
- [x] Docs show the `"default"` error-fallback pattern; `make check-all` green; coverage 95.42%