### PR TITLE
feat(decorator): accept None as body-less response shorthand in responses=

### DIFF
--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -161,7 +161,9 @@ def _normalize_unified_responses(
     * a generic collection alias such as ``list[Model]`` — the same bare-shorthand
       treatment, resolved to an array schema at spec-generation time, or
     * an OpenAPI Response Object mapping (unchanged; a Pydantic model may also appear
-      in its ``content.<media>.schema`` position and is resolved the same way).
+      in its ``content.<media>.schema`` position and is resolved the same way), or
+    * ``None`` — shorthand for a body-less response (e.g. ``204 No Content``),
+      expanded to ``{"description": ...}`` with no ``content`` key.
 
     Status keys may be ints (``200``), numeric strings (``"200"``), or the literal
     OpenAPI ``"default"`` key (the fallback response for any undocumented status);
@@ -172,7 +174,9 @@ def _normalize_unified_responses(
     normalized: dict[int | str, dict[str, Any]] = {}
     for raw_status, value in responses.items():
         status = _coerce_status_key(raw_status, func_name)
-        if _is_pydantic_model(value) or get_origin(value) is not None:
+        if value is None:
+            normalized[status] = {"description": _default_response_description(status)}
+        elif _is_pydantic_model(value) or get_origin(value) is not None:
             normalized[status] = {
                 "description": _default_response_description(status),
                 "content": {"application/json": {"schema": value}},
@@ -183,8 +187,9 @@ def _normalize_unified_responses(
             raise ValueError(
                 f"Invalid 'responses' entry for status {status} in function "
                 f"'{func_name}': each value must be a Pydantic BaseModel subclass, "
-                f"a generic collection alias (e.g. list[Model]), or an OpenAPI "
-                f"Response Object mapping, got {type(value).__name__}."
+                f"a generic collection alias (e.g. list[Model]), an OpenAPI "
+                f"Response Object mapping, or None (body-less response), "
+                f"got {type(value).__name__}."
             )
     return normalized
 

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -665,6 +665,27 @@ def test_openapi_responses_dict_rejects_invalid_value() -> None:
     assert "Invalid 'responses' entry for status 200" in str(exc_info.value)
 
 
+def test_openapi_responses_accepts_none_as_body_less_response() -> None:
+    """``None`` is shorthand for a body-less response (e.g. 204 No Content):
+    it expands to a description-only Response Object with no ``content`` key."""
+    _clear_registry()
+
+    @openapi(
+        summary="Delete item",
+        route="/api/items/{item_id}",
+        method="delete",
+        responses={204: None, "default": None},
+    )
+    def delete_item_func() -> None:
+        pass
+
+    spec = generate_openapi_spec(route_prefix="")
+    responses = spec["paths"]["/api/items/{item_id}"]["delete"]["responses"]
+    assert responses["204"] == {"description": "No Content"}
+    assert "content" not in responses["204"]
+    assert responses["default"] == {"description": "Response"}
+
+
 def test_openapi_responses_accepts_non_dict_mapping() -> None:
     """A non-dict Mapping (e.g. MappingProxyType) is accepted, matching the
     advertised Mapping[...] type contract rather than requiring a concrete dict."""


### PR DESCRIPTION
## Summary
- `responses={204: None}` now expands to a description-only Response Object (`{"description": <status phrase>}`) with no `content` key — the natural way to document body-less responses (e.g. 204 No Content).
- Previously (since #418, released in v0.21.2) a `None` value raised a hard `ValueError` at decoration time, failing the entire `@openapi` registration.
- Caught by a pre-release dogfood of the cookbook: `full_stack_crud_api.delete_item` uses `responses={204: None}` and failed against a v0.22.0 candidate. Cookbook `make test` now passes (625 passed) with this fix.

## Tests
- Added `test_openapi_responses_accepts_none_as_body_less_response` covering `204: None` and `"default": None`.
- Full suite green; coverage 95.53% (>= 95% gate); lint + typecheck clean.

Closes #480