### PR TITLE
feat(decorator): add typed path=/headers= parameters for @openapi

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -307,6 +307,56 @@ Use OpenAPI Parameter Objects in `parameters`.
 )
 ```
 
+### Typed parameters with Pydantic (`path=` / `headers=`)
+
+Writing raw parameter dicts is verbose. For **path** and **header** parameters
+you can pass a Pydantic model instead and let each field expand into a
+parameter entry — mirroring the Pydantic-first ergonomics of `requests=` /
+`responses=`.
+
+```python
+from pydantic import BaseModel, Field
+
+
+class OrderPath(BaseModel):
+    order_id: int
+
+
+class OrderHeaders(BaseModel):
+    correlation_id: str = Field(alias="X-Correlation-ID", description="Trace id")
+
+
+@openapi(
+    summary="Get order",
+    method="get",
+    route="/api/orders/{order_id}",
+    path=OrderPath,
+    headers=OrderHeaders,
+)
+def get_order(req): ...
+```
+
+Rules:
+
+- **`path=`** — every field becomes `in: path` and is always `required: true`
+  (per the OpenAPI spec).
+- **`headers=`** — every field becomes `in: header`; `required` follows the
+  model (a field with no default is required, an `Optional`/defaulted field is
+  not).
+- Field **aliases** are used as the wire parameter name; field `description`
+  flows onto the parameter.
+- Only scalar, enum, and array-of-scalar fields are allowed. **Nested-object
+  fields are rejected** because path/header parameters cannot carry objects.
+- Typed params **merge** with any raw `parameters=` you also pass. A duplicate
+  `(name, in)` pair raises an error instead of silently overriding.
+- `query=` is intentionally not offered here — use the OpenAPI 3.2
+  [`querystring=`](#the-query-http-method-openapi-32) surface for typed query
+  input.
+
+> Like the rest of `@openapi`, this is **documentation only** — it does not
+> parse or validate requests at runtime. For runtime validation, layer
+> [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python).
+
 ## Security documentation
 
 You can define security at operation-level and component-level.

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -204,6 +204,9 @@ def openapi(
     route: str | None = None,
     method: str | None = None,
     parameters: list[dict[str, Any]] | None = None,
+    # ── typed parameters (documentation sugar) ──────────────────
+    path: type[BaseModel] | None = None,
+    headers: type[BaseModel] | None = None,
     security: list[dict[str, list[str]]] | None = None,
     security_scheme: dict[str, dict[str, Any]] | None = None,
     # ── request / response schema ───────────────────────────────
@@ -291,7 +294,15 @@ def openapi(
         HTTP method (matching the Azure runtime). A bare ``@openapi`` with no
         route binding and no ``method=`` emits a single ``get`` operation.
     parameters:
-        List of param objects (query/path/header/cookie).
+        List of raw OpenAPI param objects (query/path/header/cookie).
+    path:
+        Pydantic model whose fields document ``in: path`` parameters. Every
+        field becomes ``required: true``. Nested-object fields are rejected.
+        Documentation only — no runtime validation.
+    headers:
+        Pydantic model whose fields document ``in: header`` parameters.
+        Requiredness follows the model's optional/required fields. Nested-object
+        fields are rejected. Documentation only — no runtime validation.
     security:
         List of OpenAPI Security Requirement Objects.
         Example: [{"BearerAuth": []}]
@@ -390,6 +401,9 @@ def openapi(
                 operation_id, metadata_func.__name__
             )
             validated_parameters = _validate_parameters(parameters, metadata_func.__name__)
+            validated_parameters = _merge_typed_parameters(
+                validated_parameters, path, headers, metadata_func.__name__
+            )
             validated_security = _validate_security(security, metadata_func.__name__)
             validated_security_scheme = _validate_security_scheme(
                 security_scheme, metadata_func.__name__
@@ -806,6 +820,128 @@ def _validate_and_sanitize_operation_id(operation_id: str | None, func_name: str
         raise ValueError(f"Invalid operation ID: {operation_id}")
 
     return sanitized
+
+
+def _inline_param_defs(node: Any, defs: dict[str, Any], seen: frozenset[str]) -> Any:
+    """Recursively inline ``$ref`` targets from ``$defs`` into ``node``.
+
+    Pydantic represents enums and nested models as ``$ref`` entries pointing at
+    ``$defs``. Inlining lets the parameter-schema validator inspect the real
+    shape (enum vs object) instead of an opaque reference. A ``seen`` guard
+    prevents infinite recursion on self-referential models.
+    """
+    if isinstance(node, dict):
+        ref = node.get("$ref")
+        if isinstance(ref, str):
+            name = ref.rsplit("/", 1)[-1]
+            if name in seen:
+                return {}
+            target = defs.get(name, {})
+            return _inline_param_defs(target, defs, seen | {name})
+        return {k: _inline_param_defs(v, defs, seen) for k, v in node.items()}
+    if isinstance(node, list):
+        return [_inline_param_defs(item, defs, seen) for item in node]
+    return node
+
+
+def _assert_param_schema_scalar(
+    schema: dict[str, Any], location: str, field: str, func_name: str
+) -> None:
+    """Reject object-shaped schemas for ``path``/``header`` parameters.
+
+    OpenAPI ``path`` and ``header`` parameters must be primitives, enums, or
+    arrays of primitives. Nested models (objects) are invalid, so an explicit,
+    early error is raised instead of emitting a malformed spec.
+    """
+    if schema.get("type") == "object" or "properties" in schema:
+        raise OpenAPISpecConfigError(
+            f"Field '{field}' of the '{location}' model for '{func_name}' maps to "
+            f"an object schema, which is invalid for '{location}' parameters. "
+            f"Use scalar, enum, or array-of-scalar fields only."
+        )
+    if schema.get("type") == "array":
+        items = schema.get("items")
+        if isinstance(items, dict):
+            _assert_param_schema_scalar(items, location, field, func_name)
+    for combinator in ("anyOf", "allOf", "oneOf"):
+        for sub in schema.get(combinator, []):
+            if isinstance(sub, dict) and sub.get("type") != "null":
+                _assert_param_schema_scalar(sub, location, field, func_name)
+
+
+def _expand_model_parameters(
+    model: type[BaseModel] | None, location: str, func_name: str
+) -> list[dict[str, Any]]:
+    """Expand a Pydantic model into OpenAPI ``parameters`` entries.
+
+    Each model field becomes one parameter with ``in=location``. Field aliases
+    (when present) are used as the wire name. ``path`` parameters are always
+    ``required: true`` per the OpenAPI spec; ``header`` requiredness follows the
+    model's own required/optional field semantics. Nested-object fields are
+    rejected. This is documentation sugar only — it performs no runtime
+    validation.
+    """
+    if model is None:
+        return []
+    if not (isinstance(model, type) and issubclass(model, BaseModel)):
+        raise ValueError(f"'{location}' must be a Pydantic BaseModel subclass.")
+
+    schema = model.model_json_schema()
+    defs = schema.get("$defs", {})
+    properties: dict[str, Any] = schema.get("properties", {})
+    required_names = set(schema.get("required", []))
+
+    params: list[dict[str, Any]] = []
+    for name, raw_field_schema in properties.items():
+        field_schema = _inline_param_defs(raw_field_schema, defs, frozenset())
+        _assert_param_schema_scalar(field_schema, location, name, func_name)
+
+        field_schema.pop("title", None)
+        description = field_schema.pop("description", None)
+
+        param: dict[str, Any] = {"name": name, "in": location}
+        param["required"] = True if location == "path" else name in required_names
+        if description is not None:
+            param["description"] = description
+        param["schema"] = field_schema
+        params.append(param)
+    return params
+
+
+def _merge_typed_parameters(
+    base: list[dict[str, Any]],
+    path: type[BaseModel] | None,
+    headers: type[BaseModel] | None,
+    func_name: str,
+) -> list[dict[str, Any]]:
+    """Merge typed ``path``/``headers`` params into the raw ``parameters`` list.
+
+    On a duplicate ``(name, in)`` pair — across raw and typed params, or between
+    the two typed models — fail fast rather than silently overriding.
+    """
+    typed = _expand_model_parameters(path, "path", func_name) + _expand_model_parameters(
+        headers, "header", func_name
+    )
+    if not typed:
+        return base
+
+    merged = list(base)
+    seen = {
+        (p.get("name"), p.get("in"))
+        for p in merged
+        if isinstance(p, dict) and "name" in p
+    }
+    for param in typed:
+        key = (param["name"], param["in"])
+        if key in seen:
+            raise OpenAPISpecConfigError(
+                f"Duplicate parameter '{param['name']}' (in: {param['in']}) for "
+                f"'{func_name}': typed path=/headers= collides with an existing "
+                f"parameter. Remove the duplicate from parameters= or the model."
+            )
+        seen.add(key)
+        merged.append(param)
+    return merged
 
 
 def _validate_parameters(

--- a/tests/test_typed_parameters.py
+++ b/tests/test_typed_parameters.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Optional
+
+import azure.functions as func
+from pydantic import BaseModel, Field
+import pytest
+
+from azure_functions_openapi.decorator import (
+    _expand_model_parameters,
+    _merge_typed_parameters,
+    clear_openapi_registry,
+    openapi,
+)
+from azure_functions_openapi.exceptions import OpenAPISpecConfigError
+from azure_functions_openapi.spec import generate_openapi_spec
+
+
+class Color(str, Enum):
+    red = "red"
+    blue = "blue"
+
+
+class PathModel(BaseModel):
+    id: int
+    color: Color
+
+
+class HeaderModel(BaseModel):
+    x_request_id: str = Field(alias="X-Request-Id")
+    x_trace: Optional[str] = None
+    verbose: bool = Field(default=False, description="Enable verbose output")
+
+
+class TestExpandModelParameters:
+    def test_path_fields_are_all_required(self) -> None:
+        params = _expand_model_parameters(PathModel, "path", "h")
+        assert [p["name"] for p in params] == ["id", "color"]
+        assert all(p["in"] == "path" for p in params)
+        assert all(p["required"] is True for p in params)
+
+    def test_enum_field_is_inlined_not_ref(self) -> None:
+        params = _expand_model_parameters(PathModel, "path", "h")
+        color = next(p for p in params if p["name"] == "color")
+        assert "$ref" not in color["schema"]
+        assert color["schema"]["enum"] == ["red", "blue"]
+
+    def test_scalar_schema_is_preserved(self) -> None:
+        params = _expand_model_parameters(PathModel, "path", "h")
+        ident = next(p for p in params if p["name"] == "id")
+        assert ident["schema"] == {"type": "integer"}
+
+    def test_header_alias_becomes_parameter_name(self) -> None:
+        params = _expand_model_parameters(HeaderModel, "header", "h")
+        names = [p["name"] for p in params]
+        assert "X-Request-Id" in names
+        assert "x_request_id" not in names
+
+    def test_header_requiredness_follows_model(self) -> None:
+        params = _expand_model_parameters(HeaderModel, "header", "h")
+        by_name = {p["name"]: p for p in params}
+        assert by_name["X-Request-Id"]["required"] is True
+        assert by_name["x_trace"]["required"] is False
+        assert by_name["verbose"]["required"] is False
+
+    def test_description_flows_to_parameter_level(self) -> None:
+        params = _expand_model_parameters(HeaderModel, "header", "h")
+        verbose = next(p for p in params if p["name"] == "verbose")
+        assert verbose["description"] == "Enable verbose output"
+        assert "description" not in verbose["schema"]
+
+    def test_none_model_returns_empty(self) -> None:
+        assert _expand_model_parameters(None, "path", "h") == []
+
+    def test_non_model_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Pydantic BaseModel"):
+            _expand_model_parameters(dict, "path", "h")  # type: ignore[arg-type]
+
+    def test_nested_object_field_rejected(self) -> None:
+        class Nested(BaseModel):
+            inner: PathModel
+
+        with pytest.raises(OpenAPISpecConfigError, match="object schema"):
+            _expand_model_parameters(Nested, "path", "h")
+
+    def test_array_of_scalars_allowed(self) -> None:
+        class Q(BaseModel):
+            ids: list[int]
+
+        params = _expand_model_parameters(Q, "header", "h")
+        assert params[0]["schema"]["type"] == "array"
+        assert params[0]["schema"]["items"] == {"type": "integer"}
+
+    def test_array_of_objects_rejected(self) -> None:
+        class Q(BaseModel):
+            rows: list[PathModel]
+
+        with pytest.raises(OpenAPISpecConfigError, match="object schema"):
+            _expand_model_parameters(Q, "header", "h")
+
+
+class TestMergeTypedParameters:
+    def test_no_typed_models_returns_base_unchanged(self) -> None:
+        base = [{"name": "q", "in": "query", "schema": {"type": "string"}}]
+        assert _merge_typed_parameters(base, None, None, "h") is base
+
+    def test_typed_params_appended_to_base(self) -> None:
+        base = [{"name": "q", "in": "query", "schema": {"type": "string"}}]
+        merged = _merge_typed_parameters(base, PathModel, None, "h")
+        assert len(merged) == 3
+        assert {p["name"] for p in merged} == {"q", "id", "color"}
+
+    def test_same_name_different_location_is_allowed(self) -> None:
+        class P(BaseModel):
+            token: str
+
+        class H(BaseModel):
+            token: str
+
+        merged = _merge_typed_parameters([], P, H, "h")
+        locations = {(p["name"], p["in"]) for p in merged}
+        assert locations == {("token", "path"), ("token", "header")}
+
+    def test_collision_with_raw_parameters_fails_fast(self) -> None:
+        base = [{"name": "id", "in": "path", "schema": {"type": "string"}}]
+        with pytest.raises(OpenAPISpecConfigError, match="Duplicate parameter"):
+            _merge_typed_parameters(base, PathModel, None, "h")
+
+
+class TestIntegration:
+    def teardown_method(self) -> None:
+        clear_openapi_registry()
+
+    def test_spec_includes_typed_path_and_header_params(self) -> None:
+        clear_openapi_registry()
+        app = func.FunctionApp()
+
+        @openapi(summary="get item", path=PathModel, headers=HeaderModel)
+        @app.route(route="items/{id}", methods=["GET"])
+        def handler(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+            return func.HttpResponse("ok")
+
+        spec = generate_openapi_spec()
+        key = next(k for k in spec["paths"] if k.endswith("/items/{id}"))
+        params = spec["paths"][key]["get"]["parameters"]
+        by_name = {p["name"]: p for p in params}
+        assert by_name["id"]["in"] == "path"
+        assert by_name["id"]["required"] is True
+        assert by_name["X-Request-Id"]["in"] == "header"
+
+    def test_typed_and_raw_parameters_merge_in_spec(self) -> None:
+        clear_openapi_registry()
+        app = func.FunctionApp()
+
+        @openapi(
+            summary="list",
+            parameters=[{"name": "q", "in": "query", "schema": {"type": "string"}}],
+            headers=HeaderModel,
+        )
+        @app.route(route="search", methods=["GET"])
+        def handler(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover
+            return func.HttpResponse("ok")
+
+        spec = generate_openapi_spec()
+        key = next(k for k in spec["paths"] if k.endswith("/search"))
+        names = {p["name"] for p in spec["paths"][key]["get"]["parameters"]}
+        assert "q" in names
+        assert "X-Request-Id" in names


### PR DESCRIPTION
## Summary
- Adds `@openapi(path=Model, headers=Model)` — Pydantic models expand into OpenAPI `parameters` entries, closing the DX gap where bodies were Pydantic-first but path/header params required hand-written raw dicts.
- **Path** fields are always `required: true`; **header** requiredness follows the model. Field aliases become the parameter name; `description` flows through; enums are inlined; **nested-object fields are rejected**.
- Typed params **merge** with raw `parameters=`; a duplicate `(name, in)` pair raises `OpenAPISpecConfigError` (no silent override).
- Documentation only — no runtime validation, no dependency on `azure-functions-validation`.
- `query=` intentionally deferred (overlaps the existing OpenAPI 3.2 `querystring=` surface).

## Scope note
Scope was narrowed on design review: only `path=`/`headers=` land now; `query=` is out of scope to avoid two competing query abstractions.

## Testing
- New `tests/test_typed_parameters.py` (17 tests): path-always-required, header requiredness, alias, enum inlining, nested/array-of-object rejection, raw-param collision, same-name-different-location, full spec integration.
- Full suite: coverage **95.59%** (≥95% gate met). Pre-existing unrelated failure: `test_version_matches_distribution_metadata` (dev env dist metadata 0.22.0 vs source 0.23.0).
- `make lint` / `make typecheck` clean.

Closes #484