### PR TITLE
feat(spec): support OpenAPI 3.2 querystring parameters

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -137,6 +137,36 @@ def raw(req: func.HttpRequest) -> func.HttpResponse:
     ...
 ```
 
+### Querystring parameter (OpenAPI 3.2)
+
+OpenAPI 3.2 adds a `querystring` parameter location that describes the entire
+query string with a single schema. Pass a Pydantic model or raw JSON Schema via
+`querystring=`; it is emitted only when generating a `3.2.0` document.
+
+```python
+class SearchQuery(BaseModel):
+    q: str
+    limit: int = 10
+
+@openapi(
+    summary="Search",
+    method="get",
+    querystring=SearchQuery,
+    # querystring_media_type defaults to "application/x-www-form-urlencoded"
+)
+@app.route(route="search", methods=["GET"])
+def search(req: func.HttpRequest) -> func.HttpResponse:
+    ...
+```
+
+!!! note
+    `querystring` requires `openapi_version="3.2.0"` (raises
+    `OpenAPISpecConfigError` under 3.0/3.1). At most one querystring parameter is
+    allowed per operation, and it cannot coexist with any `in: query` parameter.
+    See [Configuration](configuration.md#querystring-parameters-32-only) for
+    details.
+
+
 ### Expose OpenAPI + Swagger routes
 
 ```python

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,10 +165,47 @@ json_spec = get_openapi_json(
 - `example` values are normalized to `examples`
 
 3.2.0 is a backward-compatible superset of 3.1.0 and reuses the same JSON
-Schema 2020-12 conversions. This library emits a valid 3.2.0 document; it does
-not yet add 3.2-only constructs (querystring schemas, `additionalOperations`,
-the `query` HTTP method, or streaming media types). Note that some viewers —
-including the bundled Swagger UI — may not yet render 3.2.0 documents.
+Schema 2020-12 conversions. This library emits a valid 3.2.0 document and
+supports the 3.2-only **querystring** parameter (see below); it does not yet
+add other 3.2-only constructs (`additionalOperations`, the `query` HTTP method,
+or streaming media types). Note that some viewers — including the bundled
+Swagger UI — may not yet render 3.2.0 documents.
+
+### Querystring parameters (3.2 only)
+
+OpenAPI 3.2 introduces the `querystring` parameter location, which describes the
+**entire** query string as a single schema-backed value instead of enumerating
+individual `query` parameters. Pass a Pydantic model or a raw JSON Schema dict
+via `querystring=`:
+
+```python
+from pydantic import BaseModel
+
+class SearchQuery(BaseModel):
+    q: str
+    limit: int = 10
+
+@openapi(
+    method="get",
+    querystring=SearchQuery,
+    # querystring_media_type defaults to application/x-www-form-urlencoded
+)
+@app.route(route="search", methods=["GET"])
+def search(req):
+    ...
+```
+
+This emits a single `in: querystring` parameter whose content schema is derived
+from the model. Constraints enforced at generation time:
+
+- `querystring` is only valid when `openapi_version="3.2.0"`; using it under
+  3.0/3.1 raises `OpenAPISpecConfigError`.
+- An operation may declare **at most one** querystring parameter.
+- A querystring parameter **must not** coexist with any `in: query` parameter
+  in the same operation.
+
+The raw `parameters=[{"in": "querystring", "content": {...}}]` escape hatch is
+also supported for callers who need full control over the media type or schema.
 
 ## Spec generation options
 

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -208,6 +208,9 @@ def openapi(
     response_model: type[BaseModel] | None = None,
     response: dict[int, dict[str, Any]] | None = None,
     responses: type[BaseModel] | Mapping[int | Literal["default"], Any] | None = None,
+    # ── querystring (OpenAPI 3.2 only) ───────────────────────
+    querystring: type[BaseModel] | dict[str, Any] | None = None,
+    querystring_media_type: str = "application/x-www-form-urlencoded",
 ) -> Callable[[F], F]:
     """
     Decorator that attaches OpenAPI metadata to an Azure Functions handler.
@@ -317,6 +320,14 @@ def openapi(
           ``responses={202: AcceptedModel, 422: {"description": "Validation error"}}``
           — which previously required combining the discrete `response_model` and
           `response` parameters.
+    querystring:
+        OpenAPI 3.2 querystring parameter schema. Accepts either a Pydantic
+        model class or a raw JSON Schema dict, emitted as an ``in: querystring``
+        parameter. Only valid for ``openapi_version="3.2.0"``; raises under
+        3.0/3.1.
+    querystring_media_type:
+        Media type used to encode the querystring content. Defaults to
+        ``application/x-www-form-urlencoded``.
 
     .. deprecated::
        This decorator currently exposes two parallel parameter styles: the
@@ -416,6 +427,19 @@ def openapi(
                         "'responses' must be either a Pydantic BaseModel subclass or a dictionary."
                     )
 
+            resolved_querystring_model: type[BaseModel] | None = None
+            resolved_querystring_schema: dict[str, Any] | None = None
+            if querystring is not None:
+                if isinstance(querystring, dict):
+                    resolved_querystring_schema = querystring
+                elif isinstance(querystring, type) and issubclass(querystring, BaseModel):
+                    resolved_querystring_model = querystring
+                else:
+                    raise ValueError(
+                        "'querystring' must be either a Pydantic BaseModel subclass "
+                        "or a dictionary."
+                    )
+
             # Emit the deprecation warning only after mixed-style validation
             # has passed, so callers hitting a ValueError above are not also
             # warned about a config they were told is invalid.
@@ -483,6 +507,10 @@ def openapi(
                         "request_body_required": request_body_required,
                         "response_model": resolved_response_model,
                         "response": resolved_response or {},
+                        # ── querystring (OpenAPI 3.2) ────────────────────────
+                        "querystring_model": resolved_querystring_model,
+                        "querystring_schema": resolved_querystring_schema,
+                        "querystring_media_type": querystring_media_type,
                         "function_name": metadata_func.__name__,
                         "_function_id": function_id,
                     },
@@ -542,6 +570,8 @@ def register_openapi_metadata(
     request_body_required: bool = True,
     response_model: type[BaseModel] | None = None,
     response: dict[int, dict[str, Any]] | None = None,
+    querystring: type[BaseModel] | dict[str, Any] | None = None,
+    querystring_media_type: str = "application/x-www-form-urlencoded",
     parameters: list[dict[str, Any]] | None = None,
     security: list[dict[str, list[str]]] | None = None,
     security_scheme: dict[str, dict[str, Any]] | None = None,
@@ -577,6 +607,13 @@ def register_openapi_metadata(
         Pydantic model for the 200-response schema.
     response:
         Manual responses dict keyed by status code.
+    querystring:
+        OpenAPI 3.2 querystring parameter schema. Accepts either a Pydantic
+        model class or a raw JSON Schema dict. Emitted only for
+        ``openapi_version="3.2.0"``; raises under 3.0/3.1.
+    querystring_media_type:
+        Media type used to encode the querystring content. Defaults to
+        ``application/x-www-form-urlencoded``.
     parameters:
         List of OpenAPI parameter objects (query/path/header/cookie).
     security:
@@ -640,6 +677,19 @@ def register_openapi_metadata(
     if request_model is not None or response_model is not None:
         _validate_models(request_model, response_model, registry_key)
 
+    resolved_querystring_model: type[BaseModel] | None = None
+    resolved_querystring_schema: dict[str, Any] | None = None
+    if querystring is not None:
+        if isinstance(querystring, dict):
+            resolved_querystring_schema = querystring
+        elif isinstance(querystring, type) and issubclass(querystring, BaseModel):
+            resolved_querystring_model = querystring
+        else:
+            raise ValueError(
+                "'querystring' must be either a Pydantic BaseModel subclass "
+                "or a dictionary."
+            )
+
     reg = registry if registry is not None else _registry
     with reg.lock:
         # Same method+path is a single OpenAPI operation by definition, so
@@ -672,6 +722,9 @@ def register_openapi_metadata(
                 "request_body_required": request_body_required,
                 "response_model": response_model,
                 "response": response or {},
+                "querystring_model": resolved_querystring_model,
+                "querystring_schema": resolved_querystring_schema,
+                "querystring_media_type": querystring_media_type,
                 "function_name": registry_key,
                 "_function_id": f"programmatic.{registry_key}",
             },
@@ -759,11 +812,21 @@ def _validate_parameters(
         if not isinstance(param, dict):
             raise ValueError(f"Parameter at index {i} must be a dictionary")
 
-        # Validate required fields
-        required_fields = ["name", "in"]
-        for field in required_fields:
-            if field not in param:
-                raise ValueError(f"Parameter at index {i} missing required field: {field}")
+        # Validate required fields. OpenAPI 3.2 'querystring' parameters are
+        # special: 'name' is unused and the payload is carried in 'content'
+        # rather than 'schema'.
+        if param.get("in") == "querystring":
+            if "content" not in param:
+                raise ValueError(
+                    f"querystring parameter at index {i} missing required field: content"
+                )
+        else:
+            required_fields = ["name", "in"]
+            for field in required_fields:
+                if field not in param:
+                    raise ValueError(
+                        f"Parameter at index {i} missing required field: {field}"
+                    )
 
         validated_params.append(param)
 

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -247,8 +247,17 @@ def _convert_operation_schemas_to_3_1(paths: dict[str, Any]) -> dict[str, Any]:
 
             # parameters
             for param in operation.get("parameters", []):
-                if isinstance(param, dict) and "schema" in param:
+                if not isinstance(param, dict):
+                    continue
+                if "schema" in param:
                     param["schema"] = _convert_schema_to_3_1(param["schema"])
+                # querystring parameters (OpenAPI 3.2) carry a content map
+                # instead of a bare schema.
+                param_content = param.get("content")
+                if isinstance(param_content, dict):
+                    for _media, media_obj in param_content.items():
+                        if isinstance(media_obj, dict) and "schema" in media_obj:
+                            media_obj["schema"] = _convert_schema_to_3_1(media_obj["schema"])
 
     return paths
 
@@ -430,6 +439,69 @@ def generate_openapi_spec(
                         for param in parameters
                     ]
 
+                # querystring (OpenAPI 3.2 only) ---------------------------------
+                qs_model = meta.get("querystring_model")
+                qs_schema = meta.get("querystring_schema")
+                has_querystring = qs_model is not None or qs_schema is not None
+
+                # Count querystring entries supplied through the raw
+                # ``parameters`` escape hatch so gating/validation covers both
+                # the dedicated ``querystring=`` surface and manual parameters.
+                raw_querystring_count = sum(
+                    1
+                    for p in (op_parameters or [])
+                    if isinstance(p, dict) and p.get("in") == "querystring"
+                )
+                total_querystring = raw_querystring_count + (1 if has_querystring else 0)
+
+                if total_querystring and openapi_version != OPENAPI_VERSION_3_2:
+                    raise OpenAPISpecConfigError(
+                        f"querystring parameters require openapi_version="
+                        f"'{OPENAPI_VERSION_3_2}', got '{openapi_version}' "
+                        f"(function '{logical_name}')."
+                    )
+
+                if has_querystring:
+                    qs_media_type = meta.get(
+                        "querystring_media_type", "application/x-www-form-urlencoded"
+                    )
+                    if qs_model is not None:
+                        qs_resolved = model_to_schema(qs_model, components)
+                    else:
+                        qs_resolved = hoist_inline_defs(
+                            qs_schema, components, hoist_flat=hoist_flat_schemas
+                        )
+                    qs_param = {
+                        "in": "querystring",
+                        "content": {qs_media_type: {"schema": qs_resolved}},
+                    }
+                    if op_parameters is None:
+                        op_parameters = []
+                    op_parameters.append(qs_param)
+
+                # Validation: querystring must not coexist with 'query' params,
+                # and at most one querystring parameter may appear per operation.
+                if op_parameters:
+                    has_query_param = any(
+                        isinstance(p, dict) and p.get("in") == "query"
+                        for p in op_parameters
+                    )
+                    qs_total = sum(
+                        1
+                        for p in op_parameters
+                        if isinstance(p, dict) and p.get("in") == "querystring"
+                    )
+                    if qs_total > 1:
+                        raise OpenAPISpecConfigError(
+                            f"Operation for '{logical_name}' declares multiple "
+                            f"'querystring' parameters; at most one is allowed."
+                        )
+                    if qs_total and has_query_param:
+                        raise OpenAPISpecConfigError(
+                            f"Operation for '{logical_name}' mixes 'query' and "
+                            f"'querystring' parameters, which OpenAPI 3.2 forbids."
+                        )
+
                 # security --------------------------------------------------------
                 security: list[dict[str, list[str]]] = meta.get("security", [])
 
@@ -507,6 +579,10 @@ def generate_openapi_spec(
                         _dup_registry.add_duplicate_operation(method, path)
                     path_item[method] = op
 
+            except OpenAPISpecConfigError:
+                # Configuration contract violations (e.g. querystring misuse)
+                # must always surface, regardless of strict mode.
+                raise
             except (KeyError, TypeError, ValueError):
                 if strict:
                     logger.error("Failed to process function %s (strict mode)", func_name)

--- a/tests/test_openapi_3_2.py
+++ b/tests/test_openapi_3_2.py
@@ -73,3 +73,245 @@ class TestGetOpenapiYaml3_2:
         result = get_openapi_yaml(openapi_version=OPENAPI_VERSION_3_2)
 
         assert yaml.safe_load(result)["openapi"] == "3.2.0"
+
+
+
+class TestQuerystring3_2:
+    def test_dict_querystring_emitted_under_3_2(self) -> None:
+        from azure_functions_openapi.decorator import (
+            clear_openapi_registry,
+            register_openapi_metadata,
+        )
+
+        clear_openapi_registry()
+        try:
+            register_openapi_metadata(
+                "/api/search",
+                "get",
+                querystring={
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                },
+            )
+            spec = generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_2)
+        finally:
+            clear_openapi_registry()
+
+        params = spec["paths"]["/api/search"]["get"]["parameters"]
+        qs = [p for p in params if p.get("in") == "querystring"]
+        assert len(qs) == 1
+        schema = qs[0]["content"]["application/x-www-form-urlencoded"]["schema"]
+        assert schema["properties"]["q"]["type"] == "string"
+
+    def test_pydantic_querystring_emitted_under_3_2(self) -> None:
+        from pydantic import BaseModel
+
+        from azure_functions_openapi.decorator import (
+            clear_openapi_registry,
+            register_openapi_metadata,
+        )
+
+        class SearchQuery(BaseModel):
+            q: str
+            limit: int = 10
+
+        clear_openapi_registry()
+        try:
+            register_openapi_metadata(
+                "/api/search",
+                "get",
+                querystring=SearchQuery,
+                querystring_media_type="application/json",
+            )
+            spec = generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_2)
+        finally:
+            clear_openapi_registry()
+
+        params = spec["paths"]["/api/search"]["get"]["parameters"]
+        qs = [p for p in params if p.get("in") == "querystring"]
+        assert len(qs) == 1
+        assert "application/json" in qs[0]["content"]
+        schema = qs[0]["content"]["application/json"]["schema"]
+        # Pydantic models resolve to a $ref into components.schemas.
+        assert "$ref" in schema or "properties" in schema
+
+    def test_querystring_rejected_under_3_1(self) -> None:
+        from azure_functions_openapi.decorator import (
+            clear_openapi_registry,
+            register_openapi_metadata,
+        )
+
+        clear_openapi_registry()
+        try:
+            register_openapi_metadata(
+                "/api/search",
+                "get",
+                querystring={"type": "object"},
+            )
+            with pytest.raises(OpenAPISpecConfigError) as exc_info:
+                generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_1)
+        finally:
+            clear_openapi_registry()
+
+        assert "querystring" in str(exc_info.value)
+
+    def test_querystring_and_query_coexistence_rejected(self) -> None:
+        from azure_functions_openapi.decorator import (
+            clear_openapi_registry,
+            register_openapi_metadata,
+        )
+
+        clear_openapi_registry()
+        try:
+            register_openapi_metadata(
+                "/api/search",
+                "get",
+                parameters=[
+                    {"name": "page", "in": "query", "schema": {"type": "integer"}}
+                ],
+                querystring={"type": "object"},
+            )
+            with pytest.raises(OpenAPISpecConfigError) as exc_info:
+                generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_2)
+        finally:
+            clear_openapi_registry()
+
+        assert "query" in str(exc_info.value)
+
+    def test_multiple_querystring_rejected(self) -> None:
+        from azure_functions_openapi.decorator import (
+            clear_openapi_registry,
+            register_openapi_metadata,
+        )
+
+        clear_openapi_registry()
+        try:
+            register_openapi_metadata(
+                "/api/search",
+                "get",
+                parameters=[
+                    {
+                        "in": "querystring",
+                        "content": {
+                            "application/x-www-form-urlencoded": {
+                                "schema": {"type": "object"}
+                            }
+                        },
+                    }
+                ],
+                querystring={"type": "object"},
+            )
+            with pytest.raises(OpenAPISpecConfigError) as exc_info:
+                generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_2)
+        finally:
+            clear_openapi_registry()
+
+        assert "multiple" in str(exc_info.value).lower()
+
+    def test_querystring_content_schema_gets_3_1_conversion(self) -> None:
+        from azure_functions_openapi.decorator import (
+            clear_openapi_registry,
+            register_openapi_metadata,
+        )
+
+        clear_openapi_registry()
+        try:
+            register_openapi_metadata(
+                "/api/search",
+                "get",
+                querystring={
+                    "type": "object",
+                    "properties": {"q": {"type": "string", "nullable": True}},
+                },
+            )
+            spec = generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_2)
+        finally:
+            clear_openapi_registry()
+
+        params = spec["paths"]["/api/search"]["get"]["parameters"]
+        qs = [p for p in params if p.get("in") == "querystring"][0]
+        schema = qs["content"]["application/x-www-form-urlencoded"]["schema"]
+        q_schema = schema["properties"]["q"]
+        # 3.1 conversion drops the 3.0-only 'nullable' keyword in favour of a
+        # null type union.
+        assert "nullable" not in q_schema
+
+    def test_decorator_rejects_invalid_querystring_type(self) -> None:
+        from azure_functions_openapi.decorator import clear_openapi_registry, openapi
+
+        clear_openapi_registry()
+        try:
+            with pytest.raises(ValueError, match="querystring"):
+
+                @openapi(method="get", querystring=123)  # type: ignore[arg-type]
+                def handler(req: object) -> object:  # pragma: no cover
+                    return req
+        finally:
+            clear_openapi_registry()
+
+    def test_openapi_decorator_emits_querystring(self) -> None:
+        from azure_functions_openapi.decorator import (
+            clear_openapi_registry,
+            get_openapi_registry,
+            openapi,
+        )
+
+        clear_openapi_registry()
+        try:
+
+            @openapi(
+                method="get",
+                route="decorated-search",
+                querystring={
+                    "type": "object",
+                    "properties": {"q": {"type": "string"}},
+                },
+            )
+            def handler(req: object) -> object:
+                return req
+
+            # Metadata stored on the registry captures the querystring schema.
+            meta = get_openapi_registry()["handler"]
+            assert meta["querystring_schema"]["properties"]["q"]["type"] == "string"
+
+            spec = generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_2)
+            params = spec["paths"]["/api/decorated-search"]["get"]["parameters"]
+            qs = [p for p in params if p.get("in") == "querystring"]
+            assert len(qs) == 1
+        finally:
+            clear_openapi_registry()
+
+    def test_raw_querystring_missing_content_rejected(self) -> None:
+        from azure_functions_openapi.decorator import (
+            clear_openapi_registry,
+            register_openapi_metadata,
+        )
+
+        clear_openapi_registry()
+        try:
+            with pytest.raises(ValueError, match="content"):
+                register_openapi_metadata(
+                    "/api/search",
+                    "get",
+                    parameters=[{"in": "querystring"}],
+                )
+        finally:
+            clear_openapi_registry()
+            clear_openapi_registry()
+
+    def test_register_metadata_rejects_invalid_querystring_type(self) -> None:
+        from azure_functions_openapi.decorator import (
+            clear_openapi_registry,
+            register_openapi_metadata,
+        )
+
+        clear_openapi_registry()
+        try:
+            with pytest.raises(ValueError, match="querystring"):
+                register_openapi_metadata(
+                    "/api/search",
+                    "get",
+                    querystring=123,  # type: ignore[arg-type]
+                )
+        finally:
+            clear_openapi_registry()

--- a/tests/test_openapi_3_2.py
+++ b/tests/test_openapi_3_2.py
@@ -297,7 +297,6 @@ class TestQuerystring3_2:
                 )
         finally:
             clear_openapi_registry()
-            clear_openapi_registry()
 
     def test_register_metadata_rejects_invalid_querystring_type(self) -> None:
         from azure_functions_openapi.decorator import (


### PR DESCRIPTION
## Summary
- Add a dedicated `querystring=` surface (Pydantic model **or** raw JSON Schema dict) plus `querystring_media_type=` (default `application/x-www-form-urlencoded`) to both `@openapi` and `register_openapi_metadata`.
- Emit a single OpenAPI 3.2 `in: querystring` parameter whose payload lives in a `content` media-type map, resolving the schema via `model_to_schema` / `hoist_inline_defs`.
- Enforce the 3.2 semantics at generation time: `querystring` requires `openapi_version="3.2.0"` (raises `OpenAPISpecConfigError` under 3.0/3.1), at most one querystring per operation, and no coexistence with any `in: query` parameter.
- Extend 3.1 schema conversion to reach `parameters[].content[*].schema`, and let configuration `OpenAPISpecConfigError`s always propagate (previously swallowed by the broad `ValueError` catch in non-strict mode).
- Accept the raw `parameters=[{"in": "querystring", "content": {...}}]` escape hatch (relaxed `_validate_parameters` since querystring params carry `content`, not `name`).
- Docs: querystring sections in `docs/api.md` and `docs/configuration.md`.

## Testing
- `hatch run pytest` — 726 passed, 6 skipped
- Coverage 95.44% (≥95% gate)
- `make lint`, `make typecheck` clean

Closes #470