### PR TITLE
feat(spec): document streaming response media types (OpenAPI 3.2)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,10 +165,11 @@ json_spec = get_openapi_json(
 - `example` values are normalized to `examples`
 
 3.2.0 is a backward-compatible superset of 3.1.0 and reuses the same JSON
-Schema 2020-12 conversions. This library emits a valid 3.2.0 document; it does
-not yet add 3.2-only constructs (querystring schemas, `additionalOperations`,
-the `query` HTTP method, or streaming media types). Note that some viewers —
-including the bundled Swagger UI — may not yet render 3.2.0 documents.
+Schema 2020-12 conversions. This library emits a valid 3.2.0 document and
+supports 3.2-only constructs (querystring schemas, `additionalOperations`,
+the `query` HTTP method, and streaming media types via `itemSchema`). Note
+that some viewers — including the bundled Swagger UI — may not yet render
+3.2.0 documents.
 
 ## Spec generation options
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -8,9 +8,11 @@ Use 3.1.0 if your tooling supports it and you want newer JSON Schema alignment.
 
 Use 3.2.0 if you specifically need to advertise a 3.2 document. It is a
 backward-compatible superset of 3.1.0 and shares the same JSON Schema 2020-12
-dialect. This library emits a valid 3.2.0 document but does not yet add
-3.2-only constructs, and some viewers (including the bundled Swagger UI) may
-not render 3.2.0 yet — prefer 3.1.0 unless you have a concrete 3.2 requirement.
+dialect. This library emits a valid 3.2.0 document and supports 3.2-only
+constructs (querystring schemas, `additionalOperations`, the `query` HTTP
+method, and streaming media types via `itemSchema`). Some viewers (including
+the bundled Swagger UI) may not render 3.2.0 yet — prefer 3.1.0 unless you need
+one of those constructs or a concrete 3.2 requirement.
 
 ```python
 from azure_functions_openapi import OPENAPI_VERSION_3_1, get_openapi_json

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -222,6 +222,58 @@ defaults to `True`):
     guide](migration/unified-params.md) for full before/after recipes and the
     alias-retention policy.
 
+## Streaming responses (OpenAPI 3.2)
+
+OpenAPI 3.2 adds first-class support for **sequential / streaming media types**
+such as Server-Sent Events (`text/event-stream`), `application/jsonl`, and
+`application/json-seq`. Each streamed item is described with the Media Type
+Object's **`itemSchema`** field (the `schema` field, when present, describes the
+complete body as a whole).
+
+Pass a raw Response Object with an `itemSchema` entry — a Pydantic model, a
+generic alias like `list[Model]`, or an inline JSON Schema dict are all resolved
+the same way the `schema` position is:
+
+```python
+from pydantic import BaseModel
+
+
+class ChatDelta(BaseModel):
+    token: str
+    index: int
+
+
+@openapi(
+    summary="Stream chat completions",
+    method="get",
+    route="/api/chat/stream",
+    responses={
+        200: {
+            "description": "Server-sent event stream of chat deltas",
+            "content": {
+                # itemSchema describes each streamed event
+                "text/event-stream": {"itemSchema": ChatDelta},
+            },
+        }
+    },
+)
+@app.route(route="chat/stream", methods=["GET"])
+def chat_stream(req):
+    ...
+```
+
+Generate the document with `openapi_version="3.2.0"` so the streaming media type
+is emitted under a spec version that understands `itemSchema`:
+
+```python
+spec = generate_openapi_spec(openapi_version="3.2.0")
+```
+
+> `itemSchema` is an OpenAPI 3.2 construct. If you emit it while targeting
+> `3.0.0` or `3.1.0`, the field is still written out but a `RuntimeWarning` is
+> raised, since 3.0/3.1 tooling may not understand it. Prefer `3.2.0` for
+> streaming responses.
+
 ## Parameters (query/path/header/cookie)
 
 Use OpenAPI Parameter Objects in `parameters`.

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -7,6 +7,7 @@ import json
 import logging
 import re
 from typing import Any, get_origin
+import warnings
 
 from pydantic import BaseModel
 import yaml
@@ -216,7 +217,7 @@ def _convert_operation_schemas_to_3_1(paths: dict[str, Any]) -> dict[str, Any]:
 
     Converts schemas in:
     - requestBody.content.*.schema
-    - responses.*.content.*.schema
+    - responses.*.content.*.schema and .itemSchema
     - parameters[].schema
     """
     for _path, methods in paths.items():
@@ -242,8 +243,13 @@ def _convert_operation_schemas_to_3_1(paths: dict[str, Any]) -> dict[str, Any]:
                     content = resp.get("content")
                     if isinstance(content, dict):
                         for _media, media_obj in content.items():
-                            if isinstance(media_obj, dict) and "schema" in media_obj:
-                                media_obj["schema"] = _convert_schema_to_3_1(media_obj["schema"])
+                            if not isinstance(media_obj, dict):
+                                continue
+                            for _schema_key in _MEDIA_SCHEMA_KEYS:
+                                if _schema_key in media_obj:
+                                    media_obj[_schema_key] = _convert_schema_to_3_1(
+                                        media_obj[_schema_key]
+                                    )
 
             # parameters
             for param in operation.get("parameters", []):
@@ -251,6 +257,37 @@ def _convert_operation_schemas_to_3_1(paths: dict[str, Any]) -> dict[str, Any]:
                     param["schema"] = _convert_schema_to_3_1(param["schema"])
 
     return paths
+
+
+# Media Type Object keys (OpenAPI 3.2 adds ``itemSchema`` for sequential/
+# streaming media types such as ``text/event-stream``; see #473). Both
+# positions may carry a Pydantic model / generic alias / inline JSON Schema
+# and are resolved to a ``$ref`` (or hoisted defs) the same way.
+_MEDIA_SCHEMA_KEYS = ("schema", "itemSchema")
+
+
+def _resolve_media_schema(
+    raw_schema: Any,
+    components: dict[str, Any],
+    hoist_flat_schemas: bool,
+) -> Any:
+    """Resolve a media-type schema value into an emittable JSON Schema.
+
+    Handles the three shorthands accepted in a ``content.<media>.schema`` or
+    ``content.<media>.itemSchema`` position: a Pydantic ``BaseModel`` subclass,
+    a generic collection alias (e.g. ``list[Model]``), or a raw inline
+    JSON-Schema dict.
+    """
+    if isinstance(raw_schema, type) and issubclass(raw_schema, BaseModel):
+        # Unified per-status model shorthand (#410): resolve the model to a
+        # $ref here, where the components registry is available.
+        return model_to_schema(raw_schema, components)
+    if get_origin(raw_schema) is not None:
+        # Generic collection alias shorthand (#450), e.g. list[Model]: resolve
+        # via TypeAdapter to a valid array schema; hoist_inline_defs expects a
+        # dict JSON-Schema and would break on a raw alias.
+        return type_to_schema(raw_schema, components)
+    return hoist_inline_defs(raw_schema, components, hoist_flat=hoist_flat_schemas)
 
 
 def generate_openapi_spec(
@@ -347,28 +384,34 @@ def generate_openapi_spec(
                     if isinstance(resp_content, dict):
                         hoisted_content: dict[str, Any] = {}
                         for media, media_obj in resp_content.items():
-                            if isinstance(media_obj, dict) and "schema" in media_obj:
-                                raw_schema = media_obj["schema"]
-                                if isinstance(raw_schema, type) and issubclass(
-                                    raw_schema, BaseModel
+                            if isinstance(media_obj, dict) and any(
+                                key in media_obj for key in _MEDIA_SCHEMA_KEYS
+                            ):
+                                new_media_obj = dict(media_obj)
+                                for schema_key in _MEDIA_SCHEMA_KEYS:
+                                    if schema_key in new_media_obj:
+                                        new_media_obj[schema_key] = _resolve_media_schema(
+                                            new_media_obj[schema_key],
+                                            components,
+                                            hoist_flat_schemas,
+                                        )
+                                if (
+                                    "itemSchema" in new_media_obj
+                                    and openapi_version != OPENAPI_VERSION_3_2
                                 ):
-                                    # Unified per-status model shorthand (#410):
-                                    # resolve the model to a $ref here, where the
-                                    # components registry is available.
-                                    resolved_schema = model_to_schema(raw_schema, components)
-                                elif get_origin(raw_schema) is not None:
-                                    # Generic collection alias shorthand (#450),
-                                    # e.g. list[Model]: resolve via TypeAdapter to a
-                                    # valid array schema; hoist_inline_defs expects a
-                                    # dict JSON-Schema and would break on a raw alias.
-                                    resolved_schema = type_to_schema(raw_schema, components)
-                                else:
-                                    resolved_schema = hoist_inline_defs(
-                                        raw_schema,
-                                        components,
-                                        hoist_flat=hoist_flat_schemas,
+                                    warnings.warn(
+                                        f"Response media type '{media}' for function "
+                                        f"'{func_name}' uses 'itemSchema', which is an "
+                                        f"OpenAPI 3.2 feature for sequential/streaming "
+                                        f"media types, but the target openapi_version is "
+                                        f"{openapi_version}. The field is emitted as-is "
+                                        f"but may not be understood by 3.0/3.1 tooling. "
+                                        f"Use openapi_version='3.2.0' for streaming "
+                                        f"responses.",
+                                        RuntimeWarning,
+                                        stacklevel=2,
                                     )
-                                media_obj = {**media_obj, "schema": resolved_schema}
+                                media_obj = new_media_obj
                             hoisted_content[media] = media_obj
                         resp["content"] = hoisted_content
                     responses[str(status)] = resp

--- a/tests/test_openapi_3_2.py
+++ b/tests/test_openapi_3_2.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import json
+from typing import Any
 
 import pytest
 import yaml
 
 from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+from azure_functions_openapi.registry import OpenAPIRegistry
 from azure_functions_openapi.spec import (
     OPENAPI_VERSION_3_1,
     OPENAPI_VERSION_3_2,
@@ -73,3 +75,211 @@ class TestGetOpenapiYaml3_2:
         result = get_openapi_yaml(openapi_version=OPENAPI_VERSION_3_2)
 
         assert yaml.safe_load(result)["openapi"] == "3.2.0"
+
+
+
+class TestStreamingItemSchema3_2:
+    """OpenAPI 3.2 sequential/streaming media types via ``itemSchema`` (#473)."""
+
+    def _register(self, response: dict[int, dict[str, Any]], *, registry: OpenAPIRegistry) -> None:
+        from azure_functions_openapi.decorator import register_openapi_metadata
+
+        register_openapi_metadata(
+            "/api/events",
+            "get",
+            response=response,
+            registry=registry,
+        )
+
+    def test_item_schema_model_resolves_to_ref(self) -> None:
+        from pydantic import BaseModel
+
+        from azure_functions_openapi.registry import OpenAPIRegistry
+
+        class SseEvent(BaseModel):
+            id: int
+            message: str
+
+        registry = OpenAPIRegistry()
+        self._register(
+            {
+                200: {
+                    "description": "Event stream",
+                    "content": {"text/event-stream": {"itemSchema": SseEvent}},
+                }
+            },
+            registry=registry,
+        )
+
+        spec = generate_openapi_spec(
+            openapi_version=OPENAPI_VERSION_3_2, registry=registry, route_prefix=""
+        )
+        media = spec["paths"]["/api/events"]["get"]["responses"]["200"]["content"][
+            "text/event-stream"
+        ]
+        assert media["itemSchema"] == {"$ref": "#/components/schemas/SseEvent"}
+        assert "SseEvent" in spec["components"]["schemas"]
+
+    def test_item_schema_generic_alias_resolves_to_array(self) -> None:
+        from pydantic import BaseModel
+
+        from azure_functions_openapi.registry import OpenAPIRegistry
+
+        class Item(BaseModel):
+            name: str
+
+        registry = OpenAPIRegistry()
+        self._register(
+            {
+                200: {
+                    "description": "Sequential items",
+                    "content": {"application/jsonl": {"itemSchema": list[Item]}},
+                }
+            },
+            registry=registry,
+        )
+
+        spec = generate_openapi_spec(
+            openapi_version=OPENAPI_VERSION_3_2, registry=registry, route_prefix=""
+        )
+        media = spec["paths"]["/api/events"]["get"]["responses"]["200"]["content"][
+            "application/jsonl"
+        ]
+        assert media["itemSchema"]["type"] == "array"
+
+    def test_item_schema_inline_dict_passes_through(self) -> None:
+        from azure_functions_openapi.registry import OpenAPIRegistry
+
+        registry = OpenAPIRegistry()
+        self._register(
+            {
+                200: {
+                    "description": "Event stream",
+                    "content": {
+                        "text/event-stream": {
+                            "itemSchema": {
+                                "type": "object",
+                                "properties": {"message": {"type": "string"}},
+                            }
+                        }
+                    },
+                }
+            },
+            registry=registry,
+        )
+
+        spec = generate_openapi_spec(
+            openapi_version=OPENAPI_VERSION_3_2, registry=registry, route_prefix=""
+        )
+        media = spec["paths"]["/api/events"]["get"]["responses"]["200"]["content"][
+            "text/event-stream"
+        ]
+        assert media["itemSchema"]["properties"]["message"] == {"type": "string"}
+
+    def test_item_schema_and_schema_coexist(self) -> None:
+        from pydantic import BaseModel
+
+        from azure_functions_openapi.registry import OpenAPIRegistry
+
+        class Event(BaseModel):
+            seq: int
+
+        registry = OpenAPIRegistry()
+        self._register(
+            {
+                200: {
+                    "description": "Event stream",
+                    "content": {
+                        "text/event-stream": {
+                            "schema": {"type": "array"},
+                            "itemSchema": Event,
+                        }
+                    },
+                }
+            },
+            registry=registry,
+        )
+
+        spec = generate_openapi_spec(
+            openapi_version=OPENAPI_VERSION_3_2, registry=registry, route_prefix=""
+        )
+        media = spec["paths"]["/api/events"]["get"]["responses"]["200"]["content"][
+            "text/event-stream"
+        ]
+        assert media["schema"] == {"type": "array"}
+        assert media["itemSchema"] == {"$ref": "#/components/schemas/Event"}
+
+    def test_item_schema_warns_on_pre_3_2_version(self) -> None:
+        from azure_functions_openapi.registry import OpenAPIRegistry
+
+        registry = OpenAPIRegistry()
+        self._register(
+            {
+                200: {
+                    "description": "Event stream",
+                    "content": {
+                        "text/event-stream": {
+                            "itemSchema": {"type": "object"},
+                        }
+                    },
+                }
+            },
+            registry=registry,
+        )
+
+        with pytest.warns(RuntimeWarning, match="itemSchema"):
+            generate_openapi_spec(
+                openapi_version=OPENAPI_VERSION_3_1, registry=registry, route_prefix=""
+            )
+
+    def test_item_schema_no_warning_on_3_2(self, recwarn: pytest.WarningsRecorder) -> None:
+        from azure_functions_openapi.registry import OpenAPIRegistry
+
+        registry = OpenAPIRegistry()
+        self._register(
+            {
+                200: {
+                    "description": "Event stream",
+                    "content": {
+                        "text/event-stream": {
+                            "itemSchema": {"type": "object"},
+                        }
+                    },
+                }
+            },
+            registry=registry,
+        )
+
+        generate_openapi_spec(
+            openapi_version=OPENAPI_VERSION_3_2, registry=registry, route_prefix=""
+        )
+        assert not [w for w in recwarn.list if issubclass(w.category, RuntimeWarning)]
+
+    def test_plain_schema_response_unaffected(self) -> None:
+        """Regression: schema-only responses keep resolving as before."""
+        from pydantic import BaseModel
+
+        from azure_functions_openapi.registry import OpenAPIRegistry
+
+        class Body(BaseModel):
+            ok: bool
+
+        registry = OpenAPIRegistry()
+        self._register(
+            {
+                200: {
+                    "description": "JSON body",
+                    "content": {"application/json": {"schema": Body}},
+                }
+            },
+            registry=registry,
+        )
+
+        spec = generate_openapi_spec(
+            openapi_version=OPENAPI_VERSION_3_2, registry=registry, route_prefix=""
+        )
+        media = spec["paths"]["/api/events"]["get"]["responses"]["200"]["content"][
+            "application/json"
+        ]
+        assert media["schema"] == {"$ref": "#/components/schemas/Body"}
+        assert "itemSchema" not in media

--- a/tests/test_openapi_3_2.py
+++ b/tests/test_openapi_3_2.py
@@ -283,3 +283,39 @@ class TestStreamingItemSchema3_2:
         ]
         assert media["schema"] == {"$ref": "#/components/schemas/Body"}
         assert "itemSchema" not in media
+
+    def test_item_schema_gets_3_1_conversion(self) -> None:
+        """Regression: itemSchema is subject to the same 3.1/3.2 JSON Schema
+        conversions (nullable -> type union, example -> examples) as schema."""
+        from azure_functions_openapi.registry import OpenAPIRegistry
+
+        registry = OpenAPIRegistry()
+        self._register(
+            {
+                200: {
+                    "description": "Event stream",
+                    "content": {
+                        "text/event-stream": {
+                            "itemSchema": {
+                                "type": "string",
+                                "nullable": True,
+                                "example": "hello",
+                            }
+                        }
+                    },
+                }
+            },
+            registry=registry,
+        )
+
+        spec = generate_openapi_spec(
+            openapi_version=OPENAPI_VERSION_3_2, registry=registry, route_prefix=""
+        )
+        media = spec["paths"]["/api/events"]["get"]["responses"]["200"]["content"][
+            "text/event-stream"
+        ]
+        item = media["itemSchema"]
+        assert "nullable" not in item
+        assert item["type"] == ["string", "null"]
+        assert "example" not in item
+        assert item["examples"] == ["hello"]


### PR DESCRIPTION
## Summary
- Resolve Pydantic models / generic aliases / inline schema dicts in the response `content.<media>.itemSchema` position, mirroring the existing `schema` handling — enabling documentation of OpenAPI 3.2 sequential/streaming media types (e.g. `text/event-stream`, `application/jsonl`).
- Extend the 3.1 schema-conversion pass to also convert `itemSchema` blocks so mixed streaming responses stay valid on 3.1 targets.
- Emit a `RuntimeWarning` when `itemSchema` is used while targeting `3.0.0`/`3.1.0` (still emitted, but flagged), consistent with the repo's warning-based drift signals.
- Add a "Streaming responses (OpenAPI 3.2)" section with an SSE example to `docs/usage.md` (canonical English docs).

## Testing
- `make lint` / `make typecheck` / `make build` ✅
- Full suite ✅ — coverage 95.43% (≥95% gate met)
- New `TestStreamingItemSchema3_2` (7 tests): model→`$ref`, `list[Model]`→array, inline-dict passthrough, `schema`+`itemSchema` coexistence, warns on <3.2, no-warning on 3.2, and a regression test for plain `schema` responses.

## Notes
- Minimal API surface: no new decorator kwarg; rides on the existing raw Response Object path. Runtime streaming is out of scope (documentation only).

Closes #473