### PR TITLE
refactor(openapi): record itemSchema downgrade via VERSION_DOWNGRADE_DROP channel

### DIFF
--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -457,15 +457,33 @@ def generate_openapi_spec(
                                     "itemSchema" in new_media_obj
                                     and openapi_version != OPENAPI_VERSION_3_2
                                 ):
+                                    # itemSchema is an OpenAPI 3.2-only media
+                                    # key; on a pre-3.2 target its streaming
+                                    # semantics are lost. Route this through the
+                                    # same structured downgrade-drop channel used
+                                    # for operation-level drops (#479/#492) so
+                                    # ``collect_spec_warnings`` /
+                                    # ``--fail-on-warnings`` can observe the lost
+                                    # 3.2 contract, and preserve the user-facing
+                                    # RuntimeWarning using the *same* message
+                                    # string (single source, no divergent text).
+                                    downgrade_message = (
+                                        f"Response media type '{media}' for "
+                                        f"function '{func_name}' uses "
+                                        f"'itemSchema', which is an OpenAPI 3.2 "
+                                        f"feature for sequential/streaming media "
+                                        f"types, but the target openapi_version "
+                                        f"is {openapi_version}. The field is "
+                                        f"emitted as-is but may not be understood "
+                                        f"by 3.0/3.1 tooling. Use "
+                                        f"openapi_version='3.2.0' for streaming "
+                                        f"responses."
+                                    )
+                                    _diag_registry.add_downgrade_drop(
+                                        downgrade_message
+                                    )
                                     warnings.warn(
-                                        f"Response media type '{media}' for function "
-                                        f"'{func_name}' uses 'itemSchema', which is an "
-                                        f"OpenAPI 3.2 feature for sequential/streaming "
-                                        f"media types, but the target openapi_version is "
-                                        f"{openapi_version}. The field is emitted as-is "
-                                        f"but may not be understood by 3.0/3.1 tooling. "
-                                        f"Use openapi_version='3.2.0' for streaming "
-                                        f"responses.",
+                                        downgrade_message,
                                         RuntimeWarning,
                                         stacklevel=2,
                                     )

--- a/tests/test_spec_warnings.py
+++ b/tests/test_spec_warnings.py
@@ -834,3 +834,85 @@ class TestDowngradeDropWarnings:
         # a pre-3.2 target is exactly what --fail-on-warnings exists to catch.
         register_openapi_metadata(path="/api/cache", method="purge", summary="Purge cache")
         assert handle_generate(_args(fail_on_warnings=True, openapi_version="3.1")) == 2
+
+
+class TestItemSchemaDowngradeDrop:
+    """``itemSchema`` is an OpenAPI 3.2-only media key. On a pre-3.2 target its
+    streaming semantics cannot be expressed, so the downgrade must surface
+    through the same structured VERSION_DOWNGRADE_DROP channel as operation-level
+    drops (#492) -- not only as a bare RuntimeWarning. The field itself is still
+    emitted as-is (out of scope: 3.2 emission semantics)."""
+
+    def _register(self, registry: OpenAPIRegistry) -> None:
+        register_openapi_metadata(
+            "/api/events",
+            "get",
+            response={
+                200: {
+                    "description": "Event stream",
+                    "content": {
+                        "text/event-stream": {"itemSchema": {"type": "object"}}
+                    },
+                }
+            },
+            registry=registry,
+        )
+
+    def test_item_schema_pre_3_2_surfaces_structured_warning(self) -> None:
+        reg = OpenAPIRegistry()
+        self._register(reg)
+        spec = generate_openapi_spec(
+            openapi_version=OPENAPI_VERSION_3_1, registry=reg, route_prefix=""
+        )
+        drops = [
+            w
+            for w in collect_spec_warnings(spec, registry=reg)
+            if w.code == WarningCode.VERSION_DOWNGRADE_DROP
+        ]
+        assert len(drops) == 1
+        assert "itemSchema" in drops[0].message
+        assert OPENAPI_VERSION_3_1 in drops[0].message
+
+    def test_item_schema_still_emitted_on_pre_3_2(self) -> None:
+        # Out of scope for #492: itemSchema emission is unchanged; the field is
+        # retained as-is so existing consumers are not silently broken. Only the
+        # structured observability is added.
+        reg = OpenAPIRegistry()
+        self._register(reg)
+        spec = generate_openapi_spec(
+            openapi_version=OPENAPI_VERSION_3_1, registry=reg, route_prefix=""
+        )
+        media = spec["paths"]["/api/events"]["get"]["responses"]["200"][
+            "content"
+        ]["text/event-stream"]
+        assert "itemSchema" in media
+
+    def test_item_schema_no_drop_under_3_2(self) -> None:
+        reg = OpenAPIRegistry()
+        self._register(reg)
+        spec = generate_openapi_spec(
+            openapi_version=OPENAPI_VERSION_3_2, registry=reg, route_prefix=""
+        )
+        codes = {w.code for w in collect_spec_warnings(spec, registry=reg)}
+        assert WarningCode.VERSION_DOWNGRADE_DROP not in codes
+
+    def test_item_schema_drop_and_runtime_warning_share_one_message(self) -> None:
+        # "avoid a second, divergent warning path": the user-facing RuntimeWarning
+        # and the structured drop must carry the identical message string.
+        reg = OpenAPIRegistry()
+        self._register(reg)
+        with pytest.warns(RuntimeWarning, match="itemSchema") as caught:
+            spec = generate_openapi_spec(
+                openapi_version=OPENAPI_VERSION_3_1, registry=reg, route_prefix=""
+            )
+        runtime_messages = [
+            str(w.message)
+            for w in caught.list
+            if issubclass(w.category, RuntimeWarning)
+        ]
+        drop_messages = [
+            w.message
+            for w in collect_spec_warnings(spec, registry=reg)
+            if w.code == WarningCode.VERSION_DOWNGRADE_DROP
+        ]
+        assert runtime_messages == drop_messages


### PR DESCRIPTION
## Summary
- On a pre-3.2 target, the OpenAPI 3.2-only `itemSchema` media key loses its sequential/streaming semantics but previously surfaced only as a bare `RuntimeWarning`, invisible to the structured downgrade-drop channel that operation-level drops (custom methods #471, `query` #472) already use.
- Route the itemSchema downgrade through the existing `OpenAPIRegistry.add_downgrade_drop` channel so it emits a structured `VERSION_DOWNGRADE_DROP` warning observable by `collect_spec_warnings` / `--fail-on-warnings`, while **preserving the user-facing `RuntimeWarning` using the identical message string** (single source, no divergent text).

## Design note
- `itemSchema` emission is left unchanged — the field is still emitted as-is on pre-3.2 targets. Only structured observability is added; 3.2 emission semantics are explicitly out of scope per the issue. The `OpenAPIRegistry.add_downgrade_drop` docstring already frames itemSchema as a downgrade-drop construct, so this aligns `spec.py` with that documented intent.

## Tests
- New `TestItemSchemaDowngradeDrop` in `tests/test_spec_warnings.py`: structured warning surfaces on pre-3.2, field still emitted, no drop under 3.2, and RuntimeWarning + structured drop share one message string.

## Validation
- `make test` → 808 passed, coverage >= 95%
- `make lint` → clean
- `make typecheck` → clean

Closes #492