### PR TITLE
feat(spec): surface version-downgrade drops as structured warnings (#479)

### DIFF
--- a/src/azure_functions_openapi/_warnings.py
+++ b/src/azure_functions_openapi/_warnings.py
@@ -33,6 +33,7 @@ class WarningCode(str, Enum):
     DISCOVERY_SKIPPED = "discovery-skipped"
     EMPTY_DISCOVERY = "empty-discovery"
     METHOD_BINDING_MISMATCH = "method-binding-mismatch"
+    VERSION_DOWNGRADE_DROP = "version-downgrade-drop"
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return self.value

--- a/src/azure_functions_openapi/registry.py
+++ b/src/azure_functions_openapi/registry.py
@@ -38,6 +38,7 @@ class OpenAPIRegistry:
         self._discovery_warnings: list[tuple[str | None, str]] = []
         self._empty_discoveries: list[str] = []
         self._duplicate_operations: list[str] = []
+        self._downgrade_drops: list[str] = []
         self._lock = threading.RLock()
 
     @property
@@ -126,6 +127,7 @@ class OpenAPIRegistry:
             self._discovery_warnings.clear()
             self._empty_discoveries.clear()
             self._duplicate_operations.clear()
+            self._downgrade_drops.clear()
 
     def clear_duplicate_operations(self) -> None:
         """Clear only the duplicate-operation channel, under :attr:`lock`.
@@ -137,6 +139,18 @@ class OpenAPIRegistry:
         """
         with self._lock:
             self._duplicate_operations.clear()
+
+    def clear_downgrade_drops(self) -> None:
+        """Clear only the version-downgrade-drop channel, under :attr:`lock`.
+
+        Downgrade drops are fully recomputed on every
+        :func:`generate_openapi_spec` pass (they depend on the requested target
+        ``openapi_version``), so that generator clears this channel at entry to
+        avoid reporting a drop that a prior generation observed but the current
+        target version no longer produces.
+        """
+        with self._lock:
+            self._downgrade_drops.clear()
 
     def find_by_function_id(
         self, function_id: str, method: str | None = None
@@ -260,6 +274,28 @@ class OpenAPIRegistry:
         """Return the recorded ``METHOD path`` collisions, deduplicated and sorted."""
         with self._lock:
             return sorted(self._duplicate_operations)
+
+    def add_downgrade_drop(self, message: str) -> None:
+        """Record that a construct was dropped when downgrading the spec version.
+
+        When generating a spec for an *older* target ``openapi_version``, the
+        generator restructures or removes constructs the older version cannot
+        express (unsupported query parameters, ``additionalOperations``, and the
+        3.2 ``itemSchema`` media key). Historically those drops were only logged,
+        so ``--fail-on-warnings`` could not observe silently vanished API
+        contract. Recording them here lets the generator surface a structured
+        ``version-downgrade-drop`` warning. Identical messages are deduplicated,
+        mirroring :meth:`add_duplicate_operation`.
+        """
+        with self._lock:
+            if message not in self._downgrade_drops:
+                self._downgrade_drops.append(message)
+
+    @property
+    def downgrade_drops(self) -> list[str]:
+        """Return the recorded downgrade-drop messages, deduplicated and sorted."""
+        with self._lock:
+            return sorted(self._downgrade_drops)
 
 
 # Process-wide singleton. The ``@openapi`` decorator records metadata at import

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -404,6 +404,7 @@ def generate_openapi_spec(
         # here (#393).
         _diag_registry = registry if registry is not None else _default_registry
         _diag_registry.clear_duplicate_operations()
+        _diag_registry.clear_downgrade_drops()
         paths: dict[str, dict[str, Any]] = {}
         components: dict[str, Any] = {"schemas": {}}
 
@@ -756,12 +757,15 @@ def generate_openapi_spec(
         # operations, then relocated: under 3.2 into each path item's
         # ``additionalOperations`` map, and under 3.0/3.1 dropped (the format has
         # no way to express them) with a warning.
-        validation_warnings.extend(
-            _restructure_additional_operations(spec, openapi_version)
-        )
-        # ``query`` is a first-class operation field only in OpenAPI 3.2; under
-        # 3.0/3.1 it cannot be represented, so drop it with a warning.
-        validation_warnings.extend(_drop_unsupported_query(spec, openapi_version))
+        # Custom-method restructuring and query removal are the two constructs
+        # that vanish on a pre-3.2 downgrade. Record them on the registry's
+        # downgrade-drop channel so ``collect_spec_warnings`` / ``--fail-on-warnings``
+        # can observe silent API-contract loss (#479), in addition to logging.
+        downgrade_drops = _restructure_additional_operations(spec, openapi_version)
+        downgrade_drops.extend(_drop_unsupported_query(spec, openapi_version))
+        validation_warnings.extend(downgrade_drops)
+        for drop in downgrade_drops:
+            _diag_registry.add_downgrade_drop(drop)
         for warning in validation_warnings:
             logger.warning("OpenAPI spec validation: %s", warning)
 
@@ -1254,6 +1258,31 @@ def _collect_duplicate_operation_warnings(
     ]
 
 
+def _collect_downgrade_drop_warnings(
+    registry: OpenAPIRegistry | None = None,
+) -> list[SpecWarning]:
+    """Derive version-downgrade-drop warnings from the registry's recorded drops.
+
+    When a spec is generated for a pre-3.2 target, custom-method operations and
+    ``query`` operations cannot be represented and are removed (#471, #472);
+    :meth:`OpenAPIRegistry.add_downgrade_drop` records each removal during
+    generation. This turns each recorded drop into a structured
+    :class:`WarningCode.VERSION_DOWNGRADE_DROP` so ``--fail-on-warnings`` can
+    observe silently lost API contract instead of it only appearing in the logs
+    (#479). When ``registry`` is provided its records are used, keeping warnings
+    isolated to the same registry the spec was built from.
+    """
+    reg = registry if registry is not None else _default_registry
+    return [
+        SpecWarning(
+            code=WarningCode.VERSION_DOWNGRADE_DROP,
+            message=message,
+            function_name=None,
+        )
+        for message in reg.downgrade_drops
+    ]
+
+
 def _collect_binding_mismatch_warnings(
     registry: OpenAPIRegistry | None = None,
 ) -> list[SpecWarning]:
@@ -1351,6 +1380,7 @@ def collect_spec_warnings(
     warnings_list.extend(_collect_discovery_warnings(registry))
     warnings_list.extend(_collect_empty_discovery_warnings(registry))
     warnings_list.extend(_collect_duplicate_operation_warnings(registry))
+    warnings_list.extend(_collect_downgrade_drop_warnings(registry))
     warnings_list.extend(_collect_binding_mismatch_warnings(registry))
     for message in _validate_spec(spec):
         warnings_list.append(SpecWarning(code=WarningCode.SPEC_VALIDATION, message=message))

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -27,6 +27,8 @@ from azure_functions_openapi.exceptions import OpenAPISpecConfigError
 from azure_functions_openapi.registry import OpenAPIRegistry
 from azure_functions_openapi.registry import registry as default_registry
 from azure_functions_openapi.spec import (
+    OPENAPI_VERSION_3_1,
+    OPENAPI_VERSION_3_2,
     collect_spec_warnings,
     generate_openapi_report,
     generate_openapi_spec,
@@ -732,3 +734,103 @@ class TestCliIsolateApp:
         spec = json.loads(out.read_text(encoding="utf-8"))
         assert "/api/a/one" in spec["paths"]
         assert "/api/b/one" not in spec["paths"]
+
+
+
+class TestDowngradeDropWarnings:
+    """Constructs that cannot survive a pre-3.2 downgrade -- custom-method
+    operations (#471) and the ``query`` operation (#472) -- are removed from the
+    generated spec. Each removal must surface a structured VERSION_DOWNGRADE_DROP
+    warning so ``--fail-on-warnings`` observes the silent API-contract loss that
+    previously only reached the logs (#479)."""
+
+    def _custom_method_registry(self) -> OpenAPIRegistry:
+        reg = OpenAPIRegistry()
+        register_openapi_metadata(
+            path="/api/cache", method="purge", summary="Purge cache", registry=reg
+        )
+        return reg
+
+    def _query_registry(self) -> OpenAPIRegistry:
+        reg = OpenAPIRegistry()
+        register_openapi_metadata(
+            path="/api/search",
+            method="query",
+            summary="Query search",
+            request_body={"type": "object", "properties": {"q": {"type": "string"}}},
+            registry=reg,
+        )
+        return reg
+
+    def test_custom_method_drop_surfaces_structured_warning(self) -> None:
+        reg = self._custom_method_registry()
+        spec = generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_1, registry=reg)
+        drops = [
+            w
+            for w in collect_spec_warnings(spec, registry=reg)
+            if w.code == WarningCode.VERSION_DOWNGRADE_DROP
+        ]
+        assert len(drops) == 1
+        assert "PURGE" in drops[0].message
+        # The dropped operation really is gone from the spec.
+        assert "purge" not in spec["paths"]["/api/cache"]
+
+    def test_query_drop_surfaces_structured_warning(self) -> None:
+        reg = self._query_registry()
+        spec = generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_1, registry=reg)
+        drops = [
+            w
+            for w in collect_spec_warnings(spec, registry=reg)
+            if w.code == WarningCode.VERSION_DOWNGRADE_DROP
+        ]
+        assert len(drops) == 1
+        assert "query" in drops[0].message.lower()
+        assert "query" not in spec["paths"]["/api/search"]
+
+    def test_no_drop_warning_under_3_2(self) -> None:
+        reg = self._custom_method_registry()
+        spec = generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_2, registry=reg)
+        codes = {w.code for w in collect_spec_warnings(spec, registry=reg)}
+        assert WarningCode.VERSION_DOWNGRADE_DROP not in codes
+
+    def test_drop_warnings_are_deterministic_and_sorted(self) -> None:
+        reg = OpenAPIRegistry()
+        register_openapi_metadata(path="/api/r", method="purge", summary="a", registry=reg)
+        register_openapi_metadata(path="/api/r", method="link", summary="b", registry=reg)
+        spec = generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_1, registry=reg)
+        drops = [
+            w.message
+            for w in collect_spec_warnings(spec, registry=reg)
+            if w.code == WarningCode.VERSION_DOWNGRADE_DROP
+        ]
+        assert len(drops) == 2
+        assert drops == sorted(drops)
+
+    def test_resolved_drop_not_carried_to_next_generation(self) -> None:
+        # Run-scoped like DUPLICATE_OPERATION (#393): a drop observed while
+        # targeting 3.1 must not linger on the reused registry and resurface
+        # when the same registry is regenerated at 3.2.
+        reg = self._custom_method_registry()
+        first = collect_spec_warnings(
+            generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_1, registry=reg),
+            registry=reg,
+        )
+        assert any(w.code == WarningCode.VERSION_DOWNGRADE_DROP for w in first)
+        second = collect_spec_warnings(
+            generate_openapi_spec(openapi_version=OPENAPI_VERSION_3_2, registry=reg),
+            registry=reg,
+        )
+        assert not any(w.code == WarningCode.VERSION_DOWNGRADE_DROP for w in second)
+
+    def test_report_surfaces_downgrade_drop(self) -> None:
+        reg = self._custom_method_registry()
+        report = generate_openapi_report(openapi_version=OPENAPI_VERSION_3_1, registry=reg)
+        assert any(
+            w.code == WarningCode.VERSION_DOWNGRADE_DROP for w in report.warnings
+        )
+
+    def test_fail_on_warnings_catches_downgrade_drop(self) -> None:
+        # The global CLI path must exit non-zero: a silently dropped operation on
+        # a pre-3.2 target is exactly what --fail-on-warnings exists to catch.
+        register_openapi_metadata(path="/api/cache", method="purge", summary="Purge cache")
+        assert handle_generate(_args(fail_on_warnings=True, openapi_version="3.1")) == 2


### PR DESCRIPTION
## Summary
- When generating a spec for a **pre-3.2 target**, custom-method operations (#471) and `query` operations (#472) are removed, but that loss previously only reached the logs — `--fail-on-warnings` could not observe the silently dropped API contract.
- Adds a new registry diagnostics channel `_downgrade_drops` (mirroring the existing duplicate-operation channel) and emits a structured `WarningCode.VERSION_DOWNGRADE_DROP` via `collect_spec_warnings`.
- The channel is **run-scoped**: cleared at generation entry, so a drop observed on a 3.1 pass does not resurface when the same registry regenerates at 3.2 (mirrors the #393 fix for duplicate operations).

## Changes
- `_warnings.py`: add `WarningCode.VERSION_DOWNGRADE_DROP`.
- `registry.py`: `_downgrade_drops` channel — `add_downgrade_drop()`, `downgrade_drops` (sorted/deduped), `clear_downgrade_drops()`, wired into `clear_diagnostics()`.
- `spec.py`: clear channel at entry; record the two drop helpers' messages; `_collect_downgrade_drop_warnings()` wired into `collect_spec_warnings`. Existing `logger.warning` / `warnings.warn` calls left intact (additive only).
- `tests/test_spec_warnings.py`: new `TestDowngradeDropWarnings` (7 cases) — custom-method drop, query drop, no-warning-under-3.2, deterministic sorting, run-scoped non-carryover, report surfacing, and `--fail-on-warnings` exit-2.

## Verification
- `hatch run pytest --cov` green — **coverage 95.59%** (≥95% gate).
- `make lint` clean · `make typecheck` clean (55 files).

Closes #479