### PR TITLE
docs(openapi): clarify auth_level admin=host master key vs APIM subscription keys

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -443,6 +443,15 @@ components:
   trigger binding, so no `auth_level` is available there.
 - User-supplied values always win: inference injects `security` / `security_scheme`
   only for operations that have none.
+- **`ADMIN` = host master key.** `FUNCTION` accepts a per-function or host key,
+  while `ADMIN` requires the host-wide **master key** — both are sent in the
+  `x-functions-key` header, so they share the single `AzureFunctionKey` apiKey
+  scheme. The distinction is the key's scope/privilege, not the header.
+- **APIM subscription keys are a separate concern.** If the app sits behind Azure
+  API Management, callers present an APIM **subscription key** (typically the
+  `Ocp-Apim-Subscription-Key` header), which is unrelated to Functions
+  function/host keys. This inference does not model APIM keys; declare them
+  explicitly via `@openapi(security=...)` / `security_schemes` if needed.
 
 
 ## Multiple endpoints and tags


### PR DESCRIPTION
## Summary
Documentation-only clarification in `docs/usage.md` under the `auth_level` inference section.

- Adds an explicit one-liner: `ADMIN` = **host master key** (vs `FUNCTION`'s per-function/host key), both carried in the `x-functions-key` header and sharing the single `AzureFunctionKey` apiKey scheme — the distinction is key scope/privilege, not the header.
- Distinguishes **APIM subscription keys** (`Ocp-Apim-Subscription-Key`) as a separate concern that `auth_level` inference does not model; those must be declared explicitly via `@openapi(security=...)` / `security_schemes`.
- Injected OpenAPI snippet example unchanged (still accurate).

Closes #495