### PR TITLE
feat(spec): infer OpenAPI security from Azure Functions auth_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Spec matches code. Always. Swagger UI out of the box.
 - **Swagger UI** — built-in `/docs` endpoint with security defaults
 - **CLI tooling** — generate specs at build time for CI validation
 - **Schema support** — query, path, header, body, and response schemas
+- **`auth_level` security inference** — opt-in `infer_auth_level=True` derives OpenAPI security from a route's Azure Functions `auth_level` (see [Usage Guide](docs/usage.md#infer-security-from-auth_level-opt-in))
 
 
 ### How it fits together

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -345,6 +345,56 @@ You can define security at operation-level and component-level.
 )
 ```
 
+### Infer security from `auth_level` (opt-in)
+
+Azure Functions routes already declare their auth policy via `auth_level`:
+
+```python
+@app.route(route="users", auth_level=func.AuthLevel.FUNCTION, methods=["GET"])
+```
+
+Rather than repeating that intent in `@openapi(security=..., security_scheme=...)`,
+you can have the spec derive the security requirement and scheme directly from the
+route's `auth_level` by passing `infer_auth_level=True`:
+
+```python
+spec = generate_openapi_spec(title="My API", infer_auth_level=True)
+# get_openapi_json(..., infer_auth_level=True) and
+# get_openapi_yaml(..., infer_auth_level=True) accept the same flag.
+```
+
+Mapping:
+
+| `auth_level`         | Injected security                                      |
+| -------------------- | ------------------------------------------------------ |
+| `ANONYMOUS`          | nothing                                                |
+| `FUNCTION`           | `apiKey` `x-functions-key` (header), scheme `AzureFunctionKey` |
+| `ADMIN`              | `apiKey` `x-functions-key` (header, master key), scheme `AzureFunctionKey` |
+
+Generated output for a `FUNCTION` route:
+
+```yaml
+security:
+  - AzureFunctionKey: []
+components:
+  securitySchemes:
+    AzureFunctionKey:
+      type: apiKey
+      in: header
+      name: x-functions-key
+```
+
+**Notes:**
+
+- The flag defaults to `False`, so existing specs are unchanged unless you opt in.
+- Inference only works on the **binding-scan path** — i.e. when the spec is built by
+  scanning a `FunctionApp` instance (the CLI `module:variable` form, or
+  `scan_endpoint_metadata`). The plain `@openapi`-only path cannot see the HTTP
+  trigger binding, so no `auth_level` is available there.
+- User-supplied values always win: inference injects `security` / `security_scheme`
+  only for operations that have none.
+
+
 ## Multiple endpoints and tags
 
 You can annotate each endpoint independently and group by tags.

--- a/src/azure_functions_openapi/adapters/__init__.py
+++ b/src/azure_functions_openapi/adapters/__init__.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from azure_functions_openapi.adapters.azure_functions import (
     build_function,
+    extract_auth_level,
     extract_http_binding,
     get_bindings,
     get_function_name,
@@ -21,6 +22,7 @@ from azure_functions_openapi.adapters.azure_functions import (
 
 __all__ = [
     "build_function",
+    "extract_auth_level",
     "extract_http_binding",
     "get_bindings",
     "get_function_name",

--- a/src/azure_functions_openapi/adapters/azure_functions.py
+++ b/src/azure_functions_openapi/adapters/azure_functions.py
@@ -237,3 +237,22 @@ def extract_http_binding(function: Any) -> Any | None:
         if str(getattr(binding, "type", "")).lower() == _HTTP_TRIGGER_TYPE:
             return binding
     return None
+
+
+def extract_auth_level(binding: Any) -> str | None:
+    """Return the HTTP-trigger binding's ``auth_level`` as a lowercase string.
+
+    Azure Functions exposes the per-route auth level (declared via
+    ``@app.route(auth_level=...)``) on the HTTP-trigger binding as an
+    ``AuthLevel`` enum (e.g. ``AuthLevel.FUNCTION``). We normalize it to the
+    enum's lowercase string value (``"anonymous"`` / ``"function"`` /
+    ``"admin"``) so downstream consumers never import the SDK enum. Returns
+    ``None`` when the binding carries no ``auth_level`` (e.g. a non-trigger
+    binding), guarding every read so an SDK shape change degrades to ``None``
+    rather than raising.
+    """
+    level = getattr(binding, "auth_level", None)
+    if level is None:
+        return None
+    value = getattr(level, "value", level)
+    return str(value).lower()

--- a/src/azure_functions_openapi/bridge.py
+++ b/src/azure_functions_openapi/bridge.py
@@ -49,6 +49,20 @@ def _tag_skew(entry: dict[str, Any], codes: Iterable[WarningCode]) -> None:
     entry["_skew_flags"] = sorted(merged)
 
 
+def _stamp_auth_level(entry: dict[str, Any], auth_level: str | None) -> None:
+    """Record the binding's normalized ``auth_level`` on a registry entry.
+
+    Stored under the private ``_auth_level`` key (lowercase ``AuthLevel`` value)
+    so :func:`azure_functions_openapi.spec.generate_openapi_spec` can optionally
+    derive an OpenAPI security requirement from it when ``infer_auth_level`` is
+    enabled. A ``None`` level (non-HTTP binding, or an SDK that does not expose
+    ``auth_level``) is not stamped, leaving the entry untouched.
+    """
+    if auth_level is None:
+        return
+    entry["_auth_level"] = auth_level
+
+
 def _normalize_method(method: Any) -> str:
     if method is None:
         return "get"
@@ -509,6 +523,11 @@ def scan_endpoint_metadata(
         # but to keep meta["route"] as the binding's source-of-truth route rather
         # than a pre-normalized path that already folds in the prefix.
         raw_route = getattr(binding, "route", None)
+        # Per-route auth level (declared via ``@app.route(auth_level=...)``)
+        # lives on the HTTP-trigger binding, not the app default. Capture it as
+        # a normalized lowercase string so spec.py can optionally infer an
+        # OpenAPI security requirement from it (#482).
+        auth_level = adapters.extract_auth_level(binding)
 
         canonical_id = canonical_function_id(handler)
 
@@ -699,6 +718,21 @@ def scan_endpoint_metadata(
                 registered = reg.get(endpoint_key)
                 if registered is not None:
                     _tag_skew(registered, entry_skew)
+
+        # Stamp the per-route auth level onto every operation this function
+        # produced so spec.py can infer security when ``infer_auth_level`` is on
+        # (#482). Stamping is done here, after all terminal branches, because the
+        # method loop has several exit points (explode / plain / merge /
+        # register); resolving each finalized entry once here keeps the capture
+        # in a single place. Re-stamping is idempotent.
+        if auth_level is not None:
+            with reg.lock:
+                if canonical_target is not None:
+                    _stamp_auth_level(canonical_target, auth_level)
+                for method in methods:
+                    entry = reg.get(f"{method}::{path}")
+                    if entry is not None:
+                        _stamp_auth_level(entry, auth_level)
 
         # After exploding a method=None @openapi entry into per-method entries,
         # drop the original so spec.py does not additionally emit it as a bare

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -37,6 +37,42 @@ DEFAULT_OPENAPI_INFO_DESCRIPTION = (
 )
 
 
+# Auth-level inference (#482). Azure Functions declares a per-route auth policy
+# via ``@app.route(auth_level=...)``. When ``infer_auth_level`` is enabled, that
+# policy is translated into an OpenAPI security requirement + scheme so users do
+# not have to repeat it in ``@openapi(...)``. The scheme name is a stable
+# documented constant so downstream tooling can reference it.
+AZURE_FUNCTION_KEY_SCHEME_NAME = "AzureFunctionKey"
+_AZURE_FUNCTION_KEY_SCHEME: dict[str, Any] = {
+    "type": "apiKey",
+    "in": "header",
+    "name": "x-functions-key",
+}
+
+
+def _infer_auth_security(
+    auth_level: Any,
+) -> tuple[list[dict[str, list[str]]], dict[str, dict[str, Any]]] | None:
+    """Map a normalized ``auth_level`` to an OpenAPI (security, scheme) pair.
+
+    ``auth_level`` is the lowercase ``AuthLevel`` value captured on the binding
+    by the bridge scan (``"anonymous"`` / ``"function"`` / ``"admin"``).
+
+    * ``"anonymous"`` -> ``None`` (the endpoint is public; inject nothing).
+    * ``"function"`` / ``"admin"`` -> an ``apiKey`` ``x-functions-key`` scheme.
+      Both levels are satisfied by a function/master key sent in the
+      ``x-functions-key`` header, so they share one scheme.
+    * Anything else (unknown/missing) -> ``None`` so an SDK change never
+      fabricates a wrong requirement.
+    """
+    if auth_level in ("function", "admin"):
+        return (
+            [{AZURE_FUNCTION_KEY_SCHEME_NAME: []}],
+            {AZURE_FUNCTION_KEY_SCHEME_NAME: dict(_AZURE_FUNCTION_KEY_SCHEME)},
+        )
+    return None
+
+
 def get_openapi_registry() -> dict[str, dict[str, Any]]:
     """Return a snapshot of the process-wide OpenAPI metadata registry.
 
@@ -310,6 +346,7 @@ def generate_openapi_spec(
     strict: bool = False,
     registry: OpenAPIRegistry | None = None,
     hoist_flat_schemas: bool = False,
+    infer_auth_level: bool = False,
 ) -> dict[str, Any]:
     """
     Compile an OpenAPI specification from the registry.
@@ -334,6 +371,16 @@ def generate_openapi_spec(
             ``components.schemas`` under their ``title`` and replaced with a
             ``$ref``, deduplicating schemas reused across endpoints. Defaults to
             ``False`` to preserve the verbatim inline-schema behaviour.
+        infer_auth_level: When ``True`` (opt-in, #482), derive an OpenAPI
+            security requirement from each operation's Azure Functions
+            ``auth_level`` (captured on the binding during the metadata scan).
+            ``FUNCTION``/``ADMIN`` map to an ``apiKey`` ``x-functions-key``
+            scheme named ``AzureFunctionKey``; ``ANONYMOUS`` injects nothing.
+            Inference is only applied to operations that supply no explicit
+            ``@openapi(security=...)`` — user-declared security always wins.
+            Requires the FunctionApp-scan path (e.g. CLI ``module:variable``);
+            a plain ``@openapi``-only registry carries no ``auth_level``.
+            Defaults to ``False`` for full backward compatibility.
 
     Returns:
         OpenAPI specification dictionary
@@ -548,6 +595,14 @@ def generate_openapi_spec(
 
                 # security --------------------------------------------------------
                 security: list[dict[str, list[str]]] = meta.get("security", [])
+                # Infer from auth_level only when the operation declares no
+                # explicit security (user-declared security always wins) and the
+                # opt-in flag is set (#482). The binding-captured ``_auth_level``
+                # is only present on the FunctionApp-scan path.
+                if infer_auth_level and not security:
+                    _inferred = _infer_auth_security(meta.get("_auth_level"))
+                    if _inferred is not None:
+                        security = _inferred[0]
 
                 # requestBody schema (POST/PUT/PATCH/DELETE) ----------------------
                 request_body_obj: dict[str, Any] | None = None
@@ -666,6 +721,20 @@ def generate_openapi_spec(
                             f"new={definition!r}"
                         )
                     all_security_schemes[name] = definition
+            # Add the inferred Azure function-key scheme for operations that
+            # relied on auth_level inference (#482). Only when the operation
+            # declared neither explicit security nor an explicit scheme, and
+            # only if the name is free — a user scheme of the same name always
+            # wins (no collision error is raised for the inferred default).
+            if (
+                infer_auth_level
+                and not meta.get("security")
+                and not meta.get("security_scheme")
+            ):
+                _inferred = _infer_auth_security(meta.get("_auth_level"))
+                if _inferred is not None:
+                    for name, definition in _inferred[1].items():
+                        all_security_schemes.setdefault(name, definition)
 
         if all_security_schemes:
             components["securitySchemes"] = all_security_schemes
@@ -922,6 +991,7 @@ def get_openapi_json(
     strict: bool = False,
     registry: OpenAPIRegistry | None = None,
     hoist_flat_schemas: bool = False,
+    infer_auth_level: bool = False,
 ) -> str:
     """Return the spec as pretty-printed JSON (UTF-8).
 
@@ -941,6 +1011,9 @@ def get_openapi_json(
         hoist_flat_schemas: When ``True`` (opt-in, #375), structured flat
             schemas are promoted into ``components.schemas``. Defaults to
             ``False`` to preserve the existing generated spec shape.
+        infer_auth_level: When ``True`` (opt-in, #482), derive OpenAPI security
+            from each operation's Azure Functions ``auth_level``. Defaults to
+            ``False``. See :func:`generate_openapi_spec` for details.
 
     Returns:
         OpenAPI spec in JSON format.
@@ -955,6 +1028,7 @@ def get_openapi_json(
             route_prefix=route_prefix,
             strict=strict,
             hoist_flat_schemas=hoist_flat_schemas,
+            infer_auth_level=infer_auth_level,
             registry=registry,
         )
         return json.dumps(spec, indent=2, ensure_ascii=False)
@@ -975,6 +1049,7 @@ def get_openapi_yaml(
     strict: bool = False,
     registry: OpenAPIRegistry | None = None,
     hoist_flat_schemas: bool = False,
+    infer_auth_level: bool = False,
 ) -> str:
     """Return the spec as YAML.
 
@@ -994,6 +1069,9 @@ def get_openapi_yaml(
         hoist_flat_schemas: When ``True`` (opt-in, #375), structured flat
             schemas are promoted into ``components.schemas``. Defaults to
             ``False`` to preserve the existing generated spec shape.
+        infer_auth_level: When ``True`` (opt-in, #482), derive OpenAPI security
+            from each operation's Azure Functions ``auth_level``. Defaults to
+            ``False``. See :func:`generate_openapi_spec` for details.
 
     Returns:
         OpenAPI spec in YAML format.
@@ -1008,6 +1086,7 @@ def get_openapi_yaml(
             route_prefix=route_prefix,
             strict=strict,
             hoist_flat_schemas=hoist_flat_schemas,
+            infer_auth_level=infer_auth_level,
             registry=registry,
         )
         return yaml.safe_dump(spec, sort_keys=False, allow_unicode=True)

--- a/tests/test_auth_level_inference.py
+++ b/tests/test_auth_level_inference.py
@@ -1,0 +1,210 @@
+"""Tests for Azure Functions ``auth_level`` -> OpenAPI security inference (#482)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import azure.functions as func
+import pytest
+
+from azure_functions_openapi.adapters import extract_auth_level, extract_http_binding
+from azure_functions_openapi.bridge import scan_endpoint_metadata
+from azure_functions_openapi.decorator import clear_openapi_registry, openapi
+from azure_functions_openapi.registry import OpenAPIRegistry
+from azure_functions_openapi.spec import (
+    AZURE_FUNCTION_KEY_SCHEME_NAME,
+    _infer_auth_security,
+    generate_openapi_spec,
+)
+
+_FUNCTION_KEY_SCHEME = {
+    "type": "apiKey",
+    "in": "header",
+    "name": "x-functions-key",
+}
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+def _scan(app: func.FunctionApp) -> OpenAPIRegistry:
+    reg = OpenAPIRegistry()
+    scan_endpoint_metadata(app, registry=reg)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# Unit: mapping helper
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("level", ["function", "admin"])
+def test_infer_auth_security_maps_keyed_levels(level: str) -> None:
+    inferred = _infer_auth_security(level)
+    assert inferred is not None
+    security, schemes = inferred
+    assert security == [{AZURE_FUNCTION_KEY_SCHEME_NAME: []}]
+    assert schemes == {AZURE_FUNCTION_KEY_SCHEME_NAME: _FUNCTION_KEY_SCHEME}
+
+
+@pytest.mark.parametrize("level", ["anonymous", None, "", "unknown"])
+def test_infer_auth_security_returns_none_for_public_or_unknown(level: Any) -> None:
+    assert _infer_auth_security(level) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit: adapter binding read
+# ---------------------------------------------------------------------------
+
+
+def test_extract_auth_level_reads_binding_enum() -> None:
+    app = func.FunctionApp()
+
+    @app.route(route="x", auth_level=func.AuthLevel.FUNCTION, methods=["GET"])
+    def x(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover - body unused
+        return func.HttpResponse("ok")
+
+    built = app._function_builders[0].build(app.auth_level)
+    binding = extract_http_binding(built)
+    assert extract_auth_level(binding) == "function"
+
+
+def test_extract_auth_level_none_when_absent() -> None:
+    class _NoAuth:
+        auth_level = None
+
+    assert extract_auth_level(_NoAuth()) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: end-to-end spec generation
+# ---------------------------------------------------------------------------
+
+
+def test_function_level_infers_security_when_enabled() -> None:
+    app = func.FunctionApp()
+
+    @openapi(summary="orders")
+    @app.route(route="orders", auth_level=func.AuthLevel.FUNCTION, methods=["GET"])
+    def orders(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("ok")
+
+    reg = _scan(app)
+    spec = generate_openapi_spec(registry=reg, infer_auth_level=True)
+
+    assert spec["paths"]["/api/orders"]["get"]["security"] == [{AZURE_FUNCTION_KEY_SCHEME_NAME: []}]
+    assert spec["components"]["securitySchemes"] == {
+        AZURE_FUNCTION_KEY_SCHEME_NAME: _FUNCTION_KEY_SCHEME
+    }
+
+
+def test_admin_level_infers_function_key_scheme() -> None:
+    app = func.FunctionApp()
+
+    @openapi(summary="admin")
+    @app.route(route="admin", auth_level=func.AuthLevel.ADMIN, methods=["GET"])
+    def admin(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("ok")
+
+    reg = _scan(app)
+    spec = generate_openapi_spec(registry=reg, infer_auth_level=True)
+
+    assert spec["paths"]["/api/admin"]["get"]["security"] == [{AZURE_FUNCTION_KEY_SCHEME_NAME: []}]
+    assert AZURE_FUNCTION_KEY_SCHEME_NAME in spec["components"]["securitySchemes"]
+
+
+def test_anonymous_level_injects_no_security() -> None:
+    app = func.FunctionApp()
+
+    @openapi(summary="ping")
+    @app.route(route="ping", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+    def ping(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("ok")
+
+    reg = _scan(app)
+    spec = generate_openapi_spec(registry=reg, infer_auth_level=True)
+
+    assert "security" not in spec["paths"]["/api/ping"]["get"]
+    assert "securitySchemes" not in spec.get("components", {})
+
+
+def test_inference_off_by_default() -> None:
+    app = func.FunctionApp()
+
+    @openapi(summary="orders")
+    @app.route(route="orders", auth_level=func.AuthLevel.FUNCTION, methods=["GET"])
+    def orders(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("ok")
+
+    reg = _scan(app)
+    spec = generate_openapi_spec(registry=reg)
+
+    assert "security" not in spec["paths"]["/api/orders"]["get"]
+    assert "securitySchemes" not in spec.get("components", {})
+
+
+def test_user_declared_security_wins_over_inference() -> None:
+    app = func.FunctionApp()
+
+    @openapi(
+        summary="custom",
+        security=[{"MyAuth": []}],
+        security_scheme={"MyAuth": {"type": "http", "scheme": "bearer"}},
+    )
+    @app.route(route="custom", auth_level=func.AuthLevel.FUNCTION, methods=["GET"])
+    def custom(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("ok")
+
+    reg = _scan(app)
+    spec = generate_openapi_spec(registry=reg, infer_auth_level=True)
+
+    op = spec["paths"]["/api/custom"]["get"]
+    assert op["security"] == [{"MyAuth": []}]
+    schemes = spec["components"]["securitySchemes"]
+    assert schemes["MyAuth"] == {"type": "http", "scheme": "bearer"}
+    # No inferred scheme is injected for an operation that declared its own.
+    assert AZURE_FUNCTION_KEY_SCHEME_NAME not in schemes
+
+
+def test_mixed_levels_share_single_scheme() -> None:
+    app = func.FunctionApp()
+
+    @openapi(summary="orders")
+    @app.route(route="orders", auth_level=func.AuthLevel.FUNCTION, methods=["GET"])
+    def orders(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("ok")
+
+    @openapi(summary="ping")
+    @app.route(route="ping", auth_level=func.AuthLevel.ANONYMOUS, methods=["GET"])
+    def ping(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("ok")
+
+    reg = _scan(app)
+    spec = generate_openapi_spec(registry=reg, infer_auth_level=True)
+
+    assert spec["components"]["securitySchemes"] == {
+        AZURE_FUNCTION_KEY_SCHEME_NAME: _FUNCTION_KEY_SCHEME
+    }
+    assert "security" in spec["paths"]["/api/orders"]["get"]
+    assert "security" not in spec["paths"]["/api/ping"]["get"]
+
+
+def test_get_openapi_json_forwards_infer_auth_level() -> None:
+    import json
+
+    from azure_functions_openapi.spec import get_openapi_json
+
+    app = func.FunctionApp()
+
+    @openapi(summary="orders")
+    @app.route(route="orders", auth_level=func.AuthLevel.FUNCTION, methods=["GET"])
+    def orders(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+        return func.HttpResponse("ok")
+
+    reg = _scan(app)
+    payload = json.loads(get_openapi_json(registry=reg, infer_auth_level=True))
+    assert AZURE_FUNCTION_KEY_SCHEME_NAME in payload["components"]["securitySchemes"]

--- a/tests/test_openapi_enhanced.py
+++ b/tests/test_openapi_enhanced.py
@@ -191,6 +191,7 @@ class TestGetOpenAPIJSONEnhanced:
                 route_prefix="/api",
                 strict=False,
                 hoist_flat_schemas=False,
+                infer_auth_level=False,
                 registry=None,
             )
 
@@ -221,6 +222,7 @@ class TestGetOpenAPIJSONEnhanced:
                 route_prefix="/api",
                 strict=False,
                 hoist_flat_schemas=False,
+                infer_auth_level=False,
                 registry=None,
             )
 
@@ -260,6 +262,7 @@ class TestGetOpenAPIYAMLEnhanced:
                 route_prefix="/api",
                 strict=False,
                 hoist_flat_schemas=False,
+                infer_auth_level=False,
                 registry=None,
             )
 
@@ -290,6 +293,7 @@ class TestGetOpenAPIYAMLEnhanced:
                 route_prefix="/api",
                 strict=False,
                 hoist_flat_schemas=False,
+                infer_auth_level=False,
                 registry=None,
             )
 


### PR DESCRIPTION
## Summary

- Adds an opt-in `infer_auth_level` flag (default `False`) to `generate_openapi_spec`, `get_openapi_json`, and `get_openapi_yaml` that derives an OpenAPI security requirement + scheme directly from a route's Azure Functions `auth_level` — an Azure-native integration FastAPI cannot replicate.
- `FUNCTION`/`ADMIN` map to an `apiKey` `x-functions-key` scheme named `AzureFunctionKey` (documented constant); `ANONYMOUS` injects nothing.
- Inference only fills operations with **no** user-supplied `security`/`security_scheme` (user values always win), and only on the FunctionApp-scan path where the HTTP-trigger binding carries `auth_level`.

## Implementation

- `adapters/azure_functions.py`: new `extract_auth_level(binding)` helper (normalizes the `AuthLevel` enum to a lowercase string; degrades to `None` on SDK shape changes), re-exported from `adapters/__init__.py`.
- `bridge.py`: `scan_endpoint_metadata` captures the binding's `auth_level` and stamps it onto every finalized registry entry via `_stamp_auth_level` (private `_auth_level` key, idempotent).
- `spec.py`: `AZURE_FUNCTION_KEY_SCHEME_NAME` constant + `_infer_auth_security()` helper; security requirement and `securitySchemes` injection gated on the opt-in flag, using `setdefault` so a user scheme of the same name always wins (no collision error for the inferred default).

## Testing

- New `tests/test_auth_level_inference.py` covers FUNCTION, ADMIN, ANONYMOUS, user-override precedence, and the flag being off by default.
- Updated `tests/test_openapi_enhanced.py` call-assertions for the new forwarded kwarg.
- Full suite: **763 passed, 6 skipped**; coverage **95.55%** (≥95% gate). `make lint` and `make typecheck` clean.

## Docs

- README: new bullet under "What it does".
- `docs/usage.md`: new "Infer security from `auth_level` (opt-in)" section documenting the mapping, generated output, the binding-scan-path requirement, and the opt-in flag.

Closes #482