### PR TITLE
ci(docs): add screenshot provenance manifest + staleness checker (#408)

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -135,6 +135,46 @@ jobs:
           E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
           E2E_EXPECTED_VERSION: ${{ env.RESOLVED_VERSION }}
 
+      - name: Capture Swagger UI screenshots
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        env:
+          E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+          CAPTURE_VERSION: ${{ env.RESOLVED_VERSION }}
+        run: |
+          set -euo pipefail
+          npm install --no-save playwright@1.54.1
+          npx playwright install --with-deps chromium
+          SHA=$(git rev-parse HEAD)
+          OUT=screenshots
+          mkdir -p "$OUT"
+          npx playwright screenshot --browser=chromium --full-page --wait-for-timeout=3000 \
+            "$E2E_BASE_URL/api/docs" "$OUT/api_docs.png"
+          npx playwright screenshot --browser=chromium --wait-for-timeout=1000 \
+            "$E2E_BASE_URL/api/openapi.json" "$OUT/api_openapi_json.png"
+          SRC_HASH=$(python -c "import hashlib; rel='examples/e2e_app/function_app.py'; h=hashlib.sha256(); h.update(rel.encode()+b'\0'); h.update(open(rel,'rb').read()+b'\0'); print('sha256:'+h.hexdigest())")
+          cat > "$OUT/metadata.json" <<EOF
+          {
+            "package_version": "${CAPTURE_VERSION}",
+            "git_sha": "${SHA}",
+            "captured_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "method": "playwright",
+            "base_url": "${E2E_BASE_URL}",
+            "endpoints": ["/api/docs", "/api/openapi.json"],
+            "source_inputs": ["examples/e2e_app/function_app.py"],
+            "source_hash": "${SRC_HASH}"
+          }
+          EOF
+          cat "$OUT/metadata.json"
+
+      - name: Upload screenshots
+        if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: swagger-screenshots-${{ github.run_id }}-${{ github.run_attempt }}
+          path: screenshots/
+          if-no-files-found: error
+          retention-days: 30
+
       - name: Record certification
         run: |
           SHA=$(git rev-parse HEAD)

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,35 @@
+name: screenshots
+
+# Validates docs/assets/screenshots.yml on pull requests: fails on structural
+# problems (invalid manifest, missing image, missing source input, duplicate id)
+# and warns (without failing) when declared source inputs changed but the
+# manifest was not refreshed — that drift is expected to be reviewed by a human
+# who then re-captures the screenshot via the e2e-azure workflow.
+on:
+  pull_request:
+    paths:
+      - docs/assets/screenshots.yml
+      - scripts/check_screenshots.py
+      - examples/**
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check screenshot manifest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Install checker dependencies
+        run: pip install pyyaml
+
+      - name: Run staleness checker
+        run: python scripts/check_screenshots.py

--- a/docs/assets/screenshots.yml
+++ b/docs/assets/screenshots.yml
@@ -1,0 +1,119 @@
+# Screenshot provenance manifest.
+#
+# Records where each documentation screenshot came from so drift can be
+# detected automatically. `source.hash` is a combined SHA-256 over the
+# `source.inputs` files (see scripts/check_screenshots.py); when those inputs
+# change, the recomputed hash no longer matches and the screenshot is flagged
+# as potentially stale and in need of re-capture.
+#
+# `captured` fields are provenance only — they are never used for staleness
+# decisions (that is what `source.hash` is for). The values below were seeded
+# when the manifest was introduced; existing screenshots predate the automated
+# Playwright capture pipeline and are therefore recorded as `method: manual`.
+#
+# schema_version 1 entry shape:
+#   id:        stable unique identifier (kebab/underscore)
+#   image:     repo-relative path to the PNG
+#   captured:
+#     package_version: version the screenshot was captured against
+#     git_sha:         commit the screenshot was captured against
+#     date:            ISO-8601 capture (or seed) date
+#     method:          "manual" | "playwright"
+#   source:
+#     inputs: [repo-relative files whose change invalidates the screenshot]
+#     hash:   combined sha256 over inputs (recomputed by the checker)
+#   output:  (optional)
+#     hash:  sha256 of the image bytes, for tamper/regeneration tracking
+schema_version: 1
+screenshots:
+  - id: deployment_report_jobs_openapi_json
+    image: docs/assets/deployment_report_jobs_openapi_json.png
+    captured:
+      package_version: "0.21.2"
+      git_sha: "8310039aa73e91d45cc8389b356428071225eb5b"
+      date: "2026-08-15"
+      method: manual
+    source:
+      inputs:
+        - examples/report_jobs/function_app.py
+      hash: "sha256:955d8afaa73b5d5c252609b2c6395d06169a28126bf5456d50a7c0babff93fb5"
+    output:
+      hash: "sha256:aec622c63df0425f60a47b36551fc79853df805ff77732594340058119d78b72"
+  - id: deployment_report_jobs_swagger_ui
+    image: docs/assets/deployment_report_jobs_swagger_ui.png
+    captured:
+      package_version: "0.21.2"
+      git_sha: "8310039aa73e91d45cc8389b356428071225eb5b"
+      date: "2026-08-15"
+      method: manual
+    source:
+      inputs:
+        - examples/report_jobs/function_app.py
+      hash: "sha256:955d8afaa73b5d5c252609b2c6395d06169a28126bf5456d50a7c0babff93fb5"
+    output:
+      hash: "sha256:579ee7357acd04644926b7861e7129775553df4ffb1b67b9149b46384d0b4296"
+  - id: notification_request_swagger_ui
+    image: docs/assets/notification_request_swagger_ui.png
+    captured:
+      package_version: "0.21.2"
+      git_sha: "8310039aa73e91d45cc8389b356428071225eb5b"
+      date: "2026-08-15"
+      method: manual
+    source:
+      inputs:
+        - examples/notification_request/function_app.py
+      hash: "sha256:868ab2f640823ff4e561982f9a0bd561bb396e614ca6dd5b856fc788ce58b8aa"
+    output:
+      hash: "sha256:f8ef5429b57db07e9c222de5d978c114f76f345c84d19774ba2b8e74a016c522"
+  - id: partner_import_bridge_swagger_ui
+    image: docs/assets/partner_import_bridge_swagger_ui.png
+    captured:
+      package_version: "0.21.2"
+      git_sha: "8310039aa73e91d45cc8389b356428071225eb5b"
+      date: "2026-08-15"
+      method: manual
+    source:
+      inputs:
+        - examples/partner_import_bridge/function_app.py
+      hash: "sha256:c8319c9917e1018b10e925c98a0943789cda4ba2bd577c4d1387388287aa10cf"
+    output:
+      hash: "sha256:9f9f204a5e5028e875e4446fdd738b83e04de7a7cb17b880d69a9ab4122d0986"
+  - id: webhook_receiver_openapi_spec_preview
+    image: docs/assets/webhook_receiver_openapi_spec_preview.png
+    captured:
+      package_version: "0.21.2"
+      git_sha: "8310039aa73e91d45cc8389b356428071225eb5b"
+      date: "2026-08-15"
+      method: manual
+    source:
+      inputs:
+        - examples/webhook_receiver/function_app.py
+      hash: "sha256:3795093c98af075f4add7a137745d3ab9755bde1c6be2373dff8d691019b28ff"
+    output:
+      hash: "sha256:ecb270e3c9dd74fc55c99b67776e2c5b48e65f6be019cb6265715cd54cd03900"
+  - id: webhook_receiver_openapi_swagger_ui_preview
+    image: docs/assets/webhook_receiver_openapi_swagger_ui_preview.png
+    captured:
+      package_version: "0.21.2"
+      git_sha: "8310039aa73e91d45cc8389b356428071225eb5b"
+      date: "2026-08-15"
+      method: manual
+    source:
+      inputs:
+        - examples/webhook_receiver/function_app.py
+      hash: "sha256:3795093c98af075f4add7a137745d3ab9755bde1c6be2373dff8d691019b28ff"
+    output:
+      hash: "sha256:42658bfeeffab7caa4815a4d1588361f39ae4975434a4214ef5af5d3a281a0c8"
+  - id: webhook_receiver_swagger_ui
+    image: docs/assets/webhook_receiver_swagger_ui.png
+    captured:
+      package_version: "0.21.2"
+      git_sha: "8310039aa73e91d45cc8389b356428071225eb5b"
+      date: "2026-08-15"
+      method: manual
+    source:
+      inputs:
+        - examples/webhook_receiver/function_app.py
+      hash: "sha256:3795093c98af075f4add7a137745d3ab9755bde1c6be2373dff8d691019b28ff"
+    output:
+      hash: "sha256:5bdb7901a647ce5e15fc9ad439742160c04a5c46f655c627106b5e2856a644f0"

--- a/scripts/check_screenshots.py
+++ b/scripts/check_screenshots.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Staleness checker for documentation screenshots.
+
+Reads ``docs/assets/screenshots.yml`` and verifies that every screenshot is
+well-formed and still matches the source it was captured from. It recomputes a
+combined SHA-256 over each entry's ``source.inputs`` and compares it against the
+declared ``source.hash``.
+
+Failure modes are split by severity so this can gate PRs without blocking on
+expected, human-reviewed drift:
+
+Hard failures (exit 1):
+  * manifest missing / unreadable / not ``schema_version: 1``
+  * missing required keys, duplicate ``id``, malformed entry
+  * declared ``image`` file does not exist
+  * declared ``source.inputs`` file does not exist
+
+Soft warnings (exit 0, unless ``--strict``):
+  * recomputed source hash differs from the declared hash — the inputs changed
+    but the manifest (and likely the screenshot) was not refreshed
+
+``--update`` rewrites ``source.hash`` / ``output.hash`` in place after a
+re-capture, so maintainers do not compute hashes by hand.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+import sys
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "docs" / "assets" / "screenshots.yml"
+
+_REQUIRED_CAPTURED = ("package_version", "git_sha", "date", "method")
+
+
+def _combined_source_hash(inputs: list[str]) -> str:
+    digest = hashlib.sha256()
+    for rel in sorted(inputs):
+        digest.update(rel.encode() + b"\0")
+        digest.update((REPO_ROOT / rel).read_bytes() + b"\0")
+    return "sha256:" + digest.hexdigest()
+
+
+def _image_hash(rel: str) -> str:
+    return "sha256:" + hashlib.sha256((REPO_ROOT / rel).read_bytes()).hexdigest()
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("manifest root must be a mapping")
+    if data.get("schema_version") != 1:
+        raise ValueError(f"unsupported schema_version: {data.get('schema_version')!r} (expected 1)")
+    screenshots = data.get("screenshots")
+    if not isinstance(screenshots, list) or not screenshots:
+        raise ValueError("manifest 'screenshots' must be a non-empty list")
+    return data
+
+
+def _validate_entry(entry: Any, index: int) -> tuple[list[str], str, list[str]]:
+    """Return (hard_errors, entry_id, source_inputs) for one entry."""
+    errors: list[str] = []
+    if not isinstance(entry, dict):
+        return [f"screenshots[{index}] must be a mapping"], "", []
+
+    entry_id = entry.get("id")
+    if not isinstance(entry_id, str) or not entry_id:
+        errors.append(f"screenshots[{index}] missing string 'id'")
+        entry_id = ""
+
+    image = entry.get("image")
+    if not isinstance(image, str) or not image:
+        errors.append(f"{entry_id or index}: missing string 'image'")
+    elif not (REPO_ROOT / image).is_file():
+        errors.append(f"{entry_id or index}: image not found: {image}")
+
+    captured = entry.get("captured")
+    if not isinstance(captured, dict):
+        errors.append(f"{entry_id or index}: missing 'captured' mapping")
+    else:
+        for key in _REQUIRED_CAPTURED:
+            if key not in captured:
+                errors.append(f"{entry_id or index}: captured.{key} is required")
+
+    source = entry.get("source")
+    inputs: list[str] = []
+    if not isinstance(source, dict):
+        errors.append(f"{entry_id or index}: missing 'source' mapping")
+    else:
+        raw_inputs = source.get("inputs")
+        if not isinstance(raw_inputs, list) or not raw_inputs:
+            errors.append(f"{entry_id or index}: source.inputs must be a non-empty list")
+        else:
+            for rel in raw_inputs:
+                if not isinstance(rel, str) or not (REPO_ROOT / rel).is_file():
+                    errors.append(f"{entry_id or index}: source input not found: {rel}")
+                else:
+                    inputs.append(rel)
+        if "hash" not in source:
+            errors.append(f"{entry_id or index}: source.hash is required")
+
+    return errors, entry_id, inputs
+
+
+def _check(path: Path, strict: bool) -> int:
+    try:
+        manifest = _load_manifest(path)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"screenshot manifest invalid: {exc}")
+        return 1
+
+    hard_errors: list[str] = []
+    warnings: list[str] = []
+    seen_ids: set[str] = set()
+
+    for index, entry in enumerate(manifest["screenshots"]):
+        entry_errors, entry_id, inputs = _validate_entry(entry, index)
+        hard_errors.extend(entry_errors)
+        if entry_id:
+            if entry_id in seen_ids:
+                hard_errors.append(f"duplicate id: {entry_id}")
+            seen_ids.add(entry_id)
+        if entry_errors or not inputs:
+            continue
+        declared = entry["source"].get("hash")
+        actual = _combined_source_hash(inputs)
+        if declared != actual:
+            warnings.append(
+                f"{entry_id}: source inputs changed since capture "
+                f"(declared {declared}, actual {actual}); re-capture screenshot "
+                f"and refresh the manifest"
+            )
+
+    if hard_errors:
+        print("Screenshot manifest check FAILED:")
+        for err in hard_errors:
+            print(f"  error: {err}")
+        return 1
+
+    if warnings:
+        print("Screenshot manifest drift detected:")
+        for warn in warnings:
+            print(f"  warning: {warn}")
+        if strict:
+            return 1
+        return 0
+
+    print(f"Screenshot manifest OK: {len(seen_ids)} screenshot(s) verified.")
+    return 0
+
+
+def _update(path: Path) -> int:
+    manifest = _load_manifest(path)
+    for entry in manifest["screenshots"]:
+        source = entry["source"]
+        source["hash"] = _combined_source_hash(list(source["inputs"]))
+        if "output" in entry and isinstance(entry["output"], dict):
+            entry["output"]["hash"] = _image_hash(entry["image"])
+    path.write_text(
+        yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    print(f"Updated hashes for {len(manifest['screenshots'])} screenshot(s).")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat source-hash drift warnings as failures",
+    )
+    parser.add_argument(
+        "--update",
+        action="store_true",
+        help="recompute and rewrite source/output hashes in place",
+    )
+    args = parser.parse_args(argv)
+
+    if not args.manifest.is_file():
+        print(f"screenshot manifest not found: {args.manifest}")
+        return 1
+    if args.update:
+        return _update(args.manifest)
+    return _check(args.manifest, strict=args.strict)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_screenshot_manifest.py
+++ b/tests/test_screenshot_manifest.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "check_screenshots.py"
+MANIFEST = REPO_ROOT / "docs" / "assets" / "screenshots.yml"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+def test_committed_manifest_is_clean() -> None:
+    result = _run("--strict")
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "verified" in result.stdout
+
+
+def test_valid_manifest_matches_source_inputs() -> None:
+    result = _run("--manifest", str(MANIFEST))
+    assert result.returncode == 0
+    assert "OK" in result.stdout
+
+
+def _write(path: Path, body: str) -> None:
+    path.write_text(textwrap.dedent(body).lstrip(), encoding="utf-8")
+
+
+def test_unsupported_schema_version_fails(tmp_path: Path) -> None:
+    manifest = tmp_path / "m.yml"
+    _write(manifest, "schema_version: 2\n")
+    result = _run("--manifest", str(manifest))
+    assert result.returncode == 1
+    assert "schema_version" in result.stdout
+
+
+def test_missing_image_and_duplicate_id_fail(tmp_path: Path) -> None:
+    manifest = tmp_path / "m.yml"
+    _write(
+        manifest,
+        """
+        schema_version: 1
+        screenshots:
+          - id: dupe
+            image: docs/assets/does_not_exist.png
+            captured: {package_version: "0.0.0", git_sha: x, date: "2026-01-01", method: manual}
+            source: {inputs: [examples/webhook_receiver/function_app.py], hash: "sha256:x"}
+          - id: dupe
+            image: docs/assets/webhook_receiver_swagger_ui.png
+            captured: {package_version: "0.0.0", git_sha: x, date: "2026-01-01", method: manual}
+            source: {inputs: [examples/webhook_receiver/function_app.py], hash: "sha256:x"}
+        """,
+    )
+    result = _run("--manifest", str(manifest))
+    assert result.returncode == 1
+    assert "image not found" in result.stdout
+    assert "duplicate id: dupe" in result.stdout
+
+
+def test_source_drift_warns_but_passes_without_strict(tmp_path: Path) -> None:
+    manifest = tmp_path / "m.yml"
+    _write(
+        manifest,
+        """
+        schema_version: 1
+        screenshots:
+          - id: drift
+            image: docs/assets/webhook_receiver_swagger_ui.png
+            captured: {package_version: "0.0.0", git_sha: x, date: "2026-01-01", method: manual}
+            source: {inputs: [examples/webhook_receiver/function_app.py], hash: "sha256:stale"}
+        """,
+    )
+    ok = _run("--manifest", str(manifest))
+    assert ok.returncode == 0
+    assert "drift detected" in ok.stdout
+
+    strict = _run("--manifest", str(manifest), "--strict")
+    assert strict.returncode == 1
+    assert "drift detected" in strict.stdout


### PR DESCRIPTION
## Context

Closes #408 (items 1–4). Documentation screenshots had no provenance, so there was no way to detect when the OpenAPI output or examples drifted from the captured images. This adds a metadata manifest plus automated capture + staleness checking.

## What's included (acceptance items 1–4)

- **Manifest** — `docs/assets/screenshots.yml` (`schema_version: 1`): each screenshot records `image`, `captured.{package_version,git_sha,date,method}`, `source.{inputs,hash}`, and optional `output.hash`. Existing PNGs predate automated capture, so they are recorded as `method: manual`; hashes are seeded from current sources.
- **Staleness checker** — `scripts/check_screenshots.py` (no Azure, pyyaml-only). Recomputes a combined SHA-256 over each entry's `source.inputs` and compares to the declared hash.
  - **Hard fail (exit 1):** invalid manifest / wrong schema_version / missing image / missing source input / duplicate id.
  - **Warn-only (exit 0, or fail under `--strict`):** inputs changed but manifest not refreshed.
  - `--update` rewrites hashes in place after a re-capture.
- **Tests** — `tests/test_screenshot_manifest.py` exercises the clean, drift, `--strict`, bad-schema, missing-image, and duplicate-id paths (subprocess-based; no coverage impact).
- **e2e-azure capture step** — Playwright captures `/api/docs` and `/api/openapi.json` (tags / manual dispatch only, before cleanup) and uploads them as an artifact with version/SHA/source-hash metadata.
- **PR CI** — `.github/workflows/screenshots.yml` runs the checker on PRs touching the manifest, checker, or `examples/**`.

## Verification

- `make check-all` green locally: **709 passed, 6 skipped**, coverage **95.42%** (≥95%), workflow pin-hygiene + security clean.
- Checker manually exercised across clean / drift / `--strict` / structural-failure cases.
- Both new/edited workflow YAMLs parse; capture-step bash passes `bash -n`.

## Deferred — item 5 (needs maintainer / Azure)

> Verify end-to-end via `workflow_dispatch` against the Visual Studio subscription, then embed captured images into docs.

This requires deploying to real Azure (Azure OIDC secrets) and is **not** doable in this PR. After merge, dispatch `e2e-azure.yml` on a release commit, download the `swagger-screenshots-*` artifact, refresh `docs/assets/screenshots.yml` via `python scripts/check_screenshots.py --update`, and embed the images in a follow-up.

## Out of scope

- Rolling the pattern out to sibling repos (tracked separately once the pilot is validated).
- cookbook (no e2e-azure workflow / infra yet).