### PR TITLE
feat(openapi): restrict responses= generic shorthand to container origins; raise ValueError on Callable

### DIFF
--- a/docs/migration/unified-params.md
+++ b/docs/migration/unified-params.md
@@ -205,6 +205,63 @@ The [actual removal](https://github.com/yeongseon/azure-functions-openapi-python
 is tracked separately; this policy only fixes the earliest removal boundary so
 downstream users have a dependable window to migrate.
 
+## `responses=` generic shorthand is restricted to containers (#493)
+
+The `responses=` mapping accepts a **generic collection alias** as a bare
+response-body shorthand — for example:
+
+```python
+@openapi(route="items", method="get", responses={200: list[Item]})
+def list_items(req): ...
+```
+
+Previously **any** generic alias with a non-`None` `typing.get_origin(...)` was
+accepted and only resolved at spec-generation time, so an unsupported generic
+such as `Callable[[int], str]` was not rejected up front — it either failed
+late or produced a nonsensical schema.
+
+As of **#493**, only container generics are accepted as a shorthand:
+
+- `list[...]`, `tuple[...]`, `set[...]`, `frozenset[...]`, `dict[...]` and their
+  `collections.abc` equivalents (`Sequence`, `Mapping`, `Set`, and the
+  `Mutable*` variants).
+- Unions / `Optional` — both `typing.Union[...]` and PEP 604 `X | Y`.
+
+Any other generic (most notably `Callable`, iterators, coroutines, ...) now
+raises a `ValueError` **at decoration time** with an actionable message:
+
+```text
+Invalid 'responses' entry for status 200 in function 'handler':
+typing.Callable[[int], str] uses the unsupported generic origin 'Callable'.
+Only container generics (list, tuple, set, frozenset, dict and their
+collections.abc equivalents) and unions/Optional are accepted as a
+response-body shorthand. To describe this response, pass an explicit OpenAPI
+Response Object mapping as the value instead.
+```
+
+**Breaking change:** if you previously relied on a non-container generic being
+silently accepted (and producing whatever schema fell out of `TypeAdapter`),
+replace it with an explicit OpenAPI Response Object mapping:
+
+```python
+# before (now raises ValueError at decoration time)
+@openapi(route="cb", method="get", responses={200: Callable[[int], str]})
+def handler(req): ...
+
+# after — describe the response explicitly
+@openapi(
+    route="cb",
+    method="get",
+    responses={
+        200: {
+            "description": "Callback descriptor",
+            "content": {"application/json": {"schema": {"type": "string"}}},
+        }
+    },
+)
+def handler(req): ...
+```
+
 ## Tracking
 
 The unified-parameter migration is tracked in [#285]. If you hit a case the

--- a/src/azure_functions_openapi/decorator.py
+++ b/src/azure_functions_openapi/decorator.py
@@ -1,11 +1,13 @@
 # src/azure_functions_openapi/decorator.py
 from __future__ import annotations
 
+import collections.abc as _cabc
 from collections.abc import Mapping
 from http import HTTPStatus
 import logging
 import re
-from typing import Any, Callable, Literal, TypeGuard, TypeVar, cast, get_origin
+import types
+from typing import Any, Callable, Literal, TypeGuard, TypeVar, Union, cast, get_origin
 import warnings
 
 from pydantic import BaseModel
@@ -147,6 +149,44 @@ def _coerce_status_key(status: Any, func_name: str) -> int | Literal["default"]:
     )
 
 
+# Container generics accepted as a response-body shorthand (issue #493). Only
+# these origins have a well-defined JSON Schema projection via
+# ``TypeAdapter``; other generics (``Callable``, ``Iterator``, coroutines, ...)
+# either fail late during spec generation or produce nonsensical schemas, so
+# they are rejected at decoration time with an actionable error.
+_SHORTHAND_CONTAINER_ORIGINS: frozenset[Any] = frozenset(
+    {
+        list,
+        tuple,
+        set,
+        frozenset,
+        dict,
+        _cabc.Sequence,
+        _cabc.Mapping,
+        _cabc.Set,
+        _cabc.MutableSequence,
+        _cabc.MutableMapping,
+        _cabc.MutableSet,
+    }
+)
+
+
+def _is_supported_shorthand_generic(value: Any) -> bool:
+    """Return ``True`` if *value* is a generic alias usable as a body shorthand.
+
+    Accepts container generics (``list[...]``, ``dict[...]``, their
+    ``collections.abc`` equivalents, etc.) and unions/``Optional`` (both
+    ``typing.Union`` and PEP 604 ``X | Y``). Everything else — most notably
+    ``Callable`` — is rejected so misuse fails fast at decoration time.
+    """
+    origin = get_origin(value)
+    if origin is None:
+        return False
+    if origin in _SHORTHAND_CONTAINER_ORIGINS:
+        return True
+    return origin is Union or origin is types.UnionType
+
+
 def _normalize_unified_responses(
     responses: Mapping[Any, Any], func_name: str
 ) -> dict[int | str, dict[str, Any]]:
@@ -159,7 +199,11 @@ def _normalize_unified_responses(
       {"application/json": {"schema": Model}}}`` (the model class is resolved to
       a schema at spec-generation time, where the ``components`` registry lives), or
     * a generic collection alias such as ``list[Model]`` — the same bare-shorthand
-      treatment, resolved to an array schema at spec-generation time, or
+      treatment, resolved to an array schema at spec-generation time. Only
+      container generics (``list``/``tuple``/``set``/``frozenset``/``dict`` and
+      their ``collections.abc`` equivalents) and unions/``Optional`` are accepted;
+      any other generic (e.g. ``Callable``) raises ``ValueError`` at decoration
+      time (#493), or
     * an OpenAPI Response Object mapping (unchanged; a Pydantic model may also appear
       in its ``content.<media>.schema`` position and is resolved the same way), or
     * ``None`` — shorthand for a body-less response (e.g. ``204 No Content``),
@@ -176,7 +220,30 @@ def _normalize_unified_responses(
         status = _coerce_status_key(raw_status, func_name)
         if value is None:
             normalized[status] = {"description": _default_response_description(status)}
-        elif _is_pydantic_model(value) or get_origin(value) is not None:
+        elif _is_pydantic_model(value):
+            normalized[status] = {
+                "description": _default_response_description(status),
+                "content": {"application/json": {"schema": value}},
+            }
+        elif get_origin(value) is not None:
+            # A generic alias shorthand (e.g. ``list[Model]``). Only container
+            # generics and unions project cleanly to a JSON body schema (#493);
+            # reject anything else (``Callable``, iterators, coroutines, ...)
+            # here so the failure is at decoration time with a clear message,
+            # not a late/garbled schema during spec generation.
+            if not _is_supported_shorthand_generic(value):
+                origin = get_origin(value)
+                origin_name = getattr(origin, "__name__", str(origin))
+                raise ValueError(
+                    f"Invalid 'responses' entry for status {status} in function "
+                    f"'{func_name}': {value!r} uses the unsupported generic "
+                    f"origin '{origin_name}'. Only container generics "
+                    f"(list, tuple, set, frozenset, dict and their "
+                    f"collections.abc equivalents) and unions/Optional are "
+                    f"accepted as a response-body shorthand. To describe this "
+                    f"response, pass an explicit OpenAPI Response Object mapping "
+                    f"as the value instead."
+                )
             normalized[status] = {
                 "description": _default_response_description(status),
                 "content": {"application/json": {"schema": value}},

--- a/tests/test_responses_shorthand_generics.py
+++ b/tests/test_responses_shorthand_generics.py
@@ -1,0 +1,126 @@
+"""Tests for the ``responses=`` generic-shorthand container whitelist (#493).
+
+Only container generics (``list``/``tuple``/``set``/``frozenset``/``dict`` and
+their ``collections.abc`` equivalents) and unions/``Optional`` are accepted as a
+bare response-body shorthand. Any other generic (most notably ``Callable``)
+raises ``ValueError`` at decoration time so misuse fails fast instead of
+producing a late or nonsensical schema at spec-generation time.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Sequence
+from typing import Any, Callable, Optional, Union
+import warnings
+
+from pydantic import BaseModel
+import pytest
+
+from azure_functions_openapi.decorator import (
+    clear_openapi_registry,
+    openapi,
+)
+from azure_functions_openapi.spec import generate_openapi_spec
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Iterator[None]:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+class Item(BaseModel):
+    id: int
+    name: str
+
+
+def _register(status_value: Any) -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+
+        @openapi(route="items", method="get", responses={200: status_value})
+        def handler(req: Any) -> Any:  # pragma: no cover - never invoked
+            return req
+
+
+# ---------------------------------------------------------------------------
+# Accepted container generics
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "container",
+    [
+        list[Item],
+        tuple[Item, ...],
+        set[int],
+        frozenset[int],
+        Sequence[Item],
+    ],
+)
+def test_container_generics_are_accepted(container: Any) -> None:
+    _register(container)
+    spec = generate_openapi_spec(route_prefix="")
+    schema = spec["paths"]["/items"]["get"]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+    # Sequence-like containers resolve to an array schema.
+    assert schema.get("type") == "array"
+
+
+def test_dict_generic_is_accepted() -> None:
+    _register(dict[str, Item])
+    spec = generate_openapi_spec(route_prefix="")
+    schema = spec["paths"]["/items"]["get"]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+    assert schema.get("type") == "object"
+
+
+@pytest.mark.parametrize("union", [Optional[Item], Union[Item, int]])
+def test_union_and_optional_are_accepted(union: Any) -> None:
+    # Unions/Optional resolve without raising; the concrete schema shape is
+    # owned by TypeAdapter and not asserted here.
+    _register(union)
+    spec = generate_openapi_spec(route_prefix="")
+    assert (
+        "schema"
+        in spec["paths"]["/items"]["get"]["responses"]["200"]["content"]["application/json"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rejected non-container generics — must fail at decoration time
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "unsupported",
+    [
+        Callable[[int], str],
+        Iterator[int],
+    ],
+)
+def test_unsupported_generics_raise_at_decoration_time(unsupported: Any) -> None:
+    with pytest.raises(ValueError, match="unsupported generic origin"):
+        _register(unsupported)
+
+
+def test_rejection_message_is_actionable() -> None:
+    with pytest.raises(ValueError) as excinfo:
+        _register(Callable[[int], str])
+    message = str(excinfo.value)
+    # Names the offending origin and points at the explicit-mapping escape hatch.
+    assert "Callable" in message
+    assert "Response Object mapping" in message
+
+
+def test_plain_pydantic_model_still_accepted() -> None:
+    # Regression: the non-generic model shorthand is unaffected by the guard.
+    _register(Item)
+    spec = generate_openapi_spec(route_prefix="")
+    schema = spec["paths"]["/items"]["get"]["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+    assert schema == {"$ref": "#/components/schemas/Item"}


### PR DESCRIPTION
## Summary
- The unified `responses=` mapping accepted **any** generic alias with a non-`None` `typing.get_origin(...)` as a bare response-body shorthand, so unsupported generics (e.g. `Callable[[int], str]`) were not rejected up front — they fell through to `TypeAdapter` at spec-generation time and either failed late or produced a nonsensical schema.
- Whitelist container origins (`list`/`tuple`/`set`/`frozenset`/`dict` and their `collections.abc` equivalents) plus unions/`Optional`, and raise a `ValueError` **at decoration time** with an actionable message for any other generic.
- Add a migration note documenting the new decoration-time failure and the explicit-Response-Object escape hatch.

## Breaking-risk
- Decoration-time `ValueError` can break users who previously relied on a non-container generic being silently accepted. This is intended to land **before 1.0**; the migration note (`docs/migration/unified-params.md`) documents the before/after.

## Tests
- `tests/test_responses_shorthand_generics.py`: accepted containers (`list`/`tuple`/`set`/`frozenset`/`Sequence`/`dict`) and unions/`Optional` resolve; rejected generics (`Callable`, `Iterator`) raise at decoration time; rejection message is actionable; plain-model shorthand regression.

## Validation
- `make test` → 816 passed, coverage 95.56% (>= 95%)
- `make lint` → clean
- `make typecheck` → clean

Closes #493