### PR TITLE
feat(openapi): passthrough top-level servers/contact/license/externalDocs/tags

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -489,6 +489,25 @@ spec = generate_openapi_spec(
 )
 ```
 
+### Top-level and info metadata
+
+`generate_openapi_spec` accepts optional passthrough parameters for document
+metadata that would otherwise require post-processing the returned dict (#494).
+`contact` and `license` are merged into `info`; `servers`, `external_docs`, and
+the top-level `tags` list are emitted at the document root. Each field is added
+only when supplied.
+
+```python
+spec = generate_openapi_spec(
+    title="Orders API",
+    servers=[{"url": "https://api.example.com", "description": "prod"}],
+    contact={"name": "DX Toolkit", "email": "dx@example.com"},
+    license={"name": "MIT", "url": "https://opensource.org/licenses/MIT"},
+    external_docs={"url": "https://docs.example.com", "description": "Guide"},
+    tags=[{"name": "orders", "description": "Order operations"}],
+)
+```
+
 ### Generate JSON/YAML strings
 
 ```python

--- a/src/azure_functions_openapi/spec.py
+++ b/src/azure_functions_openapi/spec.py
@@ -347,6 +347,11 @@ def generate_openapi_spec(
     registry: OpenAPIRegistry | None = None,
     hoist_flat_schemas: bool = False,
     infer_auth_level: bool = False,
+    servers: list[dict[str, Any]] | None = None,
+    contact: dict[str, Any] | None = None,
+    license: dict[str, Any] | None = None,
+    external_docs: dict[str, Any] | None = None,
+    tags: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """
     Compile an OpenAPI specification from the registry.
@@ -381,6 +386,15 @@ def generate_openapi_spec(
             Requires the FunctionApp-scan path (e.g. CLI ``module:variable``);
             a plain ``@openapi``-only registry carries no ``auth_level``.
             Defaults to ``False`` for full backward compatibility.
+        servers: Optional list of OpenAPI Server Objects emitted at the
+            document's top-level ``servers`` field (#494). When ``None``, no
+            ``servers`` key is added.
+        contact: Optional Contact Object merged into ``info.contact`` (#494).
+        license: Optional License Object merged into ``info.license`` (#494).
+        external_docs: Optional External Documentation Object emitted at the
+            document's top-level ``externalDocs`` field (#494).
+        tags: Optional list of top-level Tag Objects emitted at the document's
+            ``tags`` field (#494). Distinct from per-operation ``tags``.
 
     Returns:
         OpenAPI specification dictionary
@@ -705,6 +719,20 @@ def generate_openapi_spec(
         if openapi_version in (OPENAPI_VERSION_3_1, OPENAPI_VERSION_3_2):
             spec["info"]["summary"] = title
             _convert_operation_schemas_to_3_1(paths)
+
+        # Top-level and info metadata passthrough (#494). Each field is emitted
+        # only when supplied; contact/license nest under ``info`` while
+        # servers/externalDocs/tags sit at the document root.
+        if contact is not None:
+            spec["info"]["contact"] = contact
+        if license is not None:
+            spec["info"]["license"] = license
+        if servers is not None:
+            spec["servers"] = servers
+        if external_docs is not None:
+            spec["externalDocs"] = external_docs
+        if tags is not None:
+            spec["tags"] = tags
 
         # Merge security schemes: explicit param + per-operation schemes from registry.
         # Raises OpenAPISpecConfigError on collision (same name, different definition).

--- a/tests/test_top_level_metadata.py
+++ b/tests/test_top_level_metadata.py
@@ -1,0 +1,101 @@
+"""Tests for top-level / info metadata passthrough on ``generate_openapi_spec`` (#494).
+
+Covers the ``servers``, ``contact``, ``license``, ``external_docs`` and top-level
+``tags`` passthrough parameters. Each field must be emitted only when supplied and
+must land in the correct location (``info`` vs document root).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import azure.functions as func
+import pytest
+
+from azure_functions_openapi.bridge import scan_endpoint_metadata
+from azure_functions_openapi.decorator import clear_openapi_registry, openapi
+from azure_functions_openapi.registry import OpenAPIRegistry
+from azure_functions_openapi.spec import generate_openapi_spec
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    clear_openapi_registry()
+    yield
+    clear_openapi_registry()
+
+
+def _reg() -> OpenAPIRegistry:
+    app = func.FunctionApp()
+
+    @openapi(summary="orders")
+    @app.route(route="orders", methods=["GET"])
+    def orders(req: func.HttpRequest) -> func.HttpResponse:  # pragma: no cover - body unused
+        return func.HttpResponse("ok")
+
+    reg = OpenAPIRegistry()
+    scan_endpoint_metadata(app, registry=reg)
+    return reg
+
+
+def test_defaults_omit_all_passthrough_fields() -> None:
+    spec = generate_openapi_spec(registry=_reg())
+
+    assert "servers" not in spec
+    assert "externalDocs" not in spec
+    assert "tags" not in spec
+    assert "contact" not in spec["info"]
+    assert "license" not in spec["info"]
+
+
+def test_servers_emitted_at_document_root() -> None:
+    servers = [{"url": "https://api.example.com", "description": "prod"}]
+    spec = generate_openapi_spec(registry=_reg(), servers=servers)
+
+    assert spec["servers"] == servers
+
+
+def test_contact_and_license_nest_under_info() -> None:
+    contact = {"name": "DX", "email": "dx@example.com"}
+    license_obj = {"name": "MIT", "url": "https://opensource.org/licenses/MIT"}
+    spec = generate_openapi_spec(registry=_reg(), contact=contact, license=license_obj)
+
+    assert spec["info"]["contact"] == contact
+    assert spec["info"]["license"] == license_obj
+
+
+def test_external_docs_emitted_at_document_root() -> None:
+    external_docs = {"url": "https://docs.example.com", "description": "guide"}
+    spec = generate_openapi_spec(registry=_reg(), external_docs=external_docs)
+
+    assert spec["externalDocs"] == external_docs
+
+
+def test_top_level_tags_emitted_at_document_root() -> None:
+    tags = [{"name": "orders", "description": "Order operations"}]
+    spec = generate_openapi_spec(registry=_reg(), tags=tags)
+
+    assert spec["tags"] == tags
+
+
+def test_all_fields_together() -> None:
+    servers = [{"url": "https://api.example.com"}]
+    contact = {"name": "DX"}
+    license_obj = {"name": "MIT"}
+    external_docs = {"url": "https://docs.example.com"}
+    tags = [{"name": "orders"}]
+
+    spec = generate_openapi_spec(
+        registry=_reg(),
+        servers=servers,
+        contact=contact,
+        license=license_obj,
+        external_docs=external_docs,
+        tags=tags,
+    )
+
+    assert spec["servers"] == servers
+    assert spec["info"]["contact"] == contact
+    assert spec["info"]["license"] == license_obj
+    assert spec["externalDocs"] == external_docs
+    assert spec["tags"] == tags


### PR DESCRIPTION
## Summary
Adds optional passthrough parameters to `generate_openapi_spec` for document metadata that previously required post-processing the returned dict.

## Audit (current settable fields, before this PR)
`generate_openapi_spec` set `openapi`, `info` (title/version/description/summary), `paths`, and `components` (merging `security_schemes`). There was **no** way to set top-level `servers`, `externalDocs`, a global `tags` list, or `info.contact` / `info.license`.

## Changes
- New params: `servers`, `contact`, `license`, `external_docs`, `tags`.
- `contact`/`license` merge into `info`; `servers`/`externalDocs`/`tags` emit at the document root.
- Each field is emitted **only when supplied** (defaults omit all — fully backward compatible).
- Minimal validation: values are passed through verbatim (no conflict-semantics over-design).

## Tests
`tests/test_top_level_metadata.py` — defaults omit all fields; each field lands in the correct location; combined case.

## Docs
`docs/usage.md` — new "Top-level and info metadata" section.

## Verification
- `make test` → 810 passed, coverage 95.62%
- `make lint`, `make typecheck` → clean

Closes #494